### PR TITLE
docs: Fix typo in Monorepos example

### DIFF
--- a/src/content/docs/guides/big-projects.mdx
+++ b/src/content/docs/guides/big-projects.mdx
@@ -118,10 +118,8 @@ In the following example we disable the rule `suspicious/noConsoleLog` inside th
       "include": ["packages/logger/**"],
       "linter": {
         "rules": {
-          "rules": {
-            "suspicious": {
-              "noConsoleLog": "off"
-            }
+          "suspicious": {
+            "noConsoleLog": "off"
           }
         }
       }


### PR DESCRIPTION
## Summary
Fix Monorepos config examples. It is incorrect that `rules` appears twice.