### PR TITLE
refactor: replace `regexManagers` with `customManagers`

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,7 +5,7 @@
 	"extends": [
 		"config:best-practices",
 		"helpers:pinGitHubActionDigestsToSemver",
-		"regexManagers:biomeVersions"
+		"customManagers:biomeVersions"
 	],
 	"rangeStrategy": "bump",
 	"lockFileMaintenance": {

--- a/src/content/docs/recipes/renovate.mdx
+++ b/src/content/docs/recipes/renovate.mdx
@@ -7,14 +7,14 @@ description: Configuring Renovate Bot
 
 ## biome.json
 
-Renovate has a [shared preset rule](https://docs.renovatebot.com/presets-regexManagers/#regexmanagersbiomeversions) that can help keep the `$schema` version in-sync and up-to-date within the `biome.json` configuration files.
+Renovate has a [shared preset rule](https://docs.renovatebot.com/presets-customManagers/#custommanagersbiomeversions) that can help keep the `$schema` version in-sync and up-to-date within the `biome.json` configuration files.
 
-To use, add `regexManagers:biomeVersions` to your `extends` list.
+To use, add `customManagers:biomeVersions` to your `extends` list.
 
 
 ```json title="renovate.json"
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["regexManagers:biomeVersions"]
+  "extends": ["customManagers:biomeVersions"]
 }
 ```


### PR DESCRIPTION
## Summary

Renovate renamed `regexManagers` with `customManagers` recently: https://github.com/renovatebot/renovate/pull/28979

The hyperlink to `renovatebot.com` does not work anymore. Time to update the docs?