### PR TITLE
Update CLI anchor link in Formatter section

### DIFF
--- a/src/content/docs/formatter/index.mdx
+++ b/src/content/docs/formatter/index.mdx
@@ -44,7 +44,7 @@ For more information about all the available options, check the [CLI reference](
 Biome provides some options to tune the behavior of its formatter.
 Differently from other tools, Biome separates language-agnostic options from language-specific options.
 
-The formatter options can be set on the [CLI](reference/cli#biome-format) or in the `biome.json` configuration file.
+The formatter options can be set on the [CLI](/reference/cli/#biome-format) or in the `biome.json` configuration file.
 Biome doesn't support `.editorconfig` [yet](https://github.com/biomejs/biome/issues/1724).
 
 It's recommended to use the [configuration](/guides/how-biome-works#configuration) file to ensure that both the Biome CLI and the Biome LSP apply the same options.


### PR DESCRIPTION
Update CLI anchor link

## Screenshots
<img width="935" alt="Screenshot 2024-05-16 at 10 02 39" src="https://github.com/biomejs/website/assets/315504/d9ce48f4-4511-41b3-bc2a-8ca9ef4af526">

## Summary

Due to a minor error the link to the CLI redirects to a page that does not exist