### PR TITLE
fix(codegen): support embedded kind code blocks

### DIFF
--- a/codegen/src/lintdoc.rs
+++ b/codegen/src/lintdoc.rs
@@ -16,7 +16,7 @@ use biome_css_syntax::CssLanguage;
 use biome_diagnostics::termcolor::NoColor;
 use biome_diagnostics::{Diagnostic, DiagnosticExt, PrintDiagnostic};
 use biome_js_parser::JsParserOptions;
-use biome_js_syntax::{JsFileSource, JsLanguage, Language, ModuleKind};
+use biome_js_syntax::{EmbeddingKind, JsFileSource, JsLanguage, Language, ModuleKind};
 use biome_json_parser::JsonParserOptions;
 use biome_json_syntax::JsonLanguage;
 use biome_service::settings::WorkspaceSettings;
@@ -687,6 +687,15 @@ impl FromStr for CodeBlockTest {
                 "tsx" => {
                     test.block_type = BlockType::Js(JsFileSource::tsx());
                 }
+                "svelte" => {
+                    test.block_type = BlockType::Js(JsFileSource::svelte());
+                }
+                "astro" => {
+                    test.block_type = BlockType::Js(JsFileSource::astro());
+                }
+                "vue" => {
+                    test.block_type = BlockType::Js(JsFileSource::vue());
+                }
 
                 // Other attributes
                 "expect_diagnostic" => {
@@ -791,6 +800,23 @@ fn assert_lint(
     settings.register_current_project(key);
     match test.block_type {
         BlockType::Js(source_type) => {
+            // Temporary support for astro, svelte and vue code blocks
+            let (code, source_type) = match source_type.as_embedding_kind() {
+                EmbeddingKind::Astro => (
+                    biome_service::file_handlers::AstroFileHandler::input(code),
+                    JsFileSource::ts(),
+                ),
+                EmbeddingKind::Svelte => (
+                    biome_service::file_handlers::SvelteFileHandler::input(code),
+                    biome_service::file_handlers::SvelteFileHandler::file_source(code),
+                ),
+                EmbeddingKind::Vue => (
+                    biome_service::file_handlers::VueFileHandler::input(code),
+                    biome_service::file_handlers::VueFileHandler::file_source(code),
+                ),
+                _ => (code, source_type),
+            };
+
             let parse = biome_js_parser::parse(code, source_type, JsParserOptions::default());
 
             if parse.has_errors() {

--- a/codegen/src/lintdoc.rs
+++ b/codegen/src/lintdoc.rs
@@ -459,15 +459,20 @@ fn parse_documentation(
                 write!(content, "```")?;
                 if !meta.is_empty() {
                     match test.block_type {
-                        BlockType::Js(source_type) => {
-                            match source_type.language() {
-                                Language::JavaScript => write!(content, "js")?,
-                                Language::TypeScript { .. } => write!(content, "ts")?,
+                        BlockType::Js(source_type) => match source_type.as_embedding_kind() {
+                            EmbeddingKind::Astro => write!(content, "astro")?,
+                            EmbeddingKind::Svelte => write!(content, "svelte")?,
+                            EmbeddingKind::Vue => write!(content, "vue")?,
+                            _ => {
+                                match source_type.language() {
+                                    Language::JavaScript => write!(content, "js")?,
+                                    Language::TypeScript { .. } => write!(content, "ts")?,
+                                };
+                                if source_type.variant().is_jsx() {
+                                    write!(content, "x")?;
+                                }
                             }
-                            if source_type.variant().is_jsx() {
-                                write!(content, "x")?;
-                            }
-                        }
+                        },
                         BlockType::Json => write!(content, "json")?,
                         BlockType::Css => write!(content, "css")?,
                     }

--- a/src/content/docs/linter/rules/no-confusing-labels.md
+++ b/src/content/docs/linter/rules/no-confusing-labels.md
@@ -16,6 +16,8 @@ Disallow labeled statements that are not loops.
 Labeled statements in JavaScript are used in conjunction with `break` and `continue` to control flow around multiple loops.
 Their use for other statements is suspicious and unfamiliar.
 
+The rule ignores reactive Svelte statements in Svelte components.
+
 ## Examples
 
 ### Invalid
@@ -108,6 +110,12 @@ outer: while (a) {
         break outer;
     }
 }
+```
+
+```js
+<script>
+$: { /* reactive block */ }
+</script>
 ```
 
 ## Related links

--- a/src/content/docs/linter/rules/no-confusing-labels.md
+++ b/src/content/docs/linter/rules/no-confusing-labels.md
@@ -112,7 +112,7 @@ outer: while (a) {
 }
 ```
 
-```js
+```svelte
 <script>
 $: { /* reactive block */ }
 </script>

--- a/src/content/docs/linter/rules/no-unused-labels.md
+++ b/src/content/docs/linter/rules/no-unused-labels.md
@@ -66,7 +66,7 @@ function nonNegative(n) {
 }
 ```
 
-```js
+```svelte
 <script>
 $: { /* reactive block */ }
 </script>

--- a/src/content/docs/linter/rules/no-unused-labels.md
+++ b/src/content/docs/linter/rules/no-unused-labels.md
@@ -16,6 +16,8 @@ Disallow unused labels.
 
 Labels that are declared and never used are most likely an error due to incomplete refactoring.
 
+The rule ignores reactive Svelte statements in Svelte components.
+
 ## Examples
 
 ### Invalid
@@ -62,6 +64,12 @@ function nonNegative(n) {
     DEV: assert(n >= 0);
     return n;
 }
+```
+
+```js
+<script>
+$: { /* reactive block */ }
+</script>
 ```
 
 ## Related links


### PR DESCRIPTION
## Summary

Support `astro`, `svelte` and `vue` code blocks in lint docs to pass the tests.