### PR TITLE
chore(ci): make codegen more robust

### DIFF
--- a/codegen/src/website.rs
+++ b/codegen/src/website.rs
@@ -126,8 +126,7 @@ pub(crate) fn generate_schema_js() -> anyhow::Result<()> {
     let schema_js_path = schema_version_folder_path.join("schema.json.js");
 
     if schema_version_folder_path.exists() {
-        fs::remove_file(&schema_js_path)?;
-        fs::remove_dir(&schema_version_folder_path)?;
+        fs::remove_dir_all(&schema_version_folder_path)?;
     }
 
     fs::create_dir(&schema_version_folder_path)?;


### PR DESCRIPTION
## Summary

There may be the case where `schema_version_folder_path` exists but `schema_js_path` does not, which will fail the codegen script. So this PR switches to use `fs::remove_dir_all` to forcely delete the stale schema folder.