### PR TITLE
refactor: break down editors pages

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -15,4 +15,4 @@ jobs:
       - name: Setup Biome
         uses: biomejs/setup-biome@1cbe33ead22c7a2fded3b52fa2893611c815c9b5 # v2.2.1
       - name: Run Biome
-        run: biome ci --reporter=github .
+        run: biome ci

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -96,13 +96,27 @@ export default defineConfig({
 							},
 						},
 						{
-							label: "Integrate Biome in your editor",
-							link: "/guides/integrate-in-editor",
+							label: "Biome in your IDE",
 							translations: {
 								ja: "Biome をあなたのエディタに導入する",
 								"zh-CN": "编辑器中使用 Biome",
-								"pt-BR": "Integrando o Biome no seu editor",
+								"pt-BR": "Biome no seu editor",
 							},
+							items: [
+								{
+									label: "First-party plugins",
+									link: "/guides/editors/first-party-plugins",
+									badge: "updated"
+								},
+								{
+									label: "Third-party plugins",
+									link: "/guides/editors/third-party-plugins"
+								},
+								{
+									label: "Integrate Biome in an editor plugin",
+									link: "/guides/editors/create-a-plugin",
+								},
+							]
 						},
 						{
 							label: "Integrate Biome with your VCS",
@@ -198,7 +212,6 @@ export default defineConfig({
 								{
 									label: "Introduction",
 									link: "/linter",
-									badge: "updated",
 									translations: {
 										ja: "イントロダクション",
 										"zh-CN": "介绍",

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -106,17 +106,17 @@ export default defineConfig({
 								{
 									label: "First-party plugins",
 									link: "/guides/editors/first-party-plugins",
-									badge: "updated"
+									badge: "updated",
 								},
 								{
 									label: "Third-party plugins",
-									link: "/guides/editors/third-party-plugins"
+									link: "/guides/editors/third-party-plugins",
 								},
 								{
 									label: "Integrate Biome in an editor plugin",
 									link: "/guides/editors/create-a-plugin",
 								},
-							]
+							],
 						},
 						{
 							label: "Integrate Biome with your VCS",

--- a/src/content/docs/guides/editors/create-a-plugin.mdx
+++ b/src/content/docs/guides/editors/create-a-plugin.mdx
@@ -1,5 +1,5 @@
 ---
-title: Integrate Biome in your editor
+title: Integrate Biome in an editor plugin
 description: Learn how you can integrate Biome with editors and IDEs
 ---
 

--- a/src/content/docs/guides/editors/first-party-plugins.mdx
+++ b/src/content/docs/guides/editors/first-party-plugins.mdx
@@ -1,0 +1,48 @@
+---
+title: First-party plugins
+description: Learn how to set up first-party plugins
+---
+
+These are plugins that are maintained by the Biome team and part of the [Biome organization](https://github.com/biomejs).
+
+### VS Code
+
+The Biome editor integration allows you to:
+
+* Format files on save or when issuing the _Format_ command.
+* Lint files and apply code fixes
+
+Install our official [Biome VS Code extension](https://marketplace.visualstudio.com/items?itemName=biomejs.biome) from the Visual Studio Marketplace.
+
+To make Biome the default formatter open a [supported file](/internals/language-support/) and:
+
+1. open the *Command Palette* (View or <kbd>Ctrl</kbd>/<kbd title="Cmd">⌘</kbd>+<kbd title="Shift">⇧</kbd>+<kbd>P</kbd>)
+1. select  *Format Document With...*
+1. select *Configure Default Formatter*
+1. select *Biome*.
+
+### IntelliJ
+
+To install the Biome IntelliJ plugin, head over to [official plugin page](https://plugins.jetbrains.com/plugin/22761-biome) or follow these steps:
+
+**From JetBrains IDEs:**
+
+1. Open IntelliJ IDEA.
+2. Go to **Settings/Preferences**.
+3. Select **Plugins** from the left-hand menu.
+4. Click on the **Marketplace** tab.
+5. Search for "Biome" and click **Install**.
+6. Restart the IDE to activate the plugin.
+
+**From disk:**
+
+1. Download the plugin .zip from releases tab.
+2. Press `⌘Сmd,` to open the IDE settings and then select Plugins.
+3. On the Plugins page, click The Settings button and then click Install Plugin from Disk….
+
+### Zed
+
+1. open the *Command Palette* (View or <kbd>Ctrl</kbd>/<kbd title="Cmd">⌘</kbd>+<kbd title="Shift">⇧</kbd>+<kbd>P</kbd>)
+2. select **zed: extensions**
+3. search **Biome**
+4. select **Install**

--- a/src/content/docs/guides/editors/third-party-plugins.mdx
+++ b/src/content/docs/guides/editors/third-party-plugins.mdx
@@ -1,0 +1,66 @@
+---
+title: Third-party plugins
+description: Learn how to set up third-party plugins
+---
+
+These are plugin maintained by other communities, that you install in your editor:
+- [`vim`](https://www.vim.org/): [`ALE`](https://github.com/dense-analysis/ale) supports Biome, just follow the installation instructions
+- [`neovim`](https://neovim.io/): you'll have to install [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig/), and follow the [instructions](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#biome). [`ALE`](https://github.com/dense-analysis/ale) also supports Biome.
+- [`helix`](https://helix-editor.com/): follow the instruction of [this manual](#helix)
+- [`coc-biome`](https://github.com/fannheyward/coc-biome): Biome extension for [`coc.nvim`](https://github.com/neoclide/coc.nvim)
+- [`sublime text`](https://www.sublimetext.com/): follow the [`LSP-biome`](https://github.com/sublimelsp/LSP-biome) installation instructions
+- [`Emacs`](https://www.gnu.org/software/emacs/): ensure you have [`lsp-mode`](https://github.com/emacs-lsp/lsp-mode) installed, follow the [`lsp-biome`](https://github.com/cxa/lsp-biome) installation instructions to enable Biome support in `lsp-mode`
+
+:::note
+Is there a plugin for an editor that isn't listed here? Please file a PR and we will be happy to add it to the list
+:::
+
+### Helix
+
+Currently, biome supports the following file extensions: `js`, `jsx`, `ts`, `tsx`, `d.ts`, `json` and `jsonc`.
+
+Biome has an `lsp-proxy` command that acts as a server for the Language Server Protocol over stdin/stdout.
+
+#### Helix 23.10
+
+Helix 23.10 has [support for multiple language servers](https://github.com/helix-editor/helix/pull/2507). Now you can use biome alongside `typescript-language-server`.
+
+```toml
+[language-server]
+biome = { command = "biome", args = ["lsp-proxy"] }
+
+[[language]]
+name = "javascript"
+language-servers = [ { name = "typescript-language-server", except-features = [ "format" ] }, "biome" ]
+auto-format = true
+
+[[language]]
+name = "typescript"
+language-servers = [ { name = "typescript-language-server", except-features = [ "format" ] }, "biome" ]
+auto-format = true
+
+[[language]]
+name = "tsx"
+auto-format = true
+language-servers = [ { name = "typescript-language-server", except-features = [ "format" ] }, "biome" ]
+
+[[language]]
+name = "jsx"
+auto-format = true
+language-servers = [ { name = "typescript-language-server", except-features = [ "format" ] }, "biome" ]
+
+[[language]]
+name = "json"
+language-servers = [ { name = "vscode-json-language-server", except-features = [ "format" ] }, "biome" ]
+```
+
+### Video record
+
+#### Code Action
+
+<video src="https://user-images.githubusercontent.com/17974631/190205045-aeb86f87-1915-4d8b-8aad-2c046443ba83.mp4" width="720" controls></video>
+
+#### Formatting
+
+<video src="https://user-images.githubusercontent.com/17974631/190205065-ddfde866-5f7c-4f53-8a62-b6cbb577982f.mp4" width="720" controls></video>
+


### PR DESCRIPTION
## Summary

This PR breaks down the`/guides/editors` page into three pages:
- first party plugins
- third party plugins
- integrate Biome into a plugin

I broke it down because I plan to add more information inside the last page. There's way more stuff that we can add, but it requires some generated code that I hope to pull off. 

I added `zed` to the list of first party plugins

