### PR TITLE
fix `use-filenaming-convention` override example

### DIFF
--- a/src/content/docs/linter/rules/use-filenaming-convention.md
+++ b/src/content/docs/linter/rules/use-filenaming-convention.md
@@ -39,8 +39,10 @@ If you want to ignore all files in the `test` directory, then you can disable th
     {
        "include": ["test/**/*"],
        "linter": {
-         "style": {
-           "useFilenamingConvention": "off"
+         "rules": {
+           "style": {
+             "useFilenamingConvention": "off"
+           }
          }
        }
     }


### PR DESCRIPTION
## Summary

<!-- 
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->
Correct the "override" example in https://biomejs.dev/linter/rules/use-filenaming-convention/.