### PR TITLE
fix(playground): multi-byte character issue

### DIFF
--- a/src/playground/Playground.tsx
+++ b/src/playground/Playground.tsx
@@ -195,6 +195,7 @@ export default function Playground({
 					children: (
 						<DiagnosticsListTab
 							editorRef={editorRef}
+							code={code}
 							diagnostics={biomeOutput.diagnostics.list}
 						/>
 					),
@@ -295,6 +296,7 @@ export default function Playground({
 						editorRef={editorRef}
 						console={biomeOutput.diagnostics.console}
 						diagnostics={biomeOutput.diagnostics.list}
+						code={code}
 					/>
 				</Resizable>
 			</div>

--- a/src/playground/components/DiagnosticsPane.tsx
+++ b/src/playground/components/DiagnosticsPane.tsx
@@ -9,12 +9,14 @@ interface Props {
 	editorRef: React.RefObject<ReactCodeMirrorRef>;
 	console: string;
 	diagnostics: Diagnostic[];
+	code: string;
 }
 
 export default function DiagnosticsPane({
 	editorRef,
 	diagnostics,
 	console,
+	code,
 }: Props) {
 	const [tab, setTab] = useState("diagnostics");
 
@@ -31,6 +33,7 @@ export default function DiagnosticsPane({
 						<DiagnosticsListTab
 							editorRef={editorRef}
 							diagnostics={diagnostics}
+							code={code}
 						/>
 					),
 				},


### PR DESCRIPTION
## Summary

In Rust we use [UTF-8 ***byte*** offsets](https://github.com/biomejs/biome/blob/c372484473b64c9c84ad3361d71b2c419345b45b/crates/biome_text_size/src/size.rs#L13) for `TextSize`, which will be used in `TextRange` and ultimately be passed to the JavaScript side as the numbers in `diagnostic.location.span`. However, in JavaScript, we use [UTF-16 ***code unit*** offsets](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#instance_methods) to access the characters.

So when a character is represented by multiple bytes in UTF-8 encoding and is placed before or is part of the code that triggers a diagnostic, the playground will wrongly interpret its byte offset as a code unit offset, thus causing an out of bounds indexing error when it tries to highlight the range or make a selection of the code that triggers the diagnostic.

To fix this problem, we need to convert the UTF-8 byte offset into an code unit offset that can be used directly by JavaScript `String` methods like `slice`. I took [the solution here](https://stackoverflow.com/a/73096001/4668057) and adapted it to fit our use case.

This conversion will inevitably introduce an `O(n)` overhead because the byte length of an UTF-8 encoded character is variable and we have to scan from the beginning to calculate the byte offset of a certain character in the middle. However, I think it's acceptable, because the code in the playground is usually not very long, and for it performance is also not our first consideration. The benefit is that we no longer have to worry about playground crashes triggered by non-English characters, especailly for users that use a second IME.

Closes https://github.com/biomejs/biome/issues/1385
Closes https://github.com/biomejs/biome/issues/3250

