### PR TITLE
fix(ci): setup-rust cache

### DIFF
--- a/.github/actions/setup-rust-toolchain/action.yaml
+++ b/.github/actions/setup-rust-toolchain/action.yaml
@@ -10,5 +10,3 @@ runs:
         echo "GITHUB_JOB=" >> $GITHUB_ENV
     - name: Install rust toolchain
       uses: moonrepo/setup-rust@d8048d4fdff0633123678b093726e6d7c8ad6de5 # v1.2.0
-      with:
-        cache-target: "target/debug"

--- a/src/playground/workers/biomeWorker.ts
+++ b/src/playground/workers/biomeWorker.ts
@@ -44,9 +44,11 @@ self.addEventListener("message", async (e) => {
 		case "init": {
 			try {
 				if (import.meta.env.DEV) {
-					await init("../../../node_modules/@biomejs/wasm-web/biome_wasm_bg.wasm?init");
+					await init(
+						"../../../node_modules/@biomejs/wasm-web/biome_wasm_bg.wasm?init",
+					);
 				} else {
-					await init()
+					await init();
 				}
 
 				workspace = new Workspace();


### PR DESCRIPTION
## Summary

We used to put the `Cargo.toml` file into the `codegen` subdir and I used a small hack to let it cache the target directory properly back then. Now we moved the manifest file to the root, so we no longer need the hack.

I also deleted all the actions cache.