### PR TITLE
docs: remove noUndeclaredVariables from htmlish rules limitations list

### DIFF
--- a/src/content/docs/internals/language-support.mdx
+++ b/src/content/docs/internals/language-support.mdx
@@ -78,9 +78,6 @@ As of version `1.6.0`, these languages are **partially** supported. Biome will g
               "style": {
                 "useConst": "off",
                 "useImportType": "off"
-              },
-              "correctness": {
-                "noUndeclaredVariables": "off"
               }
             }
           }


### PR DESCRIPTION
## Summary

In https://github.com/biomejs/website/pull/787 I incorrectly documented `noUndeclaredVariables` as not working properly on htmlish languages, I had did disabled in one of my projects before, likely to deal with globals, but that is not needed.