### PR TITLE
chore(playground/prettier): turn off embedded language formatting

### DIFF
--- a/src/playground/workers/prettierWorker.ts
+++ b/src/playground/workers/prettierWorker.ts
@@ -123,6 +123,7 @@ async function formatWithPrettier(
 			bracketSpacing: options.bracketSpacing,
 			bracketSameLine: options.bracketSameLine,
 			singleAttributePerLine: options.singleAttributePerLine ?? false,
+			embeddedLanguageFormatting: 'off',
 		};
 
 		// @ts-expect-error

--- a/src/playground/workers/prettierWorker.ts
+++ b/src/playground/workers/prettierWorker.ts
@@ -123,7 +123,7 @@ async function formatWithPrettier(
 			bracketSpacing: options.bracketSpacing,
 			bracketSameLine: options.bracketSameLine,
 			singleAttributePerLine: options.singleAttributePerLine ?? false,
-			embeddedLanguageFormatting: 'off',
+			embeddedLanguageFormatting: "off",
 		};
 
 		// @ts-expect-error


### PR DESCRIPTION
## Summary

<!-- 
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

Make it easy to compare the formatting of template strings