### PR TITLE
ci(codegen): remove diagnostics check from codegen

### DIFF
--- a/codegen/src/metadata.rs
+++ b/codegen/src/metadata.rs
@@ -276,7 +276,7 @@ pub fn generate_json_metadata() -> anyhow::Result<()> {
     println!("Project root {}", project_root().display());
     let metadata_file = project_root().join("src/pages/metadata/rules.json.js");
     println!("Metadata file {}", metadata_file.display());
-    
+
     if metadata_file.exists() {
         fs::remove_file(&metadata_file)?;
     }


### PR DESCRIPTION
## Summary

Following https://github.com/biomejs/biome/pull/3152, this PR removes the code that checks the validity of the documentation. Now the code prints markdown.