### PR TITLE
docs: add `javascript.formatter.trailingCommas`

### DIFF
--- a/src/content/docs/reference/configuration.mdx
+++ b/src/content/docs/reference/configuration.mdx
@@ -527,6 +527,15 @@ Print trailing commas wherever possible in multi-line comma-separated syntactic 
 
 > Default: `"all"`
 
+### `javascript.formatter.trailingCommas`
+
+Print trailing commas wherever possible in multi-line comma-separated syntactic structures. Possible values:
+- `"all"`, the trailing comma is always added;
+- `"es5"`, the trailing comma is added only in places where it's supported by older version of JavaScript;
+- `"none"`, trailing commas are never added.
+
+> Default: `"all"`
+
 ### `javascript.formatter.semicolons`
 
 It configures where the formatter prints semicolons:


### PR DESCRIPTION
## Summary
The `javascript.formatter.trailingComma` option is deprecated and renamed to `javascript.formatter.trailingCommas`.
Then add the configuration.

Details can be checked in https://github.com/biomejs/biome/pull/2492
<!-- 
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->