### PR TITLE
fix: update blog post edit link

### DIFF
--- a/src/pages/blog/[...slug].astro
+++ b/src/pages/blog/[...slug].astro
@@ -52,7 +52,7 @@ const head = [
     slug: entry.slug,
     head: head,
     template: "splash",
-    editUrl: `https://github.com/biomejs/biome/edit/main/website/src/content/blog/${entry.id}`,
+    editUrl: `https://github.com/biomejs/website/edit/main/src/content/blog/${entry.id}`,
   }}
 >
   <BlogLayout post={post}>


### PR DESCRIPTION
## Summary

The "Edit page" links at the bottom of blog posts on the website go to the presumably old location of this website codebase, this updates it to correctly go to this repository (the structure has not changed so this simple fix works).