### PR TITLE
docs: Fix use of deprecated `trailingCommas` in biome.json example

### DIFF
--- a/src/content/docs/formatter/index.mdx
+++ b/src/content/docs/formatter/index.mdx
@@ -70,7 +70,7 @@ The following defaults are applied:
       "jsxQuoteStyle": "double",
       "quoteProperties": "asNeeded",
       "semicolons": "always",
-      "trailingComma": "all"
+      "trailingCommas": "all"
     }
   },
   "json": {


### PR DESCRIPTION
## Summary

Update the example config to use `javascript.formatter.trailingCommas`
