### PR TITLE
fix: netlify deployment

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,3 @@
 [build]
 publish = "dist/"
-command = "pnpm setup && pnpm i --frozen-lockfile && npm add -g wasm-pack && pnpm init:biome && pnpm build"
+command = "pnpm i --frozen-lockfile && npm i -g wasm-pack && pnpm init:biome && pnpm build:wasm-dev && pnpm build:js"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
 	"name": "@biomejs/website",
 	"private": true,
 	"scripts": {
-		"init:biome": "git submodule update --init --recursive",
+		"init:biome": "git -c submodule.\"xtask/coverage/Typescript\".update=none -c submodule.\"xtask/coverage/babel\".update=none -c submodule.\"xtask/coverage/test262\".update=none submodule update --init --recursive",
 		"checkout:biome": "cd biome && git checkout",
 		"start": "astro dev",
 		"start:playground": "pnpm build:wasm-dev && pnpm start",

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -2,4 +2,4 @@
 # The default profile includes rustc, rust-std, cargo, rust-docs, rustfmt and clippy.
 # https://rust-lang.github.io/rustup/concepts/profiles.html
 profile = "default"
-channel = "1.77.0"
+channel = "1.77.2"


### PR DESCRIPTION
## Summary

This is a (not so) quick fix for the netlify deployment.

1. Exclude nested git submodules to save some time
2. Disable `wasm-opt` and use `pnpm build:wasm-dev` to save some time
3. Update `rust-toolchain.toml`