### PR TITLE
fix(zh-cn): git-hooks/lint-staged extends Reformatted

### DIFF
--- a/src/content/docs/zh-cn/recipes/git-hooks.mdx
+++ b/src/content/docs/zh-cn/recipes/git-hooks.mdx
@@ -93,7 +93,7 @@ lint-staged 的配置直接集成在 `package.json` 内。
 {
   "lint-staged": {
     // Run Biome on staged files that have the following extensions: js, ts, jsx, tsx, json and jsonc
-    "**.{js|ts|cjs|mjs|d.cts|d.mts|jsx|tsx|json|jsonc}": [
+    "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}": [
       "biome check --files-ignore-unknown=true", // Check formatting and lint
       "biome check --write --no-errors-on-unmatched", // Format, sort imports, lint, and apply safe fixes
       "biome check --write --organize-imports-enabled=false --no-errors-on-unmatched", // format and apply safe fixes


### PR DESCRIPTION
## Summary

> Detected incorrect braces with only single value: `**.{js|ts|cjs|mjs|d.cts|d.mts|jsx|tsx|json|jsonc}`. Reformatted as: `**.js|ts|cjs|mjs|d.cts|d.mts|jsx|tsx|json|jsonc`

Got warn when running `git commit`，reformat the extends

<!-- 
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->