### PR TITLE
fix: git-hooks typos

### DIFF
--- a/src/content/docs/ja/recipes/git-hooks.mdx
+++ b/src/content/docs/ja/recipes/git-hooks.mdx
@@ -46,7 +46,7 @@ Gitリポジトリのルートに`lefthook.yml`というファイルを追加し
     commands:
       check:
         glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
-        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true {pushed_files}
+        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true {push_files}
   ```
 
 `glob`と`--files-ignore-unknown=true` を併用する必要はありません。

--- a/src/content/docs/pt-br/recipes/git-hooks.mdx
+++ b/src/content/docs/pt-br/recipes/git-hooks.mdx
@@ -47,7 +47,7 @@ Alguns exemplos de configurações:
     commands:
       check:
         glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
-        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true {pushed_files}
+        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true {push_files}
   ```
 
 Não é necessário utilizar tanto `glob` quanto `--files-ignore-unknown=true`.

--- a/src/content/docs/zh-cn/recipes/git-hooks.mdx
+++ b/src/content/docs/zh-cn/recipes/git-hooks.mdx
@@ -46,7 +46,7 @@ Git 允许在运行 git 命令的过程中执行 [Git Hooks](https://git-scm.com
     commands:
       check:
         glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
-        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true {pushed_files}
+        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true {push_files}
   ```
 
 注意你并不需要使用 `glob` 和 `--files-ignore-unknown=true` _Lefthook_。


### PR DESCRIPTION
## Summary

I found a typo on the Japanese page at https://biomejs.dev/ja/recipes/git-hooks/.
While the English page correctly uses "push_files" at https://biomejs.dev/recipes/git-hooks/, the Japanese page mistakenly uses "pushed_files."

I checked the following page, which indicates that "push_files" is the correct term, so I have made the necessary correction:
https://github.com/evilmartians/lefthook/blob/a58c11d76d087a5d0bfd2259e41f61e0007cbaa0/docs/configuration.md#push_files-template