### PR TITLE
Fix overrides syntax in useFilenamingConvention example

### DIFF
--- a/src/content/docs/linter/rules/use-filenaming-convention.md
+++ b/src/content/docs/linter/rules/use-filenaming-convention.md
@@ -36,8 +36,10 @@ If you want to ignore all files in the `test` directory, then you can disable th
     {
        "include": ["test/**/*"],
        "linter": {
-         "style": {
-           "useFilenamingConvention": "off"
+         "rules": {
+           "style": {
+             "useFilenamingConvention": "off"
+           }
          }
        }
     }


### PR DESCRIPTION
Adds the missing `rules` key

## Summary

The overrides syntax has a `rules` key that was missing in this example.