### PR TITLE
docs: delete `css.formatter.indentSize` param

### DIFF
--- a/src/content/docs/reference/configuration.mdx
+++ b/src/content/docs/reference/configuration.mdx
@@ -769,12 +769,6 @@ The style of the indentation for CSS (and its super languages) files. It can be 
 > Default: `"tab"`
 
 
-### `css.formatter.indentSize`
-
-How big the indentation should be for CSS (and its super languages) files.
-
-> Default: `2`
-
 ### `css.formatter.indentWidth`
 
 How big the indentation should be for CSS (and its super languages) files.


### PR DESCRIPTION
## Summary
`css.formatter.indentSize` was renamed `css.formatter.indentWidth` at https://github.com/biomejs/biome/pull/2790.

Unlike the other deprecated indentSize options (e.g. [formatter.indentSize](https://biomejs.dev/reference/configuration/#formatterindentsize)),
`css.formatter.indentSize` doesn't work anymore.

That's why `css.formatter.indentSize` should be deleted.
<!-- 
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->