### PR TITLE
chore(ci): add `.node-version` file and disable pnpm cache

### DIFF
--- a/.github/workflows/ja-translation.yaml
+++ b/.github/workflows/ja-translation.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
-          node-version: "*"
+          node-version-file: ".node-version"
       - uses: pnpm/action-setup@fe02b34f77f8bc703788d5817da081398fad5dd2 # v4.0.0
       - name: Cache pnpm modules
         uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2

--- a/.github/workflows/synchronize.yaml
+++ b/.github/workflows/synchronize.yaml
@@ -46,8 +46,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
-          node-version: 20
-          cache: pnpm
+          node-version-file: ".node-version"
 
       - name: Update revision
         run: ./scripts/update-revision.sh '${{ env.COMMIT_ID }}'

--- a/.github/workflows/update-contributors.yaml
+++ b/.github/workflows/update-contributors.yaml
@@ -21,7 +21,7 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
-          node-version: "*"
+          node-version-file: ".node-version"
 
       - name: Update contributors
         run: node scripts/update-contributors.js --token=${{ secrets.GITHUB_TOKEN }}

--- a/.node-version
+++ b/.node-version
@@ -1,0 +1,1 @@
+lts-latest

--- a/.node-version
+++ b/.node-version
@@ -1,1 +1,1 @@
-lts-latest
+lts/*


### PR DESCRIPTION
## Summary

- Add a `.node-version` file so netlify can also use the same version of node to build the site.
- Disable the pnpm cache. It's taking up the space and I don't think it will have too much effect. Let's see.