### PR TITLE
docs: document few more rules not working for htmlish languages

### DIFF
--- a/src/content/docs/internals/language-support.mdx
+++ b/src/content/docs/internals/language-support.mdx
@@ -66,13 +66,13 @@ As of version `1.6.0`, these languages are **partially** supported. Biome will g
   </script>
   ```
 
-- When **linting** `.svelte`, '.astro' or '.vue' files, it's advised to turn off few additional rules to prevent compiler errors. Use the option `overrides` for that:
+- When **linting** `.svelte`, `.astro` or `.vue` files, it's advised to turn off few additional rules to prevent compiler errors. Use the option `overrides` for that:
 
   ```json
     {
       "overrides": [
         {
-          "include": ["*.svelte"],
+          "include": ["*.svelte", "*.astro", "*.vue"],
           "linter": {
             "rules": {
               "style": {

--- a/src/content/docs/internals/language-support.mdx
+++ b/src/content/docs/internals/language-support.mdx
@@ -65,17 +65,8 @@ As of version `1.6.0`, these languages are **partially** supported. Biome will g
   import Component from "./Component.vue";
   </script>
   ```
-- When **linting** `.astro` files, you have to add `"Astro"` to `javascript.globals`, to avoid possible false positives from some lint rules.
 
-  ```json title="biome.json"
-  {
-    "javascript": {
-      "globals": ["Astro"]
-    }
-  }
-  ```
-
-- When **linting** `.svelte` files, it's advised to turn off `useConst` to prevent compiler errors. Use the option `overrides` for that:
+- When **linting** `.svelte`, '.astro' or '.vue' files, it's advised to turn off few additional rules to prevent compiler errors. Use the option `overrides` for that:
 
   ```json
     {
@@ -85,7 +76,11 @@ As of version `1.6.0`, these languages are **partially** supported. Biome will g
           "linter": {
             "rules": {
               "style": {
-                "useConst": "off"
+                "useConst": "off",
+                "useImportType": "off"
+              },
+              "correctness": {
+                "noUndeclaredVariables": "off"
               }
             }
           }


### PR DESCRIPTION
## Summary
Remove Astro globals section because we do [include it by default](https://github.com/biomejs/biome/pull/3006).
Add `useImportType` and `noUndeclaredVariables` to rules which should be disabled when using htmlish languages.

https://github.com/biomejs/biome/discussions/3426