### PR TITLE
chore: remove submodule init from build command

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,6 +1,6 @@
 [build]
 publish = "dist/"
-command = "pnpm i --frozen-lockfile && npm i -g wasm-pack && pnpm init:biome && pnpm build:wasm-dev && pnpm build:js"
+command = "pnpm i --frozen-lockfile && npm i -g wasm-pack && pnpm build:wasm-dev && pnpm build:js"
 
 [[headers]]
 for = "/assets/*"


### PR DESCRIPTION
## Summary

Netlify will automatically checkout the submodules and it won't fetch nested submodules (which is what we want!). So we don't have to use `pnpm init:biome` anymore.

https://docs.netlify.com/git/repo-permissions-linking/#git-submodules