### PR TITLE
Include links in badges

### DIFF
--- a/src/content/docs/recipes/badges.mdx
+++ b/src/content/docs/recipes/badges.mdx
@@ -7,7 +7,7 @@ Add the Biome badges to your `README.md`! 💅
 
 ## Formatter badge
 
-![](https://img.shields.io/badge/Formatted_with-Biome-60a5fa?style=flat&logo=biome)
+[![Formatted with Biome](https://img.shields.io/badge/Formatted_with-Biome-60a5fa?style=flat&logo=biome)](https://biomejs.dev/)
 
 **URL**
 
@@ -18,18 +18,18 @@ https://img.shields.io/badge/Formatted_with-Biome-60a5fa?style=flat&logo=biome
 **Markdown**
 
 ```markdown
-![Static Badge](https://img.shields.io/badge/Formatted_with-Biome-60a5fa?style=flat&logo=biome)
+[![Formatted with Biome](https://img.shields.io/badge/Formatted_with-Biome-60a5fa?style=flat&logo=biome)](https://biomejs.dev/)
 ```
 
 **HTML**
 
 ```html
-<img alt="Static Badge" src="https://img.shields.io/badge/Formatted_with-Biome-60a5fa?style=flat&logo=biome">
+<a href="https://biomejs.dev"><img alt="Static Badge" src="https://img.shields.io/badge/Formatted_with-Biome-60a5fa?style=flat&logo=biome"></a>
 ```
 
 ## Linter badge
 
-![](https://img.shields.io/badge/Linted_with-Biome-60a5fa?style=flat&logo=biome)
+[![Linted with Biome](https://img.shields.io/badge/Linted_with-Biome-60a5fa?style=flat&logo=biome)](https://biomejs.dev)
 
 **URL**
 
@@ -40,18 +40,18 @@ https://img.shields.io/badge/Linted_with-Biome-60a5fa?style=flat&logo=biome
 **Markdown**
 
 ```markdown
-![Static Badge](https://img.shields.io/badge/Linted_with-Biome-60a5fa?style=flat&logo=biome)
+[![Linted with Biome](https://img.shields.io/badge/Linted_with-Biome-60a5fa?style=flat&logo=biome)](https://biomejs.dev)
 ```
 
 **HTML**
 
 ```html
-<img alt="Static Badge" src="https://img.shields.io/badge/Linted_with-Biome-60a5fa?style=flat&logo=biome">
+<a href="https://biomejs.dev"><img alt="Linted with Biome" src="https://img.shields.io/badge/Linted_with-Biome-60a5fa?style=flat&logo=biome"></a>
 ```
 
 ## Check badge
 
-![](https://img.shields.io/badge/Checked_with-Biome-60a5fa?style=flat&logo=biome)
+[![Checked with Biome](https://img.shields.io/badge/Checked_with-Biome-60a5fa?style=flat&logo=biome)](https://biomejs.dev)
 
 **URL**
 
@@ -62,11 +62,11 @@ https://img.shields.io/badge/Checked_with-Biome-60a5fa?style=flat&logo=biome
 **Markdown**
 
 ```markdown
-![Static Badge](https://img.shields.io/badge/Checked_with-Biome-60a5fa?style=flat&logo=biome)
+[![Checked with Biome](https://img.shields.io/badge/Checked_with-Biome-60a5fa?style=flat&logo=biome)](https://biomejs.dev)
 ```
 
 **HTML**
 
 ```html
-<img alt="Static Badge" src="https://img.shields.io/badge/Checked_with-Biome-60a5fa?style=flat&logo=biome">
+<a href="https://biomejs.dev"><img alt="Checked with Biome" src="https://img.shields.io/badge/Checked_with-Biome-60a5fa?style=flat&logo=biome"></a>
 ```


### PR DESCRIPTION
## Summary

If people are wanting to include these badges in their readmes it's because they think it's important that people are familiar with the toolchain that's being used, in case people are not familiar a link is probably what they want