### PR TITLE
chore: update edit link baseUrl

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -366,7 +366,7 @@ export default defineConfig({
 				mastodon: "https://fosstodon.org/@biomejs",
 			},
 			editLink: {
-				baseUrl: "https://github.com/biomejs/biome/edit/main/website/",
+				baseUrl: "https://github.com/biomejs/website/edit/main/",
 			},
 			components: {
 				SiteTitle: "./src/components/starlight/SiteTitle.astro",


### PR DESCRIPTION
## Summary

This PR updates the base URL of the edit link so that it points to this repository instead of the main repository.