### PR TITLE
chore(ci): skip og in deploy previews

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -24,3 +24,6 @@ cache-control = '''
 
 [[plugins]]
 package = "./scripts/netlify/plugins/wasm-cache"
+
+[context.deploy-preview.environment]
+SKIP_OG = "true"


### PR DESCRIPTION
## Summary

Skip [OpenGraph images generation](https://github.com/delucis/astro-og-canvas) in deploy previews (i.e. deployments from the PR branches). Deployments from the main branch is unaffected.

The environment variable `SKIP_OG` is used [here](https://github.com/biomejs/website/blob/b90c4acb761433cf08015124f54bd798d5cf4af4/src/pages/og/%5B...path%5D.ts#L7): https://github.com/biomejs/website/blob/b90c4acb761433cf08015124f54bd798d5cf4af4/src/pages/og/%5B...path%5D.ts#L7

This will further reduce the build time.