### PR TITLE
chore(ci): enable `cloneSubmodules` for renovate

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,5 +7,6 @@
 	"lockFileMaintenance": {
 		"enabled": false
 	},
-	"assignees": ["@biomejs/maintainers", "@biomejs/core-contributors"]
+	"assignees": ["@biomejs/maintainers", "@biomejs/core-contributors"],
+	"cloneSubmodules": true
 }


### PR DESCRIPTION
## Summary

Attempt to fix crate resolution in [`codegen/Cargo.toml`](https://github.com/biomejs/website/blob/main/codegen/Cargo.toml) in renovate PRs.