### PR TITLE
chore: mark file as autogenerated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@ pnpm-lock.yaml linguist-generated=true text=auto eol=lf
 # pages and components that are auto generated
 src/pages/lint/rules/**/*.md linguist-generated=true text=auto eol=lf
 src/components/generated/**/*.astro linguist-generated=true text=auto eol=lf
+src/pages/metadata/**/*.js linguist-generated=true text=auto eol=lf


### PR DESCRIPTION
## Summary

Adds `metadata/` as auto-generated 