### PR TITLE
chore: update/fix link in linter documentation

### DIFF
--- a/src/content/docs/linter/index.mdx
+++ b/src/content/docs/linter/index.mdx
@@ -37,7 +37,7 @@ For more information about all the available options, check the [CLI reference](
 
 The linter is organized into rules.
 A rule emits a diagnostic when it encounters a code that doesn't meet its requirements.
-For example, the [noDebugger](http://localhost:4321/linter/rules/no-debugger) rule reports using the `debugger` instruction in JavaScript code.
+For example, the [noDebugger](/linter/rules/no-debugger) rule reports using the `debugger` instruction in JavaScript code.
 
 A rule emits diagnostics with a `warn` or `error` severity.
 Diagnostics with an `error` severity cause the command to exit with a non-zero code,


### PR DESCRIPTION
## Summary

Fixed a broken link for the **noDebugger** rule in the Linter Rules documentation. Fixes issue #415 