### PR TITLE
docs: fix shell script git hook

### DIFF
--- a/src/content/docs/recipes/git-hooks.mdx
+++ b/src/content/docs/recipes/git-hooks.mdx
@@ -207,7 +207,7 @@ Some examples of shells scripts:
   #!/bin/sh
   set -eu
 
-  if ! git status --short | grep --quiet '^MM'; then
+  if git status --short | grep --quiet '^MM'; then
     printf '%s\n' "ERROR: Some staged files have unstaged changes" >&2
     exit 1;
   fi


### PR DESCRIPTION
## Summary

Script was preventing if there _isn't_ a `MM`, should be the other way around.