### PR TITLE
chore: clarify how to disable all rules

### DIFF
--- a/src/content/docs/linter/index.mdx
+++ b/src/content/docs/linter/index.mdx
@@ -49,6 +49,8 @@ biome lint --error-on-warnings ./src
 ```
 
 By default, the Biome linter only runs [**recommended rules**](/linter/rules#recommended-rules).
+To disable _all rules_, you can disable the recommended rules in your Biome configuration file.
+This may be useful in cases when you want to enable only a few rules.
 Recommended rules emit diagnostics with the `error` severity.
 
 Rules are organized into groups.


### PR DESCRIPTION
## Summary
Make it clear that in order to disable **all linter rules**, one can use the `linter.rules.recommended = false` option.

Based on https://github.com/biomejs/biome/discussions/2822