### PR TITLE
chore(ci): update renovate config with `regexManagers:biomeVersions`

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -4,7 +4,8 @@
 	"schedule": ["before 9am on monday"],
 	"extends": [
 		"config:best-practices",
-		"helpers:pinGitHubActionDigestsToSemver"
+		"helpers:pinGitHubActionDigestsToSemver",
+		"regexManagers:biomeVersions"
 	],
 	"rangeStrategy": "bump",
 	"lockFileMaintenance": {


### PR DESCRIPTION
## Summary

This repo itself uses biome, so we use [`regexManagers:biomeVersions`](https://docs.renovatebot.com/presets-regexManagers/#regexmanagersbiomeversions) to keep the schema updated.