### PR TITLE
docs: use valid JSON in Renovate config example

### DIFF
--- a/src/content/docs/recipes/renovate.mdx
+++ b/src/content/docs/recipes/renovate.mdx
@@ -9,7 +9,7 @@ description: Configuring Renovate Bot
 
 Renovate has a [shared preset rule](https://docs.renovatebot.com/presets-regexManagers/#regexmanagersbiomeversions) that can help keep the `$schema` version in-sync and up-to-date within the `biome.json` configuration files.
 
-To use, simply add `regexManagers:biomeVersions` to your `extends` list.
+To use, add `regexManagers:biomeVersions` to your `extends` list.
 
 
 ```json title="renovate.json"

--- a/src/content/docs/recipes/renovate.mdx
+++ b/src/content/docs/recipes/renovate.mdx
@@ -15,11 +15,6 @@ To use, simply add `regexManagers:biomeVersions` to your `extends` list.
 ```json title="renovate.json"
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    ...
-    "regexManagers:biomeVersions"
-    ...
-  ]
-  ...
+  "extends": ["regexManagers:biomeVersions"]
 }
 ```


### PR DESCRIPTION
## Summary

Follow up PR after:

- #140

The config example should use valid JSON. The `...` characters are not allowed in JSON files.

Having valid JSON also means that readers can copy/paste the JSON into their `renovate.json` file.

**Edit:** I'm also dropping the word `simply` from the docs. If you need to explain something, it's not simple. Also shorter sentences are easier to read and remember.

> [!TIP]
> If you're copy/pasting the example into your `renovate.json` file, then also add `config:recommended` _or_ `config:best-practices` to the `extends` array. This way Renovate will update your other dependencies as well. But that's a bit off topic for the Biome recipe example, so I'm not putting it in the docs here.