### PR TITLE
fix(editor): auto theme

### DIFF
--- a/src/frontend-scripts/util.ts
+++ b/src/frontend-scripts/util.ts
@@ -7,13 +7,17 @@ export const matchesDark: undefined | MediaQueryList =
 		: window.matchMedia("(prefers-color-scheme: dark)");
 
 export function getCurrentTheme(themeName?: string): ThemeName {
-	let currentScheme =
+	const currentScheme =
 		themeName ?? window.localStorage.getItem("starlight-theme");
 
-	if (currentScheme == null || currentScheme === "auto") {
-		currentScheme = matchesDark?.matches ? "dark" : "light";
+	switch (currentScheme) {
+		case "dark":
+			return "dark";
+		case "light":
+			return "light";
+		default:
+			return matchesDark?.matches ? "dark" : "light";
 	}
-	return currentScheme === "dark" ? "dark" : "light";
 }
 
 export function setCurrentTheme(theme: ThemeName) {

--- a/src/playground/Playground.tsx
+++ b/src/playground/Playground.tsx
@@ -40,7 +40,7 @@ import {
 	useState,
 } from "react";
 
-export default function PlaygroundLoader({
+export default function Playground({
 	setPlaygroundState,
 	resetPlaygroundState,
 	playgroundState,


### PR DESCRIPTION
## Summary

I noticed that when the theme is selected as `Auto`, the playground editors still uses the light theme when the page first loads: https://deploy-preview-227--biomejs.netlify.app/playground/

This issue is caused by the [recent refactor of the starlight component `<ThemeSelector>`](https://github.com/withastro/starlight/pull/1734/files).