### PR TITLE
chore: symlink `rust-toolchain.toml` to `biome/rust-toolchain.toml`

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,1 @@
-[toolchain]
-# The default profile includes rustc, rust-std, cargo, rust-docs, rustfmt and clippy.
-# https://rust-lang.github.io/rustup/concepts/profiles.html
-profile = "default"
-channel = "1.77.2"
+./biome/rust-toolchain.toml


### PR DESCRIPTION
## Summary

Keep the rust toolchain in sync with the biome main repo.