### PR TITLE
feat: enable `pullDiagnostics` for graphql

### DIFF
--- a/src/playground/workers/biomeWorker.ts
+++ b/src/playground/workers/biomeWorker.ts
@@ -255,19 +255,13 @@ self.addEventListener("message", async (e) => {
 			if (configuration?.linter?.enabled) {
 				categories.push("Lint");
 			}
-			const diagnosticsResult = !isGraphql
-				? workspace.pullDiagnostics({
-						path,
-						categories: categories,
-						max_diagnostics: Number.MAX_SAFE_INTEGER,
-						only: [],
-						skip: [],
-					})
-				: {
-						diagnostics: [],
-						errors: 0,
-						skipped_diagnostics: 0,
-					};
+			const diagnosticsResult = workspace.pullDiagnostics({
+				path,
+				categories: categories,
+				max_diagnostics: Number.MAX_SAFE_INTEGER,
+				only: [],
+				skip: [],
+			});
 
 			const printer = new DiagnosticPrinter(path.path, code);
 			for (const diag of diagnosticsResult.diagnostics) {


### PR DESCRIPTION
## Summary

This PR enableds `pullDiagnostics` for GraphQL, which is now supported by WASM. This allows us to print parse diagnostics in the console!