### PR TITLE
Fix example with `files.include` example to avoid Couldn't parse error

### DIFF
--- a/src/content/docs/guides/configure-biome.mdx
+++ b/src/content/docs/guides/configure-biome.mdx
@@ -209,7 +209,7 @@ Let's take the following configuration:
 ```json title="biome.json"
 {
   "files": {
-    "include": ["src/**.js", "test/**.js"],
+    "include": ["src/*.js", "test/*.js"],
     "ignore": ["**/*.min.js"],
   },
   "linter": {

--- a/src/content/docs/guides/configure-biome.mdx
+++ b/src/content/docs/guides/configure-biome.mdx
@@ -209,7 +209,7 @@ Let's take the following configuration:
 ```json title="biome.json"
 {
   "files": {
-    "include": ["src/*.js", "test/*.js"],
+    "include": ["src/**/*.js", "test/**/*.js"],
     "ignore": ["**/*.min.js"],
   },
   "linter": {


### PR DESCRIPTION
## Summary

Example generates error in Biome version 1.8.3 

```text
Couldn't parse the src/**.js, reason: recursive wildcards must form a single path component
```

There should be single `*.js` instead of `**.js`