### PR TITLE
docs(Git Hooks): add colors option for lefthook example :memo:

### DIFF
--- a/src/content/docs/ja/recipes/git-hooks.mdx
+++ b/src/content/docs/ja/recipes/git-hooks.mdx
@@ -24,7 +24,7 @@ Gitリポジトリのルートに`lefthook.yml`というファイルを追加し
     commands:
       check:
         glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
-        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true {staged_files}
+        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
   ```
 
 - コミット前にformatチェックやlintを行い、[安全な修正](/ja/linter#安全な修正safe-fixes)を行う
@@ -34,7 +34,7 @@ Gitリポジトリのルートに`lefthook.yml`というファイルを追加し
     commands:
       check:
         glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
-        run: npx @biomejs/biome check --write --no-errors-on-unmatched --files-ignore-unknown=true {staged_files}
+        run: npx @biomejs/biome check --write --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
         stage_fixed: true
   ```
 
@@ -47,7 +47,7 @@ Gitリポジトリのルートに`lefthook.yml`というファイルを追加し
     commands:
       check:
         glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
-        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true {push_files}
+        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {push_files}
   ```
 
 `glob`と`--files-ignore-unknown=true` を併用する必要はありません。

--- a/src/content/docs/pt-br/recipes/git-hooks.mdx
+++ b/src/content/docs/pt-br/recipes/git-hooks.mdx
@@ -25,7 +25,7 @@ Alguns exemplos de configurações:
     commands:
       check:
         glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
-        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true {staged_files}
+        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
   ```
 
 - Formatar, verificar erros e aplicar correções seguras antes de efetuar o commit.
@@ -35,7 +35,7 @@ Alguns exemplos de configurações:
     commands:
       check:
         glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
-        run: npx @biomejs/biome check --write --no-errors-on-unmatched --files-ignore-unknown=true {staged_files}
+        run: npx @biomejs/biome check --write --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
         stage_fixed: true
   ```
 
@@ -48,7 +48,7 @@ Alguns exemplos de configurações:
     commands:
       check:
         glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
-        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true {push_files}
+        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {push_files}
   ```
 
 Não é necessário utilizar tanto `glob` quanto `--files-ignore-unknown=true`.

--- a/src/content/docs/recipes/git-hooks.mdx
+++ b/src/content/docs/recipes/git-hooks.mdx
@@ -24,7 +24,7 @@ Some examples of _Lefthook_ configurations:
     commands:
       check:
         glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
-        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true {staged_files}
+        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
   ```
 
 - Format, lint, and apply safe code fixes before committing
@@ -34,7 +34,7 @@ Some examples of _Lefthook_ configurations:
     commands:
       check:
         glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
-        run: npx @biomejs/biome check --write --no-errors-on-unmatched --files-ignore-unknown=true {staged_files}
+        run: npx @biomejs/biome check --write --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
         stage_fixed: true
   ```
 
@@ -47,7 +47,7 @@ Some examples of _Lefthook_ configurations:
     commands:
       check:
         glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
-        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true {push_files}
+        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {push_files}
   ```
 
 Note that you don't need to use both `glob` and `--files-ignore-unknown=true`.

--- a/src/content/docs/zh-cn/recipes/git-hooks.mdx
+++ b/src/content/docs/zh-cn/recipes/git-hooks.mdx
@@ -24,7 +24,7 @@ Git 允许在运行 git 命令的过程中执行 [Git Hooks](https://git-scm.com
     commands:
       check:
         glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
-        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true {staged_files}
+        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
   ```
 
 - 提交前进行格式化，lint，以及进行安全的代码修复
@@ -34,7 +34,7 @@ Git 允许在运行 git 命令的过程中执行 [Git Hooks](https://git-scm.com
     commands:
       check:
         glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
-        run: npx @biomejs/biome check --write --no-errors-on-unmatched --files-ignore-unknown=true {staged_files}
+        run: npx @biomejs/biome check --write --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
         stage_fixed: true
   ```
 
@@ -47,7 +47,7 @@ Git 允许在运行 git 命令的过程中执行 [Git Hooks](https://git-scm.com
     commands:
       check:
         glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
-        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true {push_files}
+        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {push_files}
   ```
 
 注意你并不需要使用 `glob` 和 `--files-ignore-unknown=true` _Lefthook_。


### PR DESCRIPTION
## Summary
https://github.com/biomejs/website/issues/872

> The git error log output by Lefthook outputs ANSI escape code as is, so we need to add an option to display plain text.
> It took me a little while to get to this information, but wouldn't it be more helpful to include it by default in the Lefthook Example in the Git Hook section?

<!-- 
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->