### PR TITLE
docs: fix spelling mistake in linter docs

### DIFF
--- a/src/content/docs/linter/index.mdx
+++ b/src/content/docs/linter/index.mdx
@@ -193,7 +193,7 @@ You can set them by shaping the value of the rule differently.
   "linter": {
     "rules": {
       "style": {
-        "useNamimgConvention": {
+        "useNamingConvention": {
           "level": "error",
           "options": {
             "strictCase": false


### PR DESCRIPTION
## Summary

Fixes a spelling mistake