### PR TITLE
docs: typo `javascript.linter.enabled` at configuration

### DIFF
--- a/src/content/docs/reference/configuration.mdx
+++ b/src/content/docs/reference/configuration.mdx
@@ -651,7 +651,7 @@ https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.htm
 
 > Default: `"transparent"`
 
-### `json.linter.enabled`
+### `javascript.linter.enabled`
 
 Enables Biome's formatter for JavaScript (and its super languages) files.
 


### PR DESCRIPTION
## Summary
javascript section has an incorrect json argument.

❌wrong:
javascript
  json.linter.enabled

✔️correct:
javascript:
  javascript.linter.enabled

<!-- 
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->