### PR TITLE
chore: apply a more aggressive `cache-control` strategy

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -8,7 +8,8 @@ for = "/assets/*"
 #  Multi-value headers are expressed with multi-line strings
 cache-control = '''
       public,
-      max-age=31536000000
+      max-age=31536000000,
+      immutable
       '''
 
 [[headers]]
@@ -17,5 +18,6 @@ for = "/_astro/*"
 #  Multi-value headers are expressed with multi-line strings
 cache-control = '''
       public,
-      max-age=31536000000
+      max-age=31536000000,
+      immutable
       '''

--- a/netlify.toml
+++ b/netlify.toml
@@ -11,6 +11,7 @@ cache-control = '''
       max-age=31536000000
       '''
 
+[[headers]]
 for = "/_astro/*"
 [headers.values]
 #  Multi-value headers are expressed with multi-line strings

--- a/netlify.toml
+++ b/netlify.toml
@@ -3,7 +3,15 @@ publish = "dist/"
 command = "pnpm i --frozen-lockfile && npm i -g wasm-pack && pnpm init:biome && pnpm build:wasm-dev && pnpm build:js"
 
 [[headers]]
-for = "/assets/biome*.wasm"
+for = "/assets/*"
+[headers.values]
+#  Multi-value headers are expressed with multi-line strings
+cache-control = '''
+      public,
+      max-age=31536000000
+      '''
+
+for = "/_astro/*"
 [headers.values]
 #  Multi-value headers are expressed with multi-line strings
 cache-control = '''


### PR DESCRIPTION
## Summary

All files under `/assets/` and `/_astro/` are content-hashed, so we can use a more aggressive `cache-control` strategy for those files.