### PR TITLE
docs: update auto sort on save vscode extension settings

### DIFF
--- a/src/content/docs/analyzer/import-sorting.mdx
+++ b/src/content/docs/analyzer/import-sorting.mdx
@@ -162,8 +162,8 @@ You can add the following to your editor configuration if you want the action to
 
 ```json title="settings.json"
 {
-	"editor.codeActionsOnSave":{
-		"source.organizeImports.biome": "explicit"
+	"editor.codeActionsOnSave": {
+		"source.sortImports": "explicit",
 	}
 }
 ```

--- a/src/content/docs/ja/analyzer/import-sorting.mdx
+++ b/src/content/docs/ja/analyzer/import-sorting.mdx
@@ -123,8 +123,8 @@ BiomeのVS Code拡張機能は、_Organize Imports_ コードアクションに�
 
 ```json title="settings.json"
 {
-  "editor.codeActionsOnSave": {
-    "source.organizeImports.biome": "explicit"
-  }
+	"editor.codeActionsOnSave": {
+		"source.sortImports": "explicit",
+	}
 }
 ```

--- a/src/content/docs/pt-br/analyzer/import-sorting.mdx
+++ b/src/content/docs/pt-br/analyzer/import-sorting.mdx
@@ -122,8 +122,8 @@ Você pode adicionar o seguinte à configuração do seu editor se você deseja 
 
 ```json title="settings.json"
 {
-	"editor.codeActionsOnSave":{
-		"source.organizeImports.biome": "explicit"
+	"editor.codeActionsOnSave": {
+		"source.sortImports": "explicit",
 	}
 }
 ```

--- a/src/content/docs/zh-cn/analyzer/import-sorting.mdx
+++ b/src/content/docs/zh-cn/analyzer/import-sorting.mdx
@@ -122,8 +122,8 @@ Biome VS Code扩展通过“Organize Imports”代码操作支持导入排序。
 
 ```json title="settings.json"
 {
-  "editor.codeActionsOnSave": {
-    "source.organizeImports.biome": "explicit"
-  }
+	"editor.codeActionsOnSave": {
+		"source.sortImports": "explicit",
+	}
 }
 ```


### PR DESCRIPTION
## Summary

This change is to clarify and correct the configuration settings related to auto-sorting imports on save within VS Code. The existing configuration had an incorrect key `source.organizeImports.biome`, which has been updated to the correct key `source.sortImports`.