### PR TITLE
chore: wasm cache control

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,3 +1,12 @@
 [build]
 publish = "dist/"
 command = "pnpm i --frozen-lockfile && npm i -g wasm-pack && pnpm init:biome && pnpm build:wasm-dev && pnpm build:js"
+
+[[headers]]
+for = "/assets/biome*.wasm"
+[headers.values]
+#  Multi-value headers are expressed with multi-line strings
+cache-control = '''
+      public,
+      max-age=31536000000
+      '''


### PR DESCRIPTION
## Summary

Set `cache-control` header for the `wasm` file with a bigger `max-age` because we've already been using content hash in filenames for cache busting.