### PR TITLE
docs: update README with the correct command

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ First, make sure that you've pulled the latest version of the repository and ins
 
 ```shell
 # make sure your submodule is checked out at the correct commit
-pnpm checkout:biome .
+pnpm init:biome
 
 # generate only rules files
 pnpm codegen:rules


### PR DESCRIPTION
## Summary

To restore the submodule to the commit specified in the remote repository, we should run `pnpm init:biome`.