### PR TITLE
chore(ci): remove revision input from the codegen step

### DIFF
--- a/.github/workflows/run-codegen.yaml
+++ b/.github/workflows/run-codegen.yaml
@@ -35,7 +35,6 @@ jobs:
         with:
           kinds: ${{ inputs.kinds }}
           version: ${{ inputs.version }}
-          revision: ${{ github.event.inputs.commit-id }}
 
       - name: Create pull request
         id: create-pull-request


### PR DESCRIPTION
## Summary

This was some legacy code.