### PR TITLE
fix: prevent layout shift when hovering home page cards

### DIFF
--- a/src/styles/_overrides.scss
+++ b/src/styles/_overrides.scss
@@ -39,43 +39,10 @@
   --sl-mastodon: #6364ff;
 }
 
-.hero>.sl-flex>.actions>.primary,
-.hero>.sl-flex>.actions>.secondary {
-  border-radius: 0.3rem;
-}
-
 .card-cnt {
   margin-top: 7rem !important;
 }
 
-.card-cnt>.card-grid>.card {
-  transition: all 0.5s ease;
-  position: relative;
-  overflow: hidden;
-}
-
-.card-cnt>.card-grid>.card:hover {
-  font-size: 1.24em;
-  border: 0.06rem solid var(--sl-color-accent-high);
-}
-
-.card-cnt>.card-grid>.card::before {
-  --size: 0;
-  content: '';
-  position: absolute;
-  left: var(--x);
-  top: var(--y);
-  width: calc(4 * var(--size));
-  height: calc(4 * var(--size));
-  background: radial-gradient(hsla(var(--sl-hue-blue), 78%, 62%, 26%), transparent 40%);
-  transform: translate(-50%, -50%);
-  transition: width .2s ease, height .2s ease;
-}
-
-.card-cnt>.card-grid>.card:hover::before {
-  --size: 15vw;
-}
-
 .hero>.sl-flex>.actions>.primary,
 .hero>.sl-flex>.actions>.secondary {
   border-radius: 0.3rem;
@@ -89,7 +56,7 @@
 
 .card-cnt>.card-grid>.card:hover {
   font-size: 1.24em;
-  border: 0.06rem solid var(--sl-color-accent-high);
+  border-color: var(--sl-color-accent-high);
 }
 
 .card-cnt>.card-grid>.card::before {


### PR DESCRIPTION
## Summary

- When hovering home page cards I noticed slight layout shift. Fix it by keeping border stable and only changing color on hover.
- Also remove some duplicated styles inside `_overrides.scss`.

Before:

https://github.com/biomejs/website/assets/8914032/746e7c62-a96a-4ef1-9c98-7308fca72bd9

After:

https://github.com/biomejs/website/assets/8914032/0cdd3a2d-af21-4266-bce6-392ebc8c5c11


