### PR TITLE
chore(ci): guard submodule mutation

### DIFF
--- a/.github/workflows/file-change-guard.yaml
+++ b/.github/workflows/file-change-guard.yaml
@@ -1,0 +1,23 @@
+name: File change guard
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  file-change-guard:
+    name: File change guard
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+      - name: Get changed files
+        id: changed-files
+        continue-on-error: true
+        uses: tj-actions/changed-files@0874344d6ebbaa00a27da73276ae7162fadcaf69 # v44.3.0
+        with:
+          fail_on_submodule_diff_error: true
+      - name: Fail the job if the submodule is mutated by users
+        if: ${{ steps.changed-files.outcome != 'success' && github.event.pull_request.user.login != 'github-actions[bot]' }}
+        run: exit 1


### PR DESCRIPTION
## Summary

This PR adds a workflow to check for submodule mutations in a PR. In general, the submodule shouldn't be mutated by users except for `github-actions[bot]`.

If submodule mutations from users are detected in a PR, the check for that PR will fail.

> [!NOTE]
> Checks cannot be applied to PRs created by `github-actions[bot]`. This is an expected behavior: https://docs.github.com/en/actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow