### PR TITLE
fix: syntax highlighting for cjs code blocks

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+shamefully-hoist=true

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,3 @@
+# Hoist the shiki package so we can import language grammars from it.
+# We use this approach to add syntax highlighting support for the cjs code block.
 shamefully-hoist=true

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -8,6 +8,7 @@ import { rehypeAutolink } from "./plugins/rehype-autolink";
 
 import { version as biomeVersion } from "./node_modules/@biomejs/wasm-web/package.json";
 import { version as prettierVersion } from "./node_modules/prettier/package.json";
+import { bundledLanguages } from "./node_modules/shiki";
 
 const site = "https://biomejs.dev";
 // https://astro.build/config
@@ -410,6 +411,15 @@ export default defineConfig({
 	markdown: {
 		syntaxHighlight: "prism",
 		rehypePlugins: [rehypeSlug, ...rehypeAutolink()],
+		shikiConfig: {
+			langs: [
+				{
+					...(await bundledLanguages.javascript()).default[0],
+					scopeName: "source.cjs",
+					aliases: ["cjs"],
+				},
+			],
+		},
 	},
 
 	adapter: netlify({


### PR DESCRIPTION
## Summary

Shiki doesn't recognize `cjs` code blocks, it will fallback to render them as `plaintext`.

For example: https://biomejs.dev/linter/rules/no-redundant-use-strict/

Also check the deployment log: https://app.netlify.com/sites/biomejs/deploys/666c5e50c6f7750008bb8102#L143-L156

I patched the astro config to load the js grammar for `cjs` codeblocks.
