### PR TITLE
Fix rule name typo in schema

### DIFF
--- a/src/pages/schemas/1.7.2/schema.json.js
+++ b/src/pages/schemas/1.7.2/schema.json.js
@@ -1695,7 +1695,7 @@ export function GET() {
 							{ type: "null" },
 						],
 					},
-					useConsistentBuiltinInstatiation: {
+					useConsistentBuiltinInstantiation: {
 						description:
 							"Enforce the use of new for all builtins, except String, Number, Boolean, Symbol and BigInt.",
 						anyOf: [


### PR DESCRIPTION
## Summary

Fixes a small rule name typo in schema v1.7.2