### PR TITLE
docs: fix example configuration of `useFilenamingConvention` to ignore some files

### DIFF
--- a/src/content/docs/linter/rules/use-filenaming-convention.md
+++ b/src/content/docs/linter/rules/use-filenaming-convention.md
@@ -39,8 +39,10 @@ If you want to ignore all files in the `test` directory, then you can disable th
     {
        "include": ["test/**/*"],
        "linter": {
-         "style": {
-           "useFilenamingConvention": "off"
+         "rules": {
+           "style": {
+             "useFilenamingConvention": "off"
+           }
          }
        }
     }


### PR DESCRIPTION
## Summary

Currently the example configuration which [describes overriding of ignoring file name conventions](https://biomejs.dev/linter/rules/use-filenaming-convention/#ignoring-some-files) is missing a nesting of `rules`. This pull requests adds it to show how it can be applied.

![Screenshot 2024-07-27 at 12 11 00](https://github.com/user-attachments/assets/0b3d8bb9-3b20-46db-9bd3-00550ced16b0)