### PR TITLE
refactor: tldr migratation guide & noUnusedImports ref in import sorting

### DIFF
--- a/codegen/Cargo.lock
+++ b/codegen/Cargo.lock
@@ -661,7 +661,6 @@ dependencies = [
  "rustc-hash",
  "serde",
  "serde_json",
- "slotmap",
  "tracing",
 ]
 
@@ -1850,16 +1849,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
 dependencies = [
  "autocfg",
-]
-
-[[package]]
-name = "slotmap"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbff4acf519f630b3a3ddcfaea6c06b42174d9a44bc70c620e9ed1649d58b82a"
-dependencies = [
- "serde",
- "version_check",
 ]
 
 [[package]]

--- a/src/content/docs/analyzer/import-sorting.mdx
+++ b/src/content/docs/analyzer/import-sorting.mdx
@@ -15,6 +15,11 @@ This feature is enabled by default but can be opted-out via configuration:
 }
 ```
 
+:::note
+The import sorter doesn't remove unused imports.
+We provide the linter rule [noUnusedImports](https://biomejs.dev/linter/rules/no-unused-imports/) with a safe fix that removes unused imports.
+:::
+
 ## How imports are sorted
 
 Import statements are sorted by "distance". Modules that are "farther" from the user are put on the top, modules "closer" to the user are put on the bottom:

--- a/src/content/docs/guides/migrate-eslint-prettier.mdx
+++ b/src/content/docs/guides/migrate-eslint-prettier.mdx
@@ -7,6 +7,13 @@ import PackageManagerBiomeCommand from "@/components/PackageManagerBiomeCommand.
 
 Biome provides dedicated commands to ease the migration from ESLint and Prettier.
 
+If you don't want to know the details, just run the following commands:
+
+```shell
+biome migrate eslint --write
+biome migrate prettier --write
+```
+
 ## Migrate from ESLint
 
 Many Biome linter rules are inspired by or identical to the ESLint rules or the rules of an ESLint plugin.


### PR DESCRIPTION
## Summary

- Add a reference to `noUnusedImports` on the import sorting page
- Add a TLDR on the migration guide