### PR TITLE
fix: Add better handling of markdown list

### DIFF
--- a/codegen/src/lintdoc.rs
+++ b/codegen/src/lintdoc.rs
@@ -474,6 +474,7 @@ fn parse_documentation(
     // language supported for analysis
     let mut language = None;
     let mut list_order = None;
+    let mut list_indentation = 0;
 
     // Tracks the type and metadata of the link
     let mut start_link_tag: Option<Tag> = None;
@@ -621,17 +622,27 @@ fn parse_documentation(
                 writeln!(content)?;
             }
 
+            Event::HardBreak => {
+                writeln!(content, "<br />")?;
+            }
+
             Event::Start(Tag::List(num)) => {
+                list_indentation += 1;
                 if let Some(num) = num {
                     list_order = Some(num);
+                }
+                if list_indentation > 1 {
+                    writeln!(content)?;
                 }
             }
 
             Event::End(TagEnd::List(_)) => {
                 list_order = None;
+                list_indentation -= 1;
                 writeln!(content)?;
             }
             Event::Start(Tag::Item) => {
+                write!(content, "{}", "  ".repeat(list_indentation - 1))?;
                 if let Some(num) = list_order {
                     write!(content, "{num}. ")?;
                 } else {

--- a/src/content/docs/linter/rules/no-banned-types.md
+++ b/src/content/docs/linter/rules/no-banned-types.md
@@ -54,7 +54,8 @@ To represent an empty object, you should use `{ [k: string]: never }` or `Record
 
 To avoid any confusion, the rule forbids the use of the type `{}`, except in two situations:
 
-1. In type constraints to restrict a generic type to non-nullable types:
+
+  1. In type constraints to restrict a generic type to non-nullable types:
 
 ```ts
 function f<T extends {}>(x: T) {
@@ -62,7 +63,8 @@ function f<T extends {}>(x: T) {
 }
 ```
 
-2. In a type intersection to narrow a type to its non-nullable equivalent type:
+
+  2. In a type intersection to narrow a type to its non-nullable equivalent type:
 
 ```ts
 type NonNullableMyType = MyType & {};

--- a/src/content/docs/linter/rules/no-static-only-class.md
+++ b/src/content/docs/linter/rules/no-static-only-class.md
@@ -18,8 +18,9 @@ This rule reports when a class has no non-static members, such as for a class us
 Users who come from a [OOP](https://en.wikipedia.org/wiki/Object-oriented_programming) paradigm may wrap their utility functions in an extra class,
 instead of putting them at the top level of an ECMAScript module. Doing so is generally unnecessary in JavaScript and TypeScript projects.
 
-- Wrapper classes add extra cognitive complexity to code without adding any structural improvements- Whatever would be put on them, such as utility functions, are already organized by virtue of being in a module.
-- As an alternative, you can import * as ... the module to get all of them in a single object.
+- Wrapper classes add extra cognitive complexity to code without adding any structural improvements
+  - Whatever would be put on them, such as utility functions, are already organized by virtue of being in a module.
+  - As an alternative, you can import * as ... the module to get all of them in a single object.
 
 
 - IDEs can't provide as good suggestions for static class or namespace imported properties when you start typing property names

--- a/src/content/docs/linter/rules/use-naming-convention.md
+++ b/src/content/docs/linter/rules/use-naming-convention.md
@@ -404,54 +404,57 @@ For example, you can enforce the use of [`CONSTANT_CASE`](https://en.wikipedia.o
 A selector descibes which decalrations the convention applies to.
 You can select a decalration based on several criteria:
 
-- `kind`: the kind of the declaration among:- `any` (default kind if the kind is unset)
-- `typeLike`: classes, enums, type aliases, and interfaces
-- `class`
-- `enum`
-- `interface`
-- `typeAlias`
-- `function`: named function declarations and expressions
-- `namespaceLike`: TypeScript namespaces, import and export namespaces (`import * as namspace from`)
-- `namespace`: TypeScript namespaces
-- `importNamespace`
-- `exportNamespace`
-- `importAlias`: default imports and aliases of named imports
-- `exportAlias`: aliases of re-exported names
-- `variable`: const, let, using, and var declarations
-- `const`
-- `let`
-- `var`
-- `using`
-- `functionParameter`
-- `catchParameter`
-- `indexParameter`: parameters of index signatures
+- `kind`: the kind of the declaration among:
+  - `any` (default kind if the kind is unset)
+  - `typeLike`: classes, enums, type aliases, and interfaces
+  - `class`
+  - `enum`
+  - `interface`
+  - `typeAlias`
+  - `function`: named function declarations and expressions
+  - `namespaceLike`: TypeScript namespaces, import and export namespaces (`import * as namspace from`)
+  - `namespace`: TypeScript namespaces
+  - `importNamespace`
+  - `exportNamespace`
+  - `importAlias`: default imports and aliases of named imports
+  - `exportAlias`: aliases of re-exported names
+  - `variable`: const, let, using, and var declarations
+  - `const`
+  - `let`
+  - `var`
+  - `using`
+  - `functionParameter`
+  - `catchParameter`
+  - `indexParameter`: parameters of index signatures
 = `typeParameter`: generic type parameter
-- `classMember`: class properties, parameter properties, methods, getters, and setters
-- `classProperty`: class properties, including parameter properties
-- `classMethod`
-- `classGetter`
-- `classSetter`
-- `objectLiteralMember`: literal object properties, methods, getters, and setters
-- `objectLiteralProperty`
-- `objectLiteralMethod`
-- `objectLiteralGetter`
-- `objectLiteralSetter`
-- `typeMember`: properties, methods, getters, and setters declared in type alaises and interfaces
-- `typeProperty`
-- `typeMethod`
-- `typeGetter`
-- `typeSetter`
+  - `classMember`: class properties, parameter properties, methods, getters, and setters
+  - `classProperty`: class properties, including parameter properties
+  - `classMethod`
+  - `classGetter`
+  - `classSetter`
+  - `objectLiteralMember`: literal object properties, methods, getters, and setters
+  - `objectLiteralProperty`
+  - `objectLiteralMethod`
+  - `objectLiteralGetter`
+  - `objectLiteralSetter`
+  - `typeMember`: properties, methods, getters, and setters declared in type alaises and interfaces
+  - `typeProperty`
+  - `typeMethod`
+  - `typeGetter`
+  - `typeSetter`
 
 
-- `modifiers`: an array of modifiers among:- `abstract`: applies to class members and classes
-- `private`: applies to class members
-- `protected`: applies to class members
-- `readonly`: applies to class members and type members
-- `static`: applies to class members
+- `modifiers`: an array of modifiers among:
+  - `abstract`: applies to class members and classes
+  - `private`: applies to class members
+  - `protected`: applies to class members
+  - `readonly`: applies to class members and type members
+  - `static`: applies to class members
 
 
-- `scope`: where the declaration appears. Allowd values:- `any`: anywhere (default value if the scope is unset)
-- `global`: the global scope (also includes the namespace scopes)
+- `scope`: where the declaration appears. Allowd values:
+  - `any`: anywhere (default value if the scope is unset)
+  - `global`: the global scope (also includes the namespace scopes)
 
 
 


### PR DESCRIPTION
## Summary

Fix the documentation generation to handle correctly nested list.
This is a permanent correction for the PR #307 

It also add `HardBreak` (double space at the end of a line) in the markdown parser

It also linked to the PR https://github.com/biomejs/biome/pull/2875