### PR TITLE
docs: Fix typo

### DIFF
--- a/src/content/docs/guides/integrate-in-vcs.mdx
+++ b/src/content/docs/guides/integrate-in-vcs.mdx
@@ -77,4 +77,4 @@ Add the `--staged` option to your command, to process only those files:
 biome check --staged
 ```
 
-The `--staged' option is not available on the `ci' command because you are not expected to commit changes in a CI environment.
+The `--staged` option is not available on the `ci` command because you are not expected to commit changes in a CI environment.


### PR DESCRIPTION
Use backticks correctly

## Summary

There's two typos in the paragraph where a single quote is used instead of a backtick.