### PR TITLE
feat: auto-generate configuration from source code

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "biome"]
-	path = biome
-	url = https://github.com/biomejs/biome

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -238,7 +238,7 @@ export default defineConfig({
 						},
 						{
 							label: "Configuration",
-							link: "/reference/configuration",
+							link: "/reference/configuration_v2",
 							translations: {
 								ja: "設定",
 								"zh-CN": "配置",

--- a/codegen/src/configuration.rs
+++ b/codegen/src/configuration.rs
@@ -1,0 +1,155 @@
+//! Auto generate markdown documentation for the configuration schema.
+use std::fs::File;
+use std::io::Write;
+use biome_configuration::PartialConfiguration;
+
+use schemars::schema_for;
+use serde_json::{to_string_pretty, Value};
+
+pub fn generate_configuration() -> anyhow::Result<()> {
+    let schema = schema_for!(PartialConfiguration);
+    let json_schema = to_string_pretty(&schema)?;
+    let schema: Value = serde_json::from_str(&json_schema)?;
+    let mut markdown = File::create("src/content/docs/reference/configuration_v2.mdx")?;
+
+    writeln!(markdown, "{}", generate_markdown_hearer())?;
+
+    if let Some(schema_object) = schema.as_object() {
+        if let Some(properties) = schema_object.get("properties").and_then(Value::as_object) {
+            for (name, details) in properties {
+                writeln!(markdown, "## `{}`", name)?;
+                writeln!(markdown)?;
+                if let Some(description) = details.get("description").and_then(Value::as_str) {
+                    if description.to_string().contains("```json") {
+                        let detail = format_code_block(description)?;
+                        writeln!(markdown, "{}", detail)?;
+                    } else {
+                        writeln!(markdown, "{}", description)?;
+                    }
+                }
+                writeln!(markdown, "\n")?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn generate_markdown_hearer() -> String {
+    let header = r#"---
+title: Configuration
+emoji: ⚙️
+category: reference
+description: How to customize and configure Biome with biome.json.
+---
+
+import LintGroups from "@/components/generated/Groups.astro";
+
+{/** Make sure to update the redirect in `static/_redirects` when changing the configuration title --> **/}
+"#;
+
+    header.to_string()
+}
+
+pub fn format_code_block(description: &str) -> Result<String, serde_json::Error> {
+    let mut formatted_description = String::new();
+
+    for line in description.split('\n') {
+        let line = line.trim();
+
+        if line.starts_with("```json title=") {
+            formatted_description.push_str(&format_json_block(line)?);
+        } else {
+            formatted_description.push_str(&format_list_line(line));
+        }
+        formatted_description.push('\n');
+    }
+
+    Ok(formatted_description)
+}
+
+fn format_json_block(line: &str) -> Result<String, serde_json::Error> {
+    let title = extract_title(line);
+    let json_body = extract_json_body(line);
+
+    let parsed_json = serde_json::from_str::<Value>(&json_body)?;
+    let pretty_json = serde_json::to_string_pretty(&parsed_json)?;
+
+    Ok(format!("{}\n{}\n", title, pretty_json))
+}
+
+fn extract_title(line: &str) -> String {
+    line.split_once('\"')
+        .and_then(|(_, rest)| rest.split_once('\"'))
+        .map_or(String::new(), |(title, _)| {
+            format!("```json title=\"{}\"", title)
+        })
+}
+
+fn extract_json_body(line: &str) -> String {
+    line.split_once('{')
+        .and_then(|(_, rest)| rest.rsplit_once('}'))
+        .map_or(String::new(), |(json_body, _)| format!("{{{}}}", json_body))
+}
+
+fn format_list_line(line: &str) -> String {
+    if line.contains(": -") || line.contains(". -") {
+        format_list(line)
+    } else {
+        line.to_string()
+    }
+}
+
+fn format_list(description: &str) -> String {
+    if let Some((header, items)) = description.split_once(':') {
+        let formatted_header = format!("{}:\n", header.trim());
+        let formatted_items = items
+            .split("; -")
+            .enumerate()
+            .map(|(index, item)| format_list_item(item, index > 0))
+            .collect::<Vec<String>>()
+            .join("\n");
+
+        format!("{}{}", formatted_header, formatted_items)
+    } else {
+        description.to_string()
+    }
+}
+
+fn format_list_item(item: &str, needs_bullet_point: bool) -> String {
+    let trimmed_item = item.trim();
+    let bullet_point = if needs_bullet_point { "- " } else { "" };
+    format!("{}{}", bullet_point, trimmed_item)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_format_code_block() {
+        let description = r#"```json title="biome.json" { "key": "value" } ```"#;
+        let expected = r#"```json title="biome.json"
+{
+  "key": "value"
+}
+"#;
+        assert_eq!(format_code_block(description), expected);
+
+        let description =
+            r#"```json title="config.json" { "key1": "value1", "key2": "value2" } ```"#;
+        let expected = r#"```json title="config.json"
+{
+  "key1": "value1",
+  "key2": "value2"
+}
+"#;
+        assert_eq!(format_code_block(description), expected);
+
+        let description = "This is a test string without JSON.";
+        assert_eq!(format_code_block(description), description);
+
+        let description = r#"```json title="invalid.json" { invalid JSON } ```"#;
+        assert_eq!(format_code_block(description), description);
+    }
+}

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -6,6 +6,7 @@ pub mod lintdoc;
 pub mod metadata;
 pub mod rules_sources;
 pub mod website;
+pub mod configuration;
 
 pub fn project_root() -> PathBuf {
     Path::new(
@@ -31,6 +32,9 @@ pub enum CodegenCommand {
     /// Updates the files of a release
     #[bpaf(command)]
     ReleaseFiles,
+    
+    #[bpaf(command)]
+    Configuration,
 
     /// Updates the documentation of the rule pages and the files of a release  
     #[bpaf(command)]

--- a/codegen/src/lib.rs
+++ b/codegen/src/lib.rs
@@ -2,11 +2,11 @@ use bpaf::Bpaf;
 use std::env;
 use std::path::{Path, PathBuf};
 
+pub mod configuration;
 pub mod lintdoc;
 pub mod metadata;
 pub mod rules_sources;
 pub mod website;
-pub mod configuration;
 
 pub fn project_root() -> PathBuf {
     Path::new(
@@ -32,7 +32,7 @@ pub enum CodegenCommand {
     /// Updates the files of a release
     #[bpaf(command)]
     ReleaseFiles,
-    
+
     #[bpaf(command)]
     Configuration,
 

--- a/codegen/src/lintdoc.rs
+++ b/codegen/src/lintdoc.rs
@@ -288,7 +288,7 @@ fn generate_group(
                     FixKind::Safe => {
                         properties.push_str("<span class='inline-icon'><Icon name=\"seti:config\" label=\"The rule has a safe fix\" size=\"1.2rem\"  /></span>");
                     }
-                    FixKind::Unsafe=> {
+                    FixKind::Unsafe => {
                         properties.push_str("<span class='inline-icon'><Icon name=\"warning\" label=\"The rule has an unsafe fix\" size=\"1.2rem\" /></span>");
                     }
                     FixKind::None => {}
@@ -452,7 +452,10 @@ fn generate_rule(payload: GenRule) -> Result<Vec<Event<'static>>> {
     writeln!(content, "## Related links")?;
     writeln!(content)?;
     writeln!(content, "- [Disable a rule](/linter/#disable-a-lint-rule)")?;
-    writeln!(content, "- [Configure the rule fix](/linter#configure-the-rule-fix)")?;
+    writeln!(
+        content,
+        "- [Configure the rule fix](/linter#configure-the-rule-fix)"
+    )?;
     writeln!(content, "- [Rule options](/linter/#rule-options)")?;
 
     let dashed_rule = Case::Kebab.convert(rule);

--- a/codegen/src/main.rs
+++ b/codegen/src/main.rs
@@ -1,8 +1,8 @@
+use codegen::configuration::generate_configuration;
 use codegen::lintdoc::generate_rule_docs;
 use codegen::metadata::generate_json_metadata;
 use codegen::website::generate_files;
 use codegen::{codegen_command, CodegenCommand};
-use codegen::configuration::generate_configuration;
 
 fn main() -> anyhow::Result<()> {
     let result = codegen_command().fallback_to_usage().run();
@@ -20,9 +20,7 @@ fn main() -> anyhow::Result<()> {
             generate_json_metadata()?;
         }
         CodegenCommand::Metadata => generate_json_metadata()?,
-        CodegenCommand::Configuration => {
-            generate_configuration()?
-        }
+        CodegenCommand::Configuration => generate_configuration()?,
     }
 
     Ok(())

--- a/codegen/src/main.rs
+++ b/codegen/src/main.rs
@@ -2,6 +2,7 @@ use codegen::lintdoc::generate_rule_docs;
 use codegen::metadata::generate_json_metadata;
 use codegen::website::generate_files;
 use codegen::{codegen_command, CodegenCommand};
+use codegen::configuration::generate_configuration;
 
 fn main() -> anyhow::Result<()> {
     let result = codegen_command().fallback_to_usage().run();
@@ -19,6 +20,9 @@ fn main() -> anyhow::Result<()> {
             generate_json_metadata()?;
         }
         CodegenCommand::Metadata => generate_json_metadata()?,
+        CodegenCommand::Configuration => {
+            generate_configuration()?
+        }
     }
 
     Ok(())

--- a/codegen/src/metadata.rs
+++ b/codegen/src/metadata.rs
@@ -276,7 +276,7 @@ pub fn generate_json_metadata() -> anyhow::Result<()> {
     println!("Project root {}", project_root().display());
     let metadata_file = project_root().join("src/pages/metadata/rules.json.js");
     println!("Metadata file {}", metadata_file.display());
-    
+
     if metadata_file.exists() {
         fs::remove_file(&metadata_file)?;
     }

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
 		"codegen:rules": "pnpm codegen rules",
 		"codegen:release-files": "pnpm codegen release-files",
 		"codegen:metadata": "pnpm codegen metadata",
-		"codegen:all": "pnpm codegen all"
+		"codegen:all": "pnpm codegen all",
+		"codegen:configuration": "pnpm codegen configuration"
 	},
 	"devDependencies": {
 		"@astrojs/netlify": "5.2.1",

--- a/src/content/docs/reference/configuration_v2.mdx
+++ b/src/content/docs/reference/configuration_v2.mdx
@@ -5,62 +5,49 @@ category: reference
 description: How to customize and configure Biome with biome.json.
 ---
 
-import LintGroups from "@/components/generated/Groups.astro";
-
-{/** Make sure to update the redirect in `static/_redirects` when changing the configuration title --> **/}
+The configuration that is contained inside the file `biome.json`
 
 ## `$schema`
 
 A field for the [JSON schema](https://json-schema.org/) specification
 
-
 ## `css`
 
 Specific configuration for the Css language
-
 
 ## `extends`
 
 A list of paths to other JSON files, used to extends the current configuration.
 
-
 ## `files`
 
 The configuration of the filesystem
-
 
 ## `formatter`
 
 The configuration of the formatter
 
-
 ## `javascript`
 
 Specific configuration for the JavaScript language
-
 
 ## `json`
 
 Specific configuration for the Json language
 
-
 ## `linter`
 
 The configuration for the linter
-
 
 ## `organizeImports`
 
 The configuration of the import sorting
 
-
 ## `overrides`
 
 A list of granular patterns that should be applied only to a sub set of files
 
-
 ## `vcs`
 
 The configuration of the VCS integration
-
 

--- a/src/content/docs/reference/configuration_v2.mdx
+++ b/src/content/docs/reference/configuration_v2.mdx
@@ -15,6 +15,76 @@ A field for the [JSON schema](https://json-schema.org/) specification
 
 Specific configuration for the Css language
 
+Options applied to CSS files
+
+### `css.formatter`
+
+CSS formatter options
+
+Options that changes how the CSS formatter behaves
+
+### `css.formatter.enabled`
+
+Control the formatter for CSS (and its super languages) files.
+
+> **Type**: Boolean
+
+### `css.formatter.indentStyle`
+
+The indent style applied to CSS (and its super languages) files.
+
+### `css.formatter.indentWidth`
+
+The size of the indentation applied to CSS (and its super languages) files. Default to 2.
+
+> **Type**: Integer
+
+### `css.formatter.lineEnding`
+
+The type of line ending applied to CSS (and its super languages) files.
+
+### `css.formatter.lineWidth`
+
+What's the max width of a line applied to CSS (and its super languages) files. Defaults to 80.
+
+Validated value for the `line_width` formatter options
+
+The allowed range of values is 1..=320
+
+### `css.formatter.quoteStyle`
+
+The type of quotes used in CSS code. Defaults to double.
+
+### `css.linter`
+
+CSS linter options
+
+Options that changes how the CSS linter behaves
+
+### `css.linter.enabled`
+
+Control the linter for CSS (and its super languages) files.
+
+> **Type**: Boolean
+
+### `css.parser`
+
+CSS parsing options
+
+Options that changes how the CSS parser behaves
+
+### `css.parser.allowWrongLineComments`
+
+Allow comments to appear on incorrect lines in `.css` files
+
+> **Type**: Boolean
+
+### `css.parser.cssModules`
+
+Enables parsing of CSS Modules specific features.
+
+> **Type**: Boolean
+
 ## `extends`
 
 A list of paths to other JSON files, used to extends the current configuration.
@@ -23,25 +93,4387 @@ A list of paths to other JSON files, used to extends the current configuration.
 
 The configuration of the filesystem
 
+The configuration of the filesystem
+
+### `files.ignore`
+
+A list of Unix shell style patterns. Biome will ignore files/folders that will match these patterns.
+
+### `files.ignoreUnknown`
+
+Tells Biome to not emit diagnostics when handling files that doesn't know
+
+> **Type**: Boolean
+
+### `files.include`
+
+A list of Unix shell style patterns. Biome will handle only those files/folders that will match these patterns.
+
+### `files.maxSize`
+
+The maximum allowed size for source code files in bytes. Files above this limit will be ignored for performance reasons. Defaults to 1 MiB
+
+> **Type**: Integer
+
 ## `formatter`
 
 The configuration of the formatter
+
+Generic options applied to all files
+
+### `formatter.attributePosition`
+
+The attribute position style in HTMLish languages. By default auto.
+
+> **Type**: Boolean
+
+### `formatter.formatWithErrors`
+
+Stores whether formatting should be allowed to proceed if a given file has syntax errors
+
+> **Type**: Boolean
+
+### `formatter.ignore`
+
+A list of Unix shell style patterns. The formatter will ignore files/folders that will match these patterns.
+
+### `formatter.include`
+
+A list of Unix shell style patterns. The formatter will include files/folders that will match these patterns.
+
+### `formatter.indentSize`
+
+The size of the indentation, 2 by default (deprecated, use `indent-width`)
+
+> **Type**: Integer
+
+### `formatter.indentStyle`
+
+The indent style.
+
+### `formatter.indentWidth`
+
+The size of the indentation, 2 by default
+
+> **Type**: Integer
+
+### `formatter.lineEnding`
+
+The type of line ending.
+
+### `formatter.lineWidth`
+
+What's the max width of a line. Defaults to 80.
+
+Validated value for the `line_width` formatter options
+
+The allowed range of values is 1..=320
 
 ## `javascript`
 
 Specific configuration for the JavaScript language
 
+A set of options applied to the JavaScript files
+
+### `javascript.formatter`
+
+Formatting options
+
+Formatting options specific to the JavaScript files
+
+### `javascript.formatter.arrowParentheses`
+
+Whether to add non-necessary parentheses to arrow functions. Defaults to "always".
+
+### `javascript.formatter.attributePosition`
+
+The attribute position style in jsx elements. Defaults to auto.
+
+### `javascript.formatter.bracketSameLine`
+
+Whether to hug the closing bracket of multiline HTML/JSX tags to the end of the last line, rather than being alone on the following line. Defaults to false.
+
+> **Type**: Boolean
+
+### `javascript.formatter.bracketSpacing`
+
+Whether to insert spaces around brackets in object literals. Defaults to true.
+
+> **Type**: Boolean
+
+### `javascript.formatter.enabled`
+
+Control the formatter for JavaScript (and its super languages) files.
+
+> **Type**: Boolean
+
+### `javascript.formatter.indentSize`
+
+The size of the indentation applied to JavaScript (and its super languages) files. Default to 2.
+
+> **Type**: Integer
+
+### `javascript.formatter.indentStyle`
+
+The indent style applied to JavaScript (and its super languages) files.
+
+### `javascript.formatter.indentWidth`
+
+The size of the indentation applied to JavaScript (and its super languages) files. Default to 2.
+
+> **Type**: Integer
+
+### `javascript.formatter.jsxQuoteStyle`
+
+The type of quotes used in JSX. Defaults to double.
+
+### `javascript.formatter.lineEnding`
+
+The type of line ending applied to JavaScript (and its super languages) files.
+
+### `javascript.formatter.lineWidth`
+
+What's the max width of a line applied to JavaScript (and its super languages) files. Defaults to 80.
+
+Validated value for the `line_width` formatter options
+
+The allowed range of values is 1..=320
+
+### `javascript.formatter.quoteProperties`
+
+When properties in objects are quoted. Defaults to asNeeded.
+
+### `javascript.formatter.quoteStyle`
+
+The type of quotes used in JavaScript code. Defaults to double.
+
+### `javascript.formatter.semicolons`
+
+Whether the formatter prints semicolons for all statements or only in for statements where it is necessary because of ASI.
+
+### `javascript.formatter.trailingComma`
+
+Print trailing commas wherever possible in multi-line comma-separated syntactic structures. Defaults to "all".
+
+Print trailing commas wherever possible in multi-line comma-separated syntactic structures.
+
+### `javascript.formatter.trailingCommas`
+
+Print trailing commas wherever possible in multi-line comma-separated syntactic structures. Defaults to "all".
+
+Print trailing commas wherever possible in multi-line comma-separated syntactic structures.
+
+### `javascript.globals`
+
+A list of global bindings that should be ignored by the analyzers
+
+If defined here, they should not emit diagnostics.
+
+### `javascript.jsxRuntime`
+
+Indicates the type of runtime or transformation used for interpreting JSX.
+
+Indicates the type of runtime or transformation used for interpreting JSX.
+
+### `javascript.linter`
+
+Linter options
+
+Linter options specific to the JavaScript linter
+
+### `javascript.linter.enabled`
+
+Control the linter for JavaScript (and its super languages) files.
+
+> **Type**: Boolean
+
+### `javascript.parser`
+
+Parsing options
+
+Options that changes how the JavaScript parser behaves
+
+### `javascript.parser.unsafeParameterDecoratorsEnabled`
+
+It enables the experimental and unsafe parsing of parameter decorators
+
+These decorators belong to an old proposal, and they are subject to change.
+
+> **Type**: Boolean
+
 ## `json`
 
 Specific configuration for the Json language
+
+Options applied to JSON files
+
+### `json.formatter`
+
+Formatting options
+
+### `json.formatter.enabled`
+
+Control the formatter for JSON (and its super languages) files.
+
+> **Type**: Boolean
+
+### `json.formatter.indentSize`
+
+The size of the indentation applied to JSON (and its super languages) files. Default to 2.
+
+> **Type**: Integer
+
+### `json.formatter.indentStyle`
+
+The indent style applied to JSON (and its super languages) files.
+
+### `json.formatter.indentWidth`
+
+The size of the indentation applied to JSON (and its super languages) files. Default to 2.
+
+> **Type**: Integer
+
+### `json.formatter.lineEnding`
+
+The type of line ending applied to JSON (and its super languages) files.
+
+### `json.formatter.lineWidth`
+
+What's the max width of a line applied to JSON (and its super languages) files. Defaults to 80.
+
+Validated value for the `line_width` formatter options
+
+The allowed range of values is 1..=320
+
+### `json.formatter.trailingCommas`
+
+Print trailing commas wherever possible in multi-line comma-separated syntactic structures. Defaults to "none".
+
+### `json.linter`
+
+Linting options
+
+Linter options specific to the JSON linter
+
+### `json.linter.enabled`
+
+Control the linter for JSON (and its super languages) files.
+
+> **Type**: Boolean
+
+### `json.parser`
+
+Parsing options
+
+Options that changes how the JSON parser behaves
+
+### `json.parser.allowComments`
+
+Allow parsing comments in `.json` files
+
+> **Type**: Boolean
+
+### `json.parser.allowTrailingCommas`
+
+Allow parsing trailing commas in `.json` files
+
+> **Type**: Boolean
 
 ## `linter`
 
 The configuration for the linter
 
+### `linter.enabled`
+
+if `false`, it disables the feature and the linter won't be executed. `true` by default
+
+> **Type**: Boolean
+
+### `linter.ignore`
+
+A list of Unix shell style patterns. The formatter will ignore files/folders that will match these patterns.
+
+### `linter.include`
+
+A list of Unix shell style patterns. The formatter will include files/folders that will match these patterns.
+
+### `linter.rules`
+
+List of rules
+
+A list of rules that belong to this group
+
+### `linter.rules.a11y.all`
+
+It enables ALL rules for this group.
+
+> **Type**: Boolean
+
+### `linter.rules.a11y.noAccessKey`
+
+Enforce that the accessKey attribute is not used on any HTML element.
+
+### `linter.rules.a11y.noAccessKey.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.a11y.noAccessKey.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.a11y.noAccessKey.options`
+
+Rule's options
+
+
+### `linter.rules.a11y.noAriaHiddenOnFocusable`
+
+Enforce that aria-hidden="true" is not set on focusable elements.
+
+### `linter.rules.a11y.noAriaHiddenOnFocusable.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.a11y.noAriaHiddenOnFocusable.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.a11y.noAriaHiddenOnFocusable.options`
+
+Rule's options
+
+
+### `linter.rules.a11y.noAriaUnsupportedElements`
+
+Enforce that elements that do not support ARIA roles, states, and properties do not have those attributes.
+
+### `linter.rules.a11y.noAriaUnsupportedElements.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.a11y.noAriaUnsupportedElements.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.a11y.noAriaUnsupportedElements.options`
+
+Rule's options
+
+
+### `linter.rules.a11y.noAutofocus`
+
+Enforce that autoFocus prop is not used on elements.
+
+### `linter.rules.a11y.noAutofocus.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.a11y.noAutofocus.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.a11y.noAutofocus.options`
+
+Rule's options
+
+
+### `linter.rules.a11y.noBlankTarget`
+
+Disallow target="_blank" attribute without rel="noreferrer"
+
+### `linter.rules.a11y.noBlankTarget.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.a11y.noBlankTarget.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.a11y.noBlankTarget.options`
+
+Rule's options
+
+
+### `linter.rules.a11y.noDistractingElements`
+
+Enforces that no distracting elements are used.
+
+### `linter.rules.a11y.noDistractingElements.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.a11y.noDistractingElements.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.a11y.noDistractingElements.options`
+
+Rule's options
+
+
+### `linter.rules.a11y.noHeaderScope`
+
+The scope prop should be used only on \<th> elements.
+
+### `linter.rules.a11y.noHeaderScope.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.a11y.noHeaderScope.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.a11y.noHeaderScope.options`
+
+Rule's options
+
+
+### `linter.rules.a11y.noInteractiveElementToNoninteractiveRole`
+
+Enforce that non-interactive ARIA roles are not assigned to interactive HTML elements.
+
+### `linter.rules.a11y.noInteractiveElementToNoninteractiveRole.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.a11y.noInteractiveElementToNoninteractiveRole.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.a11y.noInteractiveElementToNoninteractiveRole.options`
+
+Rule's options
+
+
+### `linter.rules.a11y.noNoninteractiveElementToInteractiveRole`
+
+Enforce that interactive ARIA roles are not assigned to non-interactive HTML elements.
+
+### `linter.rules.a11y.noNoninteractiveElementToInteractiveRole.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.a11y.noNoninteractiveElementToInteractiveRole.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.a11y.noNoninteractiveElementToInteractiveRole.options`
+
+Rule's options
+
+
+### `linter.rules.a11y.noNoninteractiveTabindex`
+
+Enforce that tabIndex is not assigned to non-interactive HTML elements.
+
+### `linter.rules.a11y.noNoninteractiveTabindex.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.a11y.noNoninteractiveTabindex.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.a11y.noNoninteractiveTabindex.options`
+
+Rule's options
+
+
+### `linter.rules.a11y.noPositiveTabindex`
+
+Prevent the usage of positive integers on tabIndex property
+
+### `linter.rules.a11y.noPositiveTabindex.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.a11y.noPositiveTabindex.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.a11y.noPositiveTabindex.options`
+
+Rule's options
+
+
+### `linter.rules.a11y.noRedundantAlt`
+
+Enforce img alt prop does not contain the word "image", "picture", or "photo".
+
+### `linter.rules.a11y.noRedundantAlt.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.a11y.noRedundantAlt.options`
+
+Rule's options
+
+
+### `linter.rules.a11y.noRedundantRoles`
+
+Enforce explicit role property is not the same as implicit/default role property on an element.
+
+### `linter.rules.a11y.noRedundantRoles.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.a11y.noRedundantRoles.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.a11y.noRedundantRoles.options`
+
+Rule's options
+
+
+### `linter.rules.a11y.noSvgWithoutTitle`
+
+Enforces the usage of the title element for the svg element.
+
+### `linter.rules.a11y.noSvgWithoutTitle.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.a11y.noSvgWithoutTitle.options`
+
+Rule's options
+
+
+### `linter.rules.a11y.recommended`
+
+It enables the recommended rules for this group
+
+> **Type**: Boolean
+
+### `linter.rules.a11y.useAltText`
+
+Enforce that all elements that require alternative text have meaningful information to relay back to the end user.
+
+### `linter.rules.a11y.useAltText.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.a11y.useAltText.options`
+
+Rule's options
+
+
+### `linter.rules.a11y.useAnchorContent`
+
+Enforce that anchors have content and that the content is accessible to screen readers.
+
+### `linter.rules.a11y.useAnchorContent.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.a11y.useAnchorContent.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.a11y.useAnchorContent.options`
+
+Rule's options
+
+
+### `linter.rules.a11y.useAriaActivedescendantWithTabindex`
+
+Enforce that tabIndex is assigned to non-interactive HTML elements with aria-activedescendant.
+
+### `linter.rules.a11y.useAriaActivedescendantWithTabindex.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.a11y.useAriaActivedescendantWithTabindex.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.a11y.useAriaActivedescendantWithTabindex.options`
+
+Rule's options
+
+
+### `linter.rules.a11y.useAriaPropsForRole`
+
+Enforce that elements with ARIA roles must have all required ARIA attributes for that role.
+
+### `linter.rules.a11y.useAriaPropsForRole.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.a11y.useAriaPropsForRole.options`
+
+Rule's options
+
+
+### `linter.rules.a11y.useButtonType`
+
+Enforces the usage of the attribute type for the element button
+
+### `linter.rules.a11y.useButtonType.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.a11y.useButtonType.options`
+
+Rule's options
+
+
+### `linter.rules.a11y.useHeadingContent`
+
+Enforce that heading elements (h1, h2, etc.) have content and that the content is accessible to screen readers. Accessible means that it is not hidden using the aria-hidden prop.
+
+### `linter.rules.a11y.useHeadingContent.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.a11y.useHeadingContent.options`
+
+Rule's options
+
+
+### `linter.rules.a11y.useHtmlLang`
+
+Enforce that html element has lang attribute.
+
+### `linter.rules.a11y.useHtmlLang.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.a11y.useHtmlLang.options`
+
+Rule's options
+
+
+### `linter.rules.a11y.useIframeTitle`
+
+Enforces the usage of the attribute title for the element iframe.
+
+### `linter.rules.a11y.useIframeTitle.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.a11y.useIframeTitle.options`
+
+Rule's options
+
+
+### `linter.rules.a11y.useKeyWithClickEvents`
+
+Enforce onClick is accompanied by at least one of the following: onKeyUp, onKeyDown, onKeyPress.
+
+### `linter.rules.a11y.useKeyWithClickEvents.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.a11y.useKeyWithClickEvents.options`
+
+Rule's options
+
+
+### `linter.rules.a11y.useKeyWithMouseEvents`
+
+Enforce onMouseOver / onMouseOut are accompanied by onFocus / onBlur.
+
+### `linter.rules.a11y.useKeyWithMouseEvents.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.a11y.useKeyWithMouseEvents.options`
+
+Rule's options
+
+
+### `linter.rules.a11y.useMediaCaption`
+
+Enforces that audio and video elements must have a track for captions.
+
+### `linter.rules.a11y.useMediaCaption.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.a11y.useMediaCaption.options`
+
+Rule's options
+
+
+### `linter.rules.a11y.useValidAnchor`
+
+Enforce that all anchors are valid, and they are navigable elements.
+
+### `linter.rules.a11y.useValidAnchor.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.a11y.useValidAnchor.options`
+
+Rule's options
+
+
+### `linter.rules.a11y.useValidAriaProps`
+
+Ensures that ARIA properties aria-* are all valid.
+
+### `linter.rules.a11y.useValidAriaProps.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.a11y.useValidAriaProps.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.a11y.useValidAriaProps.options`
+
+Rule's options
+
+
+### `linter.rules.a11y.useValidAriaRole`
+
+Elements with ARIA roles must use a valid, non-abstract ARIA role.
+
+### `linter.rules.a11y.useValidAriaRole.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.a11y.useValidAriaRole.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.a11y.useValidAriaRole.options`
+
+Rule's options
+
+### `linter.rules.a11y.useValidAriaValues`
+
+Enforce that ARIA state and property values are valid.
+
+### `linter.rules.a11y.useValidAriaValues.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.a11y.useValidAriaValues.options`
+
+Rule's options
+
+
+### `linter.rules.a11y.useValidLang`
+
+Ensure that the attribute passed to the lang attribute is a correct ISO language and/or country.
+
+### `linter.rules.a11y.useValidLang.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.a11y.useValidLang.options`
+
+Rule's options
+
+
+### `linter.rules.all`
+
+It enables ALL rules. The rules that belong to `nursery` won't be enabled.
+
+> **Type**: Boolean
+
+A list of rules that belong to this group
+
+### `linter.rules.complexity.all`
+
+It enables ALL rules for this group.
+
+> **Type**: Boolean
+
+### `linter.rules.complexity.noBannedTypes`
+
+Disallow primitive type aliases and misleading types.
+
+### `linter.rules.complexity.noBannedTypes.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.complexity.noBannedTypes.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.complexity.noBannedTypes.options`
+
+Rule's options
+
+
+### `linter.rules.complexity.noEmptyTypeParameters`
+
+Disallow empty type parameters in type aliases and interfaces.
+
+### `linter.rules.complexity.noEmptyTypeParameters.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.complexity.noEmptyTypeParameters.options`
+
+Rule's options
+
+
+### `linter.rules.complexity.noExcessiveCognitiveComplexity`
+
+Disallow functions that exceed a given Cognitive Complexity score.
+
+### `linter.rules.complexity.noExcessiveCognitiveComplexity.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.complexity.noExcessiveCognitiveComplexity.options`
+
+Rule's options
+
+### `linter.rules.complexity.noExcessiveNestedTestSuites`
+
+This rule enforces a maximum depth to nested describe() in test files.
+
+### `linter.rules.complexity.noExcessiveNestedTestSuites.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.complexity.noExcessiveNestedTestSuites.options`
+
+Rule's options
+
+
+### `linter.rules.complexity.noExtraBooleanCast`
+
+Disallow unnecessary boolean casts
+
+### `linter.rules.complexity.noExtraBooleanCast.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.complexity.noExtraBooleanCast.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.complexity.noExtraBooleanCast.options`
+
+Rule's options
+
+
+### `linter.rules.complexity.noForEach`
+
+Prefer for...of statement instead of Array.forEach.
+
+### `linter.rules.complexity.noForEach.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.complexity.noForEach.options`
+
+Rule's options
+
+
+### `linter.rules.complexity.noMultipleSpacesInRegularExpressionLiterals`
+
+Disallow unclear usage of consecutive space characters in regular expression literals
+
+### `linter.rules.complexity.noMultipleSpacesInRegularExpressionLiterals.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.complexity.noMultipleSpacesInRegularExpressionLiterals.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.complexity.noMultipleSpacesInRegularExpressionLiterals.options`
+
+Rule's options
+
+
+### `linter.rules.complexity.noStaticOnlyClass`
+
+This rule reports when a class has no non-static members, such as for a class used exclusively as a static namespace.
+
+### `linter.rules.complexity.noStaticOnlyClass.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.complexity.noStaticOnlyClass.options`
+
+Rule's options
+
+
+### `linter.rules.complexity.noThisInStatic`
+
+Disallow this and super in static contexts.
+
+### `linter.rules.complexity.noThisInStatic.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.complexity.noThisInStatic.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.complexity.noThisInStatic.options`
+
+Rule's options
+
+
+### `linter.rules.complexity.noUselessCatch`
+
+Disallow unnecessary catch clauses.
+
+### `linter.rules.complexity.noUselessCatch.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.complexity.noUselessCatch.options`
+
+Rule's options
+
+
+### `linter.rules.complexity.noUselessConstructor`
+
+Disallow unnecessary constructors.
+
+### `linter.rules.complexity.noUselessConstructor.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.complexity.noUselessConstructor.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.complexity.noUselessConstructor.options`
+
+Rule's options
+
+
+### `linter.rules.complexity.noUselessEmptyExport`
+
+Disallow empty exports that don't change anything in a module file.
+
+### `linter.rules.complexity.noUselessEmptyExport.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.complexity.noUselessEmptyExport.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.complexity.noUselessEmptyExport.options`
+
+Rule's options
+
+
+### `linter.rules.complexity.noUselessFragments`
+
+Disallow unnecessary fragments
+
+### `linter.rules.complexity.noUselessFragments.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.complexity.noUselessFragments.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.complexity.noUselessFragments.options`
+
+Rule's options
+
+
+### `linter.rules.complexity.noUselessLabel`
+
+Disallow unnecessary labels.
+
+### `linter.rules.complexity.noUselessLabel.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.complexity.noUselessLabel.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.complexity.noUselessLabel.options`
+
+Rule's options
+
+
+### `linter.rules.complexity.noUselessLoneBlockStatements`
+
+Disallow unnecessary nested block statements.
+
+### `linter.rules.complexity.noUselessLoneBlockStatements.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.complexity.noUselessLoneBlockStatements.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.complexity.noUselessLoneBlockStatements.options`
+
+Rule's options
+
+
+### `linter.rules.complexity.noUselessRename`
+
+Disallow renaming import, export, and destructured assignments to the same name.
+
+### `linter.rules.complexity.noUselessRename.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.complexity.noUselessRename.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.complexity.noUselessRename.options`
+
+Rule's options
+
+
+### `linter.rules.complexity.noUselessSwitchCase`
+
+Disallow useless case in switch statements.
+
+### `linter.rules.complexity.noUselessSwitchCase.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.complexity.noUselessSwitchCase.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.complexity.noUselessSwitchCase.options`
+
+Rule's options
+
+
+### `linter.rules.complexity.noUselessTernary`
+
+Disallow ternary operators when simpler alternatives exist.
+
+### `linter.rules.complexity.noUselessTernary.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.complexity.noUselessTernary.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.complexity.noUselessTernary.options`
+
+Rule's options
+
+
+### `linter.rules.complexity.noUselessThisAlias`
+
+Disallow useless this aliasing.
+
+### `linter.rules.complexity.noUselessThisAlias.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.complexity.noUselessThisAlias.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.complexity.noUselessThisAlias.options`
+
+Rule's options
+
+
+### `linter.rules.complexity.noUselessTypeConstraint`
+
+Disallow using any or unknown as type constraint.
+
+### `linter.rules.complexity.noUselessTypeConstraint.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.complexity.noUselessTypeConstraint.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.complexity.noUselessTypeConstraint.options`
+
+Rule's options
+
+
+### `linter.rules.complexity.noVoid`
+
+Disallow the use of void operators, which is not a familiar operator.
+
+### `linter.rules.complexity.noVoid.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.complexity.noVoid.options`
+
+Rule's options
+
+
+### `linter.rules.complexity.noWith`
+
+Disallow with statements in non-strict contexts.
+
+### `linter.rules.complexity.noWith.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.complexity.noWith.options`
+
+Rule's options
+
+
+### `linter.rules.complexity.recommended`
+
+It enables the recommended rules for this group
+
+> **Type**: Boolean
+
+### `linter.rules.complexity.useArrowFunction`
+
+Use arrow functions over function expressions.
+
+### `linter.rules.complexity.useArrowFunction.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.complexity.useArrowFunction.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.complexity.useArrowFunction.options`
+
+Rule's options
+
+
+### `linter.rules.complexity.useFlatMap`
+
+Promotes the use of .flatMap() when map().flat() are used together.
+
+### `linter.rules.complexity.useFlatMap.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.complexity.useFlatMap.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.complexity.useFlatMap.options`
+
+Rule's options
+
+
+### `linter.rules.complexity.useLiteralKeys`
+
+Enforce the usage of a literal access to properties over computed property access.
+
+### `linter.rules.complexity.useLiteralKeys.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.complexity.useLiteralKeys.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.complexity.useLiteralKeys.options`
+
+Rule's options
+
+
+### `linter.rules.complexity.useOptionalChain`
+
+Enforce using concise optional chain instead of chained logical expressions.
+
+### `linter.rules.complexity.useOptionalChain.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.complexity.useOptionalChain.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.complexity.useOptionalChain.options`
+
+Rule's options
+
+
+### `linter.rules.complexity.useRegexLiterals`
+
+Enforce the use of the regular expression literals instead of the RegExp constructor if possible.
+
+### `linter.rules.complexity.useRegexLiterals.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.complexity.useRegexLiterals.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.complexity.useRegexLiterals.options`
+
+Rule's options
+
+
+### `linter.rules.complexity.useSimpleNumberKeys`
+
+Disallow number literal object member names which are not base10 or uses underscore as separator
+
+### `linter.rules.complexity.useSimpleNumberKeys.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.complexity.useSimpleNumberKeys.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.complexity.useSimpleNumberKeys.options`
+
+Rule's options
+
+
+### `linter.rules.complexity.useSimplifiedLogicExpression`
+
+Discard redundant terms from logical expressions.
+
+### `linter.rules.complexity.useSimplifiedLogicExpression.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.complexity.useSimplifiedLogicExpression.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.complexity.useSimplifiedLogicExpression.options`
+
+Rule's options
+
+
+A list of rules that belong to this group
+
+### `linter.rules.correctness.all`
+
+It enables ALL rules for this group.
+
+> **Type**: Boolean
+
+### `linter.rules.correctness.noChildrenProp`
+
+Prevent passing of children as props.
+
+### `linter.rules.correctness.noChildrenProp.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.correctness.noChildrenProp.options`
+
+Rule's options
+
+
+### `linter.rules.correctness.noConstAssign`
+
+Prevents from having const variables being re-assigned.
+
+### `linter.rules.correctness.noConstAssign.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.correctness.noConstAssign.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.correctness.noConstAssign.options`
+
+Rule's options
+
+
+### `linter.rules.correctness.noConstantCondition`
+
+Disallow constant expressions in conditions
+
+### `linter.rules.correctness.noConstantCondition.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.correctness.noConstantCondition.options`
+
+Rule's options
+
+
+### `linter.rules.correctness.noConstantMathMinMaxClamp`
+
+Disallow the use of Math.min and Math.max to clamp a value where the result itself is constant.
+
+### `linter.rules.correctness.noConstantMathMinMaxClamp.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.correctness.noConstantMathMinMaxClamp.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.correctness.noConstantMathMinMaxClamp.options`
+
+Rule's options
+
+
+### `linter.rules.correctness.noConstructorReturn`
+
+Disallow returning a value from a constructor.
+
+### `linter.rules.correctness.noConstructorReturn.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.correctness.noConstructorReturn.options`
+
+Rule's options
+
+
+### `linter.rules.correctness.noEmptyCharacterClassInRegex`
+
+Disallow empty character classes in regular expression literals.
+
+### `linter.rules.correctness.noEmptyCharacterClassInRegex.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.correctness.noEmptyCharacterClassInRegex.options`
+
+Rule's options
+
+
+### `linter.rules.correctness.noEmptyPattern`
+
+Disallows empty destructuring patterns.
+
+### `linter.rules.correctness.noEmptyPattern.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.correctness.noEmptyPattern.options`
+
+Rule's options
+
+
+### `linter.rules.correctness.noFlatMapIdentity`
+
+Disallow to use unnecessary callback on flatMap.
+
+### `linter.rules.correctness.noFlatMapIdentity.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.correctness.noFlatMapIdentity.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.correctness.noFlatMapIdentity.options`
+
+Rule's options
+
+
+### `linter.rules.correctness.noGlobalObjectCalls`
+
+Disallow calling global object properties as functions
+
+### `linter.rules.correctness.noGlobalObjectCalls.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.correctness.noGlobalObjectCalls.options`
+
+Rule's options
+
+
+### `linter.rules.correctness.noInnerDeclarations`
+
+Disallow function and var declarations that are accessible outside their block.
+
+### `linter.rules.correctness.noInnerDeclarations.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.correctness.noInnerDeclarations.options`
+
+Rule's options
+
+
+### `linter.rules.correctness.noInvalidConstructorSuper`
+
+Prevents the incorrect use of super() inside classes. It also checks whether a call super() is missing from classes that extends other constructors.
+
+### `linter.rules.correctness.noInvalidConstructorSuper.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.correctness.noInvalidConstructorSuper.options`
+
+Rule's options
+
+
+### `linter.rules.correctness.noInvalidNewBuiltin`
+
+Disallow new operators with global non-constructor functions.
+
+### `linter.rules.correctness.noInvalidNewBuiltin.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.correctness.noInvalidNewBuiltin.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.correctness.noInvalidNewBuiltin.options`
+
+Rule's options
+
+
+### `linter.rules.correctness.noInvalidUseBeforeDeclaration`
+
+Disallow the use of variables and function parameters before their declaration
+
+### `linter.rules.correctness.noInvalidUseBeforeDeclaration.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.correctness.noInvalidUseBeforeDeclaration.options`
+
+Rule's options
+
+
+### `linter.rules.correctness.noNewSymbol`
+
+Disallow new operators with the Symbol object.
+
+### `linter.rules.correctness.noNewSymbol.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.correctness.noNewSymbol.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.correctness.noNewSymbol.options`
+
+Rule's options
+
+
+### `linter.rules.correctness.noNodejsModules`
+
+Forbid the use of Node.js builtin modules.
+
+### `linter.rules.correctness.noNodejsModules.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.correctness.noNodejsModules.options`
+
+Rule's options
+
+
+### `linter.rules.correctness.noNonoctalDecimalEscape`
+
+Disallow \8 and \9 escape sequences in string literals.
+
+### `linter.rules.correctness.noNonoctalDecimalEscape.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.correctness.noNonoctalDecimalEscape.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.correctness.noNonoctalDecimalEscape.options`
+
+Rule's options
+
+
+### `linter.rules.correctness.noPrecisionLoss`
+
+Disallow literal numbers that lose precision
+
+### `linter.rules.correctness.noPrecisionLoss.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.correctness.noPrecisionLoss.options`
+
+Rule's options
+
+
+### `linter.rules.correctness.noRenderReturnValue`
+
+Prevent the usage of the return value of React.render.
+
+### `linter.rules.correctness.noRenderReturnValue.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.correctness.noRenderReturnValue.options`
+
+Rule's options
+
+
+### `linter.rules.correctness.noSelfAssign`
+
+Disallow assignments where both sides are exactly the same.
+
+### `linter.rules.correctness.noSelfAssign.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.correctness.noSelfAssign.options`
+
+Rule's options
+
+
+### `linter.rules.correctness.noSetterReturn`
+
+Disallow returning a value from a setter
+
+### `linter.rules.correctness.noSetterReturn.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.correctness.noSetterReturn.options`
+
+Rule's options
+
+
+### `linter.rules.correctness.noStringCaseMismatch`
+
+Disallow comparison of expressions modifying the string case with non-compliant value.
+
+### `linter.rules.correctness.noStringCaseMismatch.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.correctness.noStringCaseMismatch.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.correctness.noStringCaseMismatch.options`
+
+Rule's options
+
+
+### `linter.rules.correctness.noSwitchDeclarations`
+
+Disallow lexical declarations in switch clauses.
+
+### `linter.rules.correctness.noSwitchDeclarations.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.correctness.noSwitchDeclarations.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.correctness.noSwitchDeclarations.options`
+
+Rule's options
+
+
+### `linter.rules.correctness.noUndeclaredVariables`
+
+Prevents the usage of variables that haven't been declared inside the document.
+
+### `linter.rules.correctness.noUndeclaredVariables.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.correctness.noUndeclaredVariables.options`
+
+Rule's options
+
+
+### `linter.rules.correctness.noUnnecessaryContinue`
+
+Avoid using unnecessary continue.
+
+### `linter.rules.correctness.noUnnecessaryContinue.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.correctness.noUnnecessaryContinue.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.correctness.noUnnecessaryContinue.options`
+
+Rule's options
+
+
+### `linter.rules.correctness.noUnreachable`
+
+Disallow unreachable code
+
+### `linter.rules.correctness.noUnreachable.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.correctness.noUnreachable.options`
+
+Rule's options
+
+
+### `linter.rules.correctness.noUnreachableSuper`
+
+Ensures the super() constructor is called exactly once on every code  path in a class constructor before this is accessed if the class has a superclass
+
+### `linter.rules.correctness.noUnreachableSuper.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.correctness.noUnreachableSuper.options`
+
+Rule's options
+
+
+### `linter.rules.correctness.noUnsafeFinally`
+
+Disallow control flow statements in finally blocks.
+
+### `linter.rules.correctness.noUnsafeFinally.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.correctness.noUnsafeFinally.options`
+
+Rule's options
+
+
+### `linter.rules.correctness.noUnsafeOptionalChaining`
+
+Disallow the use of optional chaining in contexts where the undefined value is not allowed.
+
+### `linter.rules.correctness.noUnsafeOptionalChaining.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.correctness.noUnsafeOptionalChaining.options`
+
+Rule's options
+
+
+### `linter.rules.correctness.noUnusedImports`
+
+Disallow unused imports.
+
+### `linter.rules.correctness.noUnusedImports.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.correctness.noUnusedImports.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.correctness.noUnusedImports.options`
+
+Rule's options
+
+
+### `linter.rules.correctness.noUnusedLabels`
+
+Disallow unused labels.
+
+### `linter.rules.correctness.noUnusedLabels.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.correctness.noUnusedLabels.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.correctness.noUnusedLabels.options`
+
+Rule's options
+
+
+### `linter.rules.correctness.noUnusedPrivateClassMembers`
+
+Disallow unused private class members
+
+### `linter.rules.correctness.noUnusedPrivateClassMembers.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.correctness.noUnusedPrivateClassMembers.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.correctness.noUnusedPrivateClassMembers.options`
+
+Rule's options
+
+
+### `linter.rules.correctness.noUnusedVariables`
+
+Disallow unused variables.
+
+### `linter.rules.correctness.noUnusedVariables.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.correctness.noUnusedVariables.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.correctness.noUnusedVariables.options`
+
+Rule's options
+
+
+### `linter.rules.correctness.noVoidElementsWithChildren`
+
+This rules prevents void elements (AKA self-closing elements) from having children.
+
+### `linter.rules.correctness.noVoidElementsWithChildren.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.correctness.noVoidElementsWithChildren.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.correctness.noVoidElementsWithChildren.options`
+
+Rule's options
+
+
+### `linter.rules.correctness.noVoidTypeReturn`
+
+Disallow returning a value from a function with the return type 'void'
+
+### `linter.rules.correctness.noVoidTypeReturn.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.correctness.noVoidTypeReturn.options`
+
+Rule's options
+
+
+### `linter.rules.correctness.recommended`
+
+It enables the recommended rules for this group
+
+> **Type**: Boolean
+
+### `linter.rules.correctness.useArrayLiterals`
+
+Disallow Array constructors.
+
+### `linter.rules.correctness.useArrayLiterals.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.correctness.useArrayLiterals.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.correctness.useArrayLiterals.options`
+
+Rule's options
+
+
+### `linter.rules.correctness.useExhaustiveDependencies`
+
+Enforce all dependencies are correctly specified in a React hook.
+
+### `linter.rules.correctness.useExhaustiveDependencies.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.correctness.useExhaustiveDependencies.options`
+
+Rule's options
+
+### `linter.rules.correctness.useHookAtTopLevel`
+
+Enforce that all React hooks are being called from the Top Level component functions.
+
+### `linter.rules.correctness.useHookAtTopLevel.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.correctness.useHookAtTopLevel.options`
+
+Rule's options
+
+### `linter.rules.correctness.useIsNan`
+
+Require calls to isNaN() when checking for NaN.
+
+### `linter.rules.correctness.useIsNan.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.correctness.useIsNan.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.correctness.useIsNan.options`
+
+Rule's options
+
+
+### `linter.rules.correctness.useJsxKeyInIterable`
+
+Disallow missing key props in iterators/collection literals.
+
+### `linter.rules.correctness.useJsxKeyInIterable.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.correctness.useJsxKeyInIterable.options`
+
+Rule's options
+
+
+### `linter.rules.correctness.useValidForDirection`
+
+Enforce "for" loop update clause moving the counter in the right direction.
+
+### `linter.rules.correctness.useValidForDirection.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.correctness.useValidForDirection.options`
+
+Rule's options
+
+
+### `linter.rules.correctness.useYield`
+
+Require generator functions to contain yield.
+
+### `linter.rules.correctness.useYield.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.correctness.useYield.options`
+
+Rule's options
+
+
+A list of rules that belong to this group
+
+### `linter.rules.nursery.all`
+
+It enables ALL rules for this group.
+
+> **Type**: Boolean
+
+### `linter.rules.nursery.noConsole`
+
+Disallow the use of console.
+
+### `linter.rules.nursery.noConsole.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.nursery.noConsole.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.nursery.noConsole.options`
+
+Rule's options
+
+
+### `linter.rules.nursery.noDoneCallback`
+
+Disallow using a callback in asynchronous tests and hooks.
+
+### `linter.rules.nursery.noDoneCallback.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.nursery.noDoneCallback.options`
+
+Rule's options
+
+
+### `linter.rules.nursery.noDuplicateAtImportRules`
+
+Disallow duplicate @import rules.
+
+### `linter.rules.nursery.noDuplicateAtImportRules.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.nursery.noDuplicateAtImportRules.options`
+
+Rule's options
+
+
+### `linter.rules.nursery.noDuplicateElseIf`
+
+Disallow duplicate conditions in if-else-if chains
+
+### `linter.rules.nursery.noDuplicateElseIf.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.nursery.noDuplicateElseIf.options`
+
+Rule's options
+
+
+### `linter.rules.nursery.noDuplicateFontNames`
+
+Disallow duplicate names within font families.
+
+### `linter.rules.nursery.noDuplicateFontNames.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.nursery.noDuplicateFontNames.options`
+
+Rule's options
+
+
+### `linter.rules.nursery.noDuplicateJsonKeys`
+
+Disallow two keys with the same name inside a JSON object.
+
+### `linter.rules.nursery.noDuplicateJsonKeys.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.nursery.noDuplicateJsonKeys.options`
+
+Rule's options
+
+
+### `linter.rules.nursery.noDuplicateSelectorsKeyframeBlock`
+
+Disallow duplicate selectors within keyframe blocks.
+
+### `linter.rules.nursery.noDuplicateSelectorsKeyframeBlock.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.nursery.noDuplicateSelectorsKeyframeBlock.options`
+
+Rule's options
+
+
+### `linter.rules.nursery.noEmptyBlock`
+
+Disallow CSS empty blocks.
+
+### `linter.rules.nursery.noEmptyBlock.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.nursery.noEmptyBlock.options`
+
+Rule's options
+
+
+### `linter.rules.nursery.noEvolvingTypes`
+
+Disallow variables from evolving into any type through reassignments.
+
+### `linter.rules.nursery.noEvolvingTypes.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.nursery.noEvolvingTypes.options`
+
+Rule's options
+
+
+### `linter.rules.nursery.noImportantInKeyframe`
+
+Disallow invalid !important within keyframe declarations
+
+### `linter.rules.nursery.noImportantInKeyframe.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.nursery.noImportantInKeyframe.options`
+
+Rule's options
+
+
+### `linter.rules.nursery.noInvalidPositionAtImportRule`
+
+Disallow the use of @import at-rules in invalid positions.
+
+### `linter.rules.nursery.noInvalidPositionAtImportRule.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.nursery.noInvalidPositionAtImportRule.options`
+
+Rule's options
+
+
+### `linter.rules.nursery.noLabelWithoutControl`
+
+Enforce that a label element or component has a text label and an associated input.
+
+### `linter.rules.nursery.noLabelWithoutControl.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.nursery.noLabelWithoutControl.options`
+
+Rule's options
+
+### `linter.rules.nursery.noMisplacedAssertion`
+
+Checks that the assertion function, for example expect, is placed inside an it() function call.
+
+### `linter.rules.nursery.noMisplacedAssertion.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.nursery.noMisplacedAssertion.options`
+
+Rule's options
+
+
+### `linter.rules.nursery.noReactSpecificProps`
+
+Prevents React-specific JSX properties from being used.
+
+### `linter.rules.nursery.noReactSpecificProps.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.nursery.noReactSpecificProps.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.nursery.noReactSpecificProps.options`
+
+Rule's options
+
+
+### `linter.rules.nursery.noRestrictedImports`
+
+Disallow specified modules when loaded by import or require.
+
+### `linter.rules.nursery.noRestrictedImports.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.nursery.noRestrictedImports.options`
+
+Rule's options
+
+### `linter.rules.nursery.noUndeclaredDependencies`
+
+Disallow the use of dependencies that aren't specified in the package.json.
+
+### `linter.rules.nursery.noUndeclaredDependencies.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.nursery.noUndeclaredDependencies.options`
+
+Rule's options
+
+
+### `linter.rules.nursery.noUnknownFunction`
+
+Disallow unknown CSS value functions.
+
+### `linter.rules.nursery.noUnknownFunction.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.nursery.noUnknownFunction.options`
+
+Rule's options
+
+
+### `linter.rules.nursery.noUnknownMediaFeatureName`
+
+Disallow unknown media feature names.
+
+### `linter.rules.nursery.noUnknownMediaFeatureName.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.nursery.noUnknownMediaFeatureName.options`
+
+Rule's options
+
+
+### `linter.rules.nursery.noUnknownProperty`
+
+Disallow unknown properties.
+
+### `linter.rules.nursery.noUnknownProperty.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.nursery.noUnknownProperty.options`
+
+Rule's options
+
+
+### `linter.rules.nursery.noUnknownSelectorPseudoElement`
+
+Disallow unknown pseudo-element selectors.
+
+### `linter.rules.nursery.noUnknownSelectorPseudoElement.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.nursery.noUnknownSelectorPseudoElement.options`
+
+Rule's options
+
+
+### `linter.rules.nursery.noUnknownUnit`
+
+Disallow unknown CSS units.
+
+### `linter.rules.nursery.noUnknownUnit.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.nursery.noUnknownUnit.options`
+
+Rule's options
+
+
+### `linter.rules.nursery.noUnmatchableAnbSelector`
+
+Disallow unmatchable An+B selectors.
+
+### `linter.rules.nursery.noUnmatchableAnbSelector.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.nursery.noUnmatchableAnbSelector.options`
+
+Rule's options
+
+
+### `linter.rules.nursery.noUnusedFunctionParameters`
+
+Disallow unused function parameters.
+
+### `linter.rules.nursery.noUnusedFunctionParameters.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.nursery.noUnusedFunctionParameters.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.nursery.noUnusedFunctionParameters.options`
+
+Rule's options
+
+
+### `linter.rules.nursery.noUselessStringConcat`
+
+Disallow unnecessary concatenation of string or template literals.
+
+### `linter.rules.nursery.noUselessStringConcat.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.nursery.noUselessStringConcat.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.nursery.noUselessStringConcat.options`
+
+Rule's options
+
+
+### `linter.rules.nursery.noUselessUndefinedInitialization`
+
+Disallow initializing variables to undefined.
+
+### `linter.rules.nursery.noUselessUndefinedInitialization.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.nursery.noUselessUndefinedInitialization.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.nursery.noUselessUndefinedInitialization.options`
+
+Rule's options
+
+
+### `linter.rules.nursery.noYodaExpression`
+
+Disallow the use of yoda expressions.
+
+### `linter.rules.nursery.noYodaExpression.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.nursery.noYodaExpression.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.nursery.noYodaExpression.options`
+
+Rule's options
+
+
+### `linter.rules.nursery.recommended`
+
+It enables the recommended rules for this group
+
+> **Type**: Boolean
+
+### `linter.rules.nursery.useAdjacentOverloadSignatures`
+
+Disallow the use of overload signatures that are not next to each other.
+
+### `linter.rules.nursery.useAdjacentOverloadSignatures.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.nursery.useAdjacentOverloadSignatures.options`
+
+Rule's options
+
+
+### `linter.rules.nursery.useConsistentBuiltinInstantiation`
+
+Enforce the use of new for all builtins, except String, Number, Boolean, Symbol and BigInt.
+
+### `linter.rules.nursery.useConsistentBuiltinInstantiation.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.nursery.useConsistentBuiltinInstantiation.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.nursery.useConsistentBuiltinInstantiation.options`
+
+Rule's options
+
+
+### `linter.rules.nursery.useDateNow`
+
+Use Date.now() to get the number of milliseconds since the Unix Epoch.
+
+### `linter.rules.nursery.useDateNow.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.nursery.useDateNow.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.nursery.useDateNow.options`
+
+Rule's options
+
+
+### `linter.rules.nursery.useDefaultSwitchClause`
+
+Require the default clause in switch statements.
+
+### `linter.rules.nursery.useDefaultSwitchClause.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.nursery.useDefaultSwitchClause.options`
+
+Rule's options
+
+
+### `linter.rules.nursery.useErrorMessage`
+
+Enforce passing a message value when creating a built-in error.
+
+### `linter.rules.nursery.useErrorMessage.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.nursery.useErrorMessage.options`
+
+Rule's options
+
+
+### `linter.rules.nursery.useExplicitLengthCheck`
+
+Enforce explicitly comparing the length, size, byteLength or byteOffset property of a value.
+
+### `linter.rules.nursery.useExplicitLengthCheck.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.nursery.useExplicitLengthCheck.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.nursery.useExplicitLengthCheck.options`
+
+Rule's options
+
+
+### `linter.rules.nursery.useFocusableInteractive`
+
+Elements with an interactive role and interaction handlers must be focusable.
+
+### `linter.rules.nursery.useFocusableInteractive.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.nursery.useFocusableInteractive.options`
+
+Rule's options
+
+
+### `linter.rules.nursery.useGenericFontNames`
+
+Disallow a missing generic family keyword within font families.
+
+### `linter.rules.nursery.useGenericFontNames.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.nursery.useGenericFontNames.options`
+
+Rule's options
+
+
+### `linter.rules.nursery.useImportExtensions`
+
+Enforce file extensions for relative imports.
+
+### `linter.rules.nursery.useImportExtensions.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.nursery.useImportExtensions.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.nursery.useImportExtensions.options`
+
+Rule's options
+
+
+### `linter.rules.nursery.useImportRestrictions`
+
+Disallows package private imports.
+
+### `linter.rules.nursery.useImportRestrictions.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.nursery.useImportRestrictions.options`
+
+Rule's options
+
+
+### `linter.rules.nursery.useNumberToFixedDigitsArgument`
+
+Enforce using the digits argument with Number#toFixed().
+
+### `linter.rules.nursery.useNumberToFixedDigitsArgument.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.nursery.useNumberToFixedDigitsArgument.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.nursery.useNumberToFixedDigitsArgument.options`
+
+Rule's options
+
+
+### `linter.rules.nursery.useSemanticElements`
+
+It detects the use of role attributes in JSX elements and suggests using semantic elements instead.
+
+### `linter.rules.nursery.useSemanticElements.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.nursery.useSemanticElements.options`
+
+Rule's options
+
+
+### `linter.rules.nursery.useSortedClasses`
+
+Enforce the sorting of CSS utility classes.
+
+### `linter.rules.nursery.useSortedClasses.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.nursery.useSortedClasses.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.nursery.useSortedClasses.options`
+
+Rule's options
+
+### `linter.rules.nursery.useThrowNewError`
+
+Require new when throwing an error.
+
+### `linter.rules.nursery.useThrowNewError.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.nursery.useThrowNewError.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.nursery.useThrowNewError.options`
+
+Rule's options
+
+
+### `linter.rules.nursery.useThrowOnlyError`
+
+Disallow throwing non-Error values.
+
+### `linter.rules.nursery.useThrowOnlyError.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.nursery.useThrowOnlyError.options`
+
+Rule's options
+
+
+### `linter.rules.nursery.useTopLevelRegex`
+
+Require regex literals to be declared at the top level.
+
+### `linter.rules.nursery.useTopLevelRegex.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.nursery.useTopLevelRegex.options`
+
+Rule's options
+
+
+A list of rules that belong to this group
+
+### `linter.rules.performance.all`
+
+It enables ALL rules for this group.
+
+> **Type**: Boolean
+
+### `linter.rules.performance.noAccumulatingSpread`
+
+Disallow the use of spread (...) syntax on accumulators.
+
+### `linter.rules.performance.noAccumulatingSpread.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.performance.noAccumulatingSpread.options`
+
+Rule's options
+
+
+### `linter.rules.performance.noBarrelFile`
+
+Disallow the use of barrel file.
+
+### `linter.rules.performance.noBarrelFile.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.performance.noBarrelFile.options`
+
+Rule's options
+
+
+### `linter.rules.performance.noDelete`
+
+Disallow the use of the delete operator.
+
+### `linter.rules.performance.noDelete.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.performance.noDelete.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.performance.noDelete.options`
+
+Rule's options
+
+
+### `linter.rules.performance.noReExportAll`
+
+Avoid re-export all.
+
+### `linter.rules.performance.noReExportAll.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.performance.noReExportAll.options`
+
+Rule's options
+
+
+### `linter.rules.performance.recommended`
+
+It enables the recommended rules for this group
+
+> **Type**: Boolean
+
+### `linter.rules.recommended`
+
+It enables the lint rules recommended by Biome. `true` by default.
+
+> **Type**: Boolean
+
+A list of rules that belong to this group
+
+### `linter.rules.security.all`
+
+It enables ALL rules for this group.
+
+> **Type**: Boolean
+
+### `linter.rules.security.noDangerouslySetInnerHtml`
+
+Prevent the usage of dangerous JSX props
+
+### `linter.rules.security.noDangerouslySetInnerHtml.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.security.noDangerouslySetInnerHtml.options`
+
+Rule's options
+
+
+### `linter.rules.security.noDangerouslySetInnerHtmlWithChildren`
+
+Report when a DOM element or a component uses both children and dangerouslySetInnerHTML prop.
+
+### `linter.rules.security.noDangerouslySetInnerHtmlWithChildren.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.security.noDangerouslySetInnerHtmlWithChildren.options`
+
+Rule's options
+
+
+### `linter.rules.security.noGlobalEval`
+
+Disallow the use of global eval().
+
+### `linter.rules.security.noGlobalEval.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.security.noGlobalEval.options`
+
+Rule's options
+
+
+### `linter.rules.security.recommended`
+
+It enables the recommended rules for this group
+
+> **Type**: Boolean
+
+A list of rules that belong to this group
+
+### `linter.rules.style.all`
+
+It enables ALL rules for this group.
+
+> **Type**: Boolean
+
+### `linter.rules.style.noArguments`
+
+Disallow the use of arguments.
+
+### `linter.rules.style.noArguments.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.style.noArguments.options`
+
+Rule's options
+
+
+### `linter.rules.style.noCommaOperator`
+
+Disallow comma operator.
+
+### `linter.rules.style.noCommaOperator.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.style.noCommaOperator.options`
+
+Rule's options
+
+
+### `linter.rules.style.noDefaultExport`
+
+Disallow default exports.
+
+### `linter.rules.style.noDefaultExport.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.style.noDefaultExport.options`
+
+Rule's options
+
+
+### `linter.rules.style.noImplicitBoolean`
+
+Disallow implicit true values on JSX boolean attributes
+
+### `linter.rules.style.noImplicitBoolean.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.style.noImplicitBoolean.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.style.noImplicitBoolean.options`
+
+Rule's options
+
+
+### `linter.rules.style.noInferrableTypes`
+
+Disallow type annotations for variables, parameters, and class properties initialized with a literal expression.
+
+### `linter.rules.style.noInferrableTypes.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.style.noInferrableTypes.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.style.noInferrableTypes.options`
+
+Rule's options
+
+
+### `linter.rules.style.noNamespace`
+
+Disallow the use of TypeScript's namespaces.
+
+### `linter.rules.style.noNamespace.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.style.noNamespace.options`
+
+Rule's options
+
+
+### `linter.rules.style.noNamespaceImport`
+
+Disallow the use of namespace imports.
+
+### `linter.rules.style.noNamespaceImport.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.style.noNamespaceImport.options`
+
+Rule's options
+
+
+### `linter.rules.style.noNegationElse`
+
+Disallow negation in the condition of an if statement if it has an else clause.
+
+### `linter.rules.style.noNegationElse.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.style.noNegationElse.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.style.noNegationElse.options`
+
+Rule's options
+
+
+### `linter.rules.style.noNonNullAssertion`
+
+Disallow non-null assertions using the ! postfix operator.
+
+### `linter.rules.style.noNonNullAssertion.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.style.noNonNullAssertion.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.style.noNonNullAssertion.options`
+
+Rule's options
+
+
+### `linter.rules.style.noParameterAssign`
+
+Disallow reassigning function parameters.
+
+### `linter.rules.style.noParameterAssign.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.style.noParameterAssign.options`
+
+Rule's options
+
+
+### `linter.rules.style.noParameterProperties`
+
+Disallow the use of parameter properties in class constructors.
+
+### `linter.rules.style.noParameterProperties.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.style.noParameterProperties.options`
+
+Rule's options
+
+
+### `linter.rules.style.noRestrictedGlobals`
+
+This rule allows you to specify global variable names that you don’t want to use in your application.
+
+### `linter.rules.style.noRestrictedGlobals.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.style.noRestrictedGlobals.options`
+
+Rule's options
+
+### `linter.rules.style.noShoutyConstants`
+
+Disallow the use of constants which its value is the upper-case version of its name.
+
+### `linter.rules.style.noShoutyConstants.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.style.noShoutyConstants.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.style.noShoutyConstants.options`
+
+Rule's options
+
+
+### `linter.rules.style.noUnusedTemplateLiteral`
+
+Disallow template literals if interpolation and special-character handling are not needed
+
+### `linter.rules.style.noUnusedTemplateLiteral.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.style.noUnusedTemplateLiteral.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.style.noUnusedTemplateLiteral.options`
+
+Rule's options
+
+
+### `linter.rules.style.noUselessElse`
+
+Disallow else block when the if block breaks early.
+
+### `linter.rules.style.noUselessElse.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.style.noUselessElse.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.style.noUselessElse.options`
+
+Rule's options
+
+
+### `linter.rules.style.noVar`
+
+Disallow the use of var
+
+### `linter.rules.style.noVar.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.style.noVar.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.style.noVar.options`
+
+Rule's options
+
+
+### `linter.rules.style.recommended`
+
+It enables the recommended rules for this group
+
+> **Type**: Boolean
+
+### `linter.rules.style.useAsConstAssertion`
+
+Enforce the use of as const over literal type and type annotation.
+
+### `linter.rules.style.useAsConstAssertion.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.style.useAsConstAssertion.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.style.useAsConstAssertion.options`
+
+Rule's options
+
+
+### `linter.rules.style.useBlockStatements`
+
+Requires following curly brace conventions.
+
+### `linter.rules.style.useBlockStatements.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.style.useBlockStatements.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.style.useBlockStatements.options`
+
+Rule's options
+
+
+### `linter.rules.style.useCollapsedElseIf`
+
+Enforce using else if instead of nested if in else clauses.
+
+### `linter.rules.style.useCollapsedElseIf.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.style.useCollapsedElseIf.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.style.useCollapsedElseIf.options`
+
+Rule's options
+
+
+### `linter.rules.style.useConsistentArrayType`
+
+Require consistently using either T\[] or Array\<T>
+
+### `linter.rules.style.useConsistentArrayType.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.style.useConsistentArrayType.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.style.useConsistentArrayType.options`
+
+Rule's options
+
+### `linter.rules.style.useConst`
+
+Require const declarations for variables that are only assigned once.
+
+### `linter.rules.style.useConst.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.style.useConst.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.style.useConst.options`
+
+Rule's options
+
+
+### `linter.rules.style.useDefaultParameterLast`
+
+Enforce default function parameters and optional function parameters to be last.
+
+### `linter.rules.style.useDefaultParameterLast.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.style.useDefaultParameterLast.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.style.useDefaultParameterLast.options`
+
+Rule's options
+
+
+### `linter.rules.style.useEnumInitializers`
+
+Require that each enum member value be explicitly initialized.
+
+### `linter.rules.style.useEnumInitializers.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.style.useEnumInitializers.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.style.useEnumInitializers.options`
+
+Rule's options
+
+
+### `linter.rules.style.useExponentiationOperator`
+
+Disallow the use of Math.pow in favor of the ** operator.
+
+### `linter.rules.style.useExponentiationOperator.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.style.useExponentiationOperator.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.style.useExponentiationOperator.options`
+
+Rule's options
+
+
+### `linter.rules.style.useExportType`
+
+Promotes the use of export type for types.
+
+### `linter.rules.style.useExportType.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.style.useExportType.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.style.useExportType.options`
+
+Rule's options
+
+
+### `linter.rules.style.useFilenamingConvention`
+
+Enforce naming conventions for JavaScript and TypeScript filenames.
+
+### `linter.rules.style.useFilenamingConvention.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.style.useFilenamingConvention.options`
+
+Rule's options
+
+### `linter.rules.style.useForOf`
+
+This rule recommends a for-of loop when in a for loop, the index used to extract an item from the iterated array.
+
+### `linter.rules.style.useForOf.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.style.useForOf.options`
+
+Rule's options
+
+
+### `linter.rules.style.useFragmentSyntax`
+
+This rule enforces the use of \<>...\</> over \<Fragment>...\</Fragment>.
+
+### `linter.rules.style.useFragmentSyntax.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.style.useFragmentSyntax.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.style.useFragmentSyntax.options`
+
+Rule's options
+
+
+### `linter.rules.style.useImportType`
+
+Promotes the use of import type for types.
+
+### `linter.rules.style.useImportType.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.style.useImportType.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.style.useImportType.options`
+
+Rule's options
+
+
+### `linter.rules.style.useLiteralEnumMembers`
+
+Require all enum members to be literal values.
+
+### `linter.rules.style.useLiteralEnumMembers.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.style.useLiteralEnumMembers.options`
+
+Rule's options
+
+
+### `linter.rules.style.useNamingConvention`
+
+Enforce naming conventions for everything across a codebase.
+
+### `linter.rules.style.useNamingConvention.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.style.useNamingConvention.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.style.useNamingConvention.options`
+
+Rule's options
+
+### `linter.rules.style.useNodeAssertStrict`
+
+Promotes the usage of node:assert/strict over node:assert.
+
+### `linter.rules.style.useNodeAssertStrict.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.style.useNodeAssertStrict.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.style.useNodeAssertStrict.options`
+
+Rule's options
+
+
+### `linter.rules.style.useNodejsImportProtocol`
+
+Enforces using the node: protocol for Node.js builtin modules.
+
+### `linter.rules.style.useNodejsImportProtocol.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.style.useNodejsImportProtocol.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.style.useNodejsImportProtocol.options`
+
+Rule's options
+
+
+### `linter.rules.style.useNumberNamespace`
+
+Use the Number properties instead of global ones.
+
+### `linter.rules.style.useNumberNamespace.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.style.useNumberNamespace.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.style.useNumberNamespace.options`
+
+Rule's options
+
+
+### `linter.rules.style.useNumericLiterals`
+
+Disallow parseInt() and Number.parseInt() in favor of binary, octal, and hexadecimal literals
+
+### `linter.rules.style.useNumericLiterals.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.style.useNumericLiterals.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.style.useNumericLiterals.options`
+
+Rule's options
+
+
+### `linter.rules.style.useSelfClosingElements`
+
+Prevent extra closing tags for components without children
+
+### `linter.rules.style.useSelfClosingElements.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.style.useSelfClosingElements.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.style.useSelfClosingElements.options`
+
+Rule's options
+
+
+### `linter.rules.style.useShorthandArrayType`
+
+When expressing array types, this rule promotes the usage of T\[] shorthand instead of Array\<T>.
+
+### `linter.rules.style.useShorthandArrayType.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.style.useShorthandArrayType.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.style.useShorthandArrayType.options`
+
+Rule's options
+
+
+### `linter.rules.style.useShorthandAssign`
+
+Require assignment operator shorthand where possible.
+
+### `linter.rules.style.useShorthandAssign.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.style.useShorthandAssign.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.style.useShorthandAssign.options`
+
+Rule's options
+
+
+### `linter.rules.style.useShorthandFunctionType`
+
+Enforce using function types instead of object type with call signatures.
+
+### `linter.rules.style.useShorthandFunctionType.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.style.useShorthandFunctionType.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.style.useShorthandFunctionType.options`
+
+Rule's options
+
+
+### `linter.rules.style.useSingleCaseStatement`
+
+Enforces switch clauses have a single statement, emits a quick fix wrapping the statements in a block.
+
+### `linter.rules.style.useSingleCaseStatement.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.style.useSingleCaseStatement.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.style.useSingleCaseStatement.options`
+
+Rule's options
+
+
+### `linter.rules.style.useSingleVarDeclarator`
+
+Disallow multiple variable declarations in the same variable statement
+
+### `linter.rules.style.useSingleVarDeclarator.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.style.useSingleVarDeclarator.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.style.useSingleVarDeclarator.options`
+
+Rule's options
+
+
+### `linter.rules.style.useTemplate`
+
+Prefer template literals over string concatenation.
+
+### `linter.rules.style.useTemplate.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.style.useTemplate.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.style.useTemplate.options`
+
+Rule's options
+
+
+### `linter.rules.style.useWhile`
+
+Enforce the use of while loops instead of for loops when the initializer and update expressions are not needed.
+
+### `linter.rules.style.useWhile.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.style.useWhile.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.style.useWhile.options`
+
+Rule's options
+
+
+A list of rules that belong to this group
+
+### `linter.rules.suspicious.all`
+
+It enables ALL rules for this group.
+
+> **Type**: Boolean
+
+### `linter.rules.suspicious.noApproximativeNumericConstant`
+
+Use standard constants instead of approximated literals.
+
+### `linter.rules.suspicious.noApproximativeNumericConstant.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.suspicious.noApproximativeNumericConstant.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.noApproximativeNumericConstant.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.noArrayIndexKey`
+
+Discourage the usage of Array index in keys.
+
+### `linter.rules.suspicious.noArrayIndexKey.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.noArrayIndexKey.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.noAssignInExpressions`
+
+Disallow assignments in expressions.
+
+### `linter.rules.suspicious.noAssignInExpressions.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.noAssignInExpressions.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.noAsyncPromiseExecutor`
+
+Disallows using an async function as a Promise executor.
+
+### `linter.rules.suspicious.noAsyncPromiseExecutor.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.noAsyncPromiseExecutor.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.noCatchAssign`
+
+Disallow reassigning exceptions in catch clauses.
+
+### `linter.rules.suspicious.noCatchAssign.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.noCatchAssign.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.noClassAssign`
+
+Disallow reassigning class members.
+
+### `linter.rules.suspicious.noClassAssign.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.noClassAssign.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.noCommentText`
+
+Prevent comments from being inserted as text nodes
+
+### `linter.rules.suspicious.noCommentText.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.suspicious.noCommentText.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.noCommentText.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.noCompareNegZero`
+
+Disallow comparing against -0
+
+### `linter.rules.suspicious.noCompareNegZero.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.suspicious.noCompareNegZero.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.noCompareNegZero.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.noConfusingLabels`
+
+Disallow labeled statements that are not loops.
+
+### `linter.rules.suspicious.noConfusingLabels.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.noConfusingLabels.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.noConfusingVoidType`
+
+Disallow void type outside of generic or return types.
+
+### `linter.rules.suspicious.noConfusingVoidType.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.suspicious.noConfusingVoidType.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.noConfusingVoidType.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.noConsoleLog`
+
+Disallow the use of console.log
+
+### `linter.rules.suspicious.noConsoleLog.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.suspicious.noConsoleLog.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.noConsoleLog.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.noConstEnum`
+
+Disallow TypeScript const enum
+
+### `linter.rules.suspicious.noConstEnum.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.suspicious.noConstEnum.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.noConstEnum.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.noControlCharactersInRegex`
+
+Prevents from having control characters and some escape sequences that match control characters in regular expressions.
+
+### `linter.rules.suspicious.noControlCharactersInRegex.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.noControlCharactersInRegex.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.noDebugger`
+
+Disallow the use of debugger
+
+### `linter.rules.suspicious.noDebugger.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.suspicious.noDebugger.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.noDebugger.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.noDoubleEquals`
+
+Require the use of === and !==
+
+### `linter.rules.suspicious.noDoubleEquals.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.suspicious.noDoubleEquals.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.noDoubleEquals.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.noDuplicateCase`
+
+Disallow duplicate case labels.
+
+### `linter.rules.suspicious.noDuplicateCase.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.noDuplicateCase.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.noDuplicateClassMembers`
+
+Disallow duplicate class members.
+
+### `linter.rules.suspicious.noDuplicateClassMembers.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.noDuplicateClassMembers.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.noDuplicateJsxProps`
+
+Prevents JSX properties to be assigned multiple times.
+
+### `linter.rules.suspicious.noDuplicateJsxProps.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.noDuplicateJsxProps.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.noDuplicateObjectKeys`
+
+Prevents object literals having more than one property declaration for the same name.
+
+### `linter.rules.suspicious.noDuplicateObjectKeys.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.suspicious.noDuplicateObjectKeys.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.noDuplicateObjectKeys.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.noDuplicateParameters`
+
+Disallow duplicate function parameter name.
+
+### `linter.rules.suspicious.noDuplicateParameters.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.noDuplicateParameters.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.noDuplicateTestHooks`
+
+A describe block should not contain duplicate hooks.
+
+### `linter.rules.suspicious.noDuplicateTestHooks.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.noDuplicateTestHooks.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.noEmptyBlockStatements`
+
+Disallow empty block statements and static blocks.
+
+### `linter.rules.suspicious.noEmptyBlockStatements.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.noEmptyBlockStatements.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.noEmptyInterface`
+
+Disallow the declaration of empty interfaces.
+
+### `linter.rules.suspicious.noEmptyInterface.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.suspicious.noEmptyInterface.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.noEmptyInterface.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.noExplicitAny`
+
+Disallow the any type usage.
+
+### `linter.rules.suspicious.noExplicitAny.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.noExplicitAny.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.noExportsInTest`
+
+Disallow using export or module.exports in files containing tests
+
+### `linter.rules.suspicious.noExportsInTest.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.noExportsInTest.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.noExtraNonNullAssertion`
+
+Prevents the wrong usage of the non-null assertion operator (!) in TypeScript files.
+
+### `linter.rules.suspicious.noExtraNonNullAssertion.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.suspicious.noExtraNonNullAssertion.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.noExtraNonNullAssertion.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.noFallthroughSwitchClause`
+
+Disallow fallthrough of switch clauses.
+
+### `linter.rules.suspicious.noFallthroughSwitchClause.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.noFallthroughSwitchClause.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.noFocusedTests`
+
+Disallow focused tests.
+
+### `linter.rules.suspicious.noFocusedTests.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.suspicious.noFocusedTests.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.noFocusedTests.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.noFunctionAssign`
+
+Disallow reassigning function declarations.
+
+### `linter.rules.suspicious.noFunctionAssign.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.noFunctionAssign.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.noGlobalAssign`
+
+Disallow assignments to native objects and read-only global variables.
+
+### `linter.rules.suspicious.noGlobalAssign.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.noGlobalAssign.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.noGlobalIsFinite`
+
+Use Number.isFinite instead of global isFinite.
+
+### `linter.rules.suspicious.noGlobalIsFinite.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.suspicious.noGlobalIsFinite.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.noGlobalIsFinite.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.noGlobalIsNan`
+
+Use Number.isNaN instead of global isNaN.
+
+### `linter.rules.suspicious.noGlobalIsNan.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.suspicious.noGlobalIsNan.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.noGlobalIsNan.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.noImplicitAnyLet`
+
+Disallow use of implicit any type on variable declarations.
+
+### `linter.rules.suspicious.noImplicitAnyLet.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.noImplicitAnyLet.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.noImportAssign`
+
+Disallow assigning to imported bindings
+
+### `linter.rules.suspicious.noImportAssign.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.noImportAssign.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.noLabelVar`
+
+Disallow labels that share a name with a variable
+
+### `linter.rules.suspicious.noLabelVar.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.noLabelVar.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.noMisleadingCharacterClass`
+
+Disallow characters made with multiple code points in character class syntax.
+
+### `linter.rules.suspicious.noMisleadingCharacterClass.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.suspicious.noMisleadingCharacterClass.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.noMisleadingCharacterClass.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.noMisleadingInstantiator`
+
+Enforce proper usage of new and constructor.
+
+### `linter.rules.suspicious.noMisleadingInstantiator.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.noMisleadingInstantiator.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.noMisrefactoredShorthandAssign`
+
+Disallow shorthand assign when variable appears on both sides.
+
+### `linter.rules.suspicious.noMisrefactoredShorthandAssign.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.suspicious.noMisrefactoredShorthandAssign.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.noMisrefactoredShorthandAssign.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.noPrototypeBuiltins`
+
+Disallow direct use of Object.prototype builtins.
+
+### `linter.rules.suspicious.noPrototypeBuiltins.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.noPrototypeBuiltins.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.noRedeclare`
+
+Disallow variable, function, class, and type redeclarations in the same scope.
+
+### `linter.rules.suspicious.noRedeclare.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.noRedeclare.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.noRedundantUseStrict`
+
+Prevents from having redundant "use strict".
+
+### `linter.rules.suspicious.noRedundantUseStrict.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.suspicious.noRedundantUseStrict.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.noRedundantUseStrict.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.noSelfCompare`
+
+Disallow comparisons where both sides are exactly the same.
+
+### `linter.rules.suspicious.noSelfCompare.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.noSelfCompare.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.noShadowRestrictedNames`
+
+Disallow identifiers from shadowing restricted names.
+
+### `linter.rules.suspicious.noShadowRestrictedNames.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.noShadowRestrictedNames.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.noSkippedTests`
+
+Disallow disabled tests.
+
+### `linter.rules.suspicious.noSkippedTests.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.suspicious.noSkippedTests.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.noSkippedTests.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.noSparseArray`
+
+Disallow sparse arrays
+
+### `linter.rules.suspicious.noSparseArray.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.suspicious.noSparseArray.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.noSparseArray.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.noSuspiciousSemicolonInJsx`
+
+It detects possible "wrong" semicolons inside JSX elements.
+
+### `linter.rules.suspicious.noSuspiciousSemicolonInJsx.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.noSuspiciousSemicolonInJsx.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.noThenProperty`
+
+Disallow then property.
+
+### `linter.rules.suspicious.noThenProperty.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.noThenProperty.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.noUnsafeDeclarationMerging`
+
+Disallow unsafe declaration merging between interfaces and classes.
+
+### `linter.rules.suspicious.noUnsafeDeclarationMerging.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.noUnsafeDeclarationMerging.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.noUnsafeNegation`
+
+Disallow using unsafe negation.
+
+### `linter.rules.suspicious.noUnsafeNegation.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.suspicious.noUnsafeNegation.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.noUnsafeNegation.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.recommended`
+
+It enables the recommended rules for this group
+
+> **Type**: Boolean
+
+### `linter.rules.suspicious.useAwait`
+
+Ensure async functions utilize await.
+
+### `linter.rules.suspicious.useAwait.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.useAwait.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.useDefaultSwitchClauseLast`
+
+Enforce default clauses in switch statements to be last
+
+### `linter.rules.suspicious.useDefaultSwitchClauseLast.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.useDefaultSwitchClauseLast.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.useGetterReturn`
+
+Enforce get methods to always return a value.
+
+### `linter.rules.suspicious.useGetterReturn.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.useGetterReturn.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.useIsArray`
+
+Use Array.isArray() instead of instanceof Array.
+
+### `linter.rules.suspicious.useIsArray.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.suspicious.useIsArray.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.useIsArray.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.useNamespaceKeyword`
+
+Require using the namespace keyword over the module keyword to declare TypeScript namespaces.
+
+### `linter.rules.suspicious.useNamespaceKeyword.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.suspicious.useNamespaceKeyword.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.useNamespaceKeyword.options`
+
+Rule's options
+
+
+### `linter.rules.suspicious.useValidTypeof`
+
+This rule verifies the result of typeof $expr unary expressions is being compared to valid values, either string literals containing valid type names or other typeof expressions
+
+### `linter.rules.suspicious.useValidTypeof.fix`
+
+The kind of the code actions emitted by the rule
+
+Used to identify the kind of code action emitted by a rule
+
+### `linter.rules.suspicious.useValidTypeof.level`
+
+The severity of the emitted diagnostics by the rule
+
+### `linter.rules.suspicious.useValidTypeof.options`
+
+Rule's options
+
+
 ## `organizeImports`
 
 The configuration of the import sorting
+
+### `organizeImports.enabled`
+
+Enables the organization of imports
+
+> **Type**: Boolean
+
+### `organizeImports.ignore`
+
+A list of Unix shell style patterns. The formatter will ignore files/folders that will match these patterns.
+
+### `organizeImports.include`
+
+A list of Unix shell style patterns. The formatter will include files/folders that will match these patterns.
 
 ## `overrides`
 
@@ -50,4 +4482,36 @@ A list of granular patterns that should be applied only to a sub set of files
 ## `vcs`
 
 The configuration of the VCS integration
+
+Set of properties to integrate Biome with a VCS software.
+
+### `vcs.clientKind`
+
+The kind of client.
+
+### `vcs.defaultBranch`
+
+The main branch of the project
+
+> **Type**: String
+
+### `vcs.enabled`
+
+Whether Biome should integrate itself with the VCS client
+
+> **Type**: Boolean
+
+### `vcs.root`
+
+The folder where Biome should check for VCS files. By default, Biome will use the same folder where `biome.json` was found.
+
+If Biome can't find the configuration, it will attempt to use the current working directory. If no current working directory can't be found, Biome won't use the VCS integration, and a diagnostic will be emitted
+
+> **Type**: String
+
+### `vcs.useIgnoreFile`
+
+Whether Biome should use the VCS ignore file. When [true], Biome will ignore the files specified in the ignore file.
+
+> **Type**: Boolean
 

--- a/src/content/docs/reference/configuration_v2.mdx
+++ b/src/content/docs/reference/configuration_v2.mdx
@@ -1,0 +1,66 @@
+---
+title: Configuration
+emoji: ⚙️
+category: reference
+description: How to customize and configure Biome with biome.json.
+---
+
+import LintGroups from "@/components/generated/Groups.astro";
+
+{/** Make sure to update the redirect in `static/_redirects` when changing the configuration title --> **/}
+
+## `$schema`
+
+A field for the [JSON schema](https://json-schema.org/) specification
+
+
+## `css`
+
+Specific configuration for the Css language
+
+
+## `extends`
+
+A list of paths to other JSON files, used to extends the current configuration.
+
+
+## `files`
+
+The configuration of the filesystem
+
+
+## `formatter`
+
+The configuration of the formatter
+
+
+## `javascript`
+
+Specific configuration for the JavaScript language
+
+
+## `json`
+
+Specific configuration for the Json language
+
+
+## `linter`
+
+The configuration for the linter
+
+
+## `organizeImports`
+
+The configuration of the import sorting
+
+
+## `overrides`
+
+A list of granular patterns that should be applied only to a sub set of files
+
+
+## `vcs`
+
+The configuration of the VCS integration
+
+


### PR DESCRIPTION
## Summary

This is my attempt to create the configuration reference page from source code.

The drawback: we lose many examples
The con: we keep one source of truth

I see two options here:
- Making our doc comments in the source more rich, with markdown examples and more. They will be rendered here.
- Having use cases and examples in a separate page.


What do you think?