### PR TITLE
fix: typo on "Configure Biome" page

### DIFF
--- a/src/content/docs/guides/configure-biome.mdx
+++ b/src/content/docs/guides/configure-biome.mdx
@@ -69,7 +69,7 @@ We disabled the formatter for JSON files.
 
 :::note
 Biome refers as `javascript` all variants of the JavaScript language.
-This includes TypeScrip, JSX and TSX.
+This includes TypeScript, JSX and TSX.
 :::
 
 


### PR DESCRIPTION
## Summary

There is a small typo on the "Configure Biome" page.