### PR TITLE
docs: update eslint-plugin-solid docs position

### DIFF
--- a/src/content/docs/linter/rules-sources.mdx
+++ b/src/content/docs/linter/rules-sources.mdx
@@ -285,7 +285,7 @@ Some **Biome** rules might **not** have options, compared to the original rule.
 ### eslint-plugin-solid
 | eslint-plugin-solid rule name | Biome rule name |
 | ---- | ---- |
-| [no-react-specific-props](https://github.com/solidjs-community/eslint-plugin-solid/blob/main/docs/no-react-specific-props.md) |[noReactSpecificProps](/linter/rules/no-react-specific-props) (inspired) |
+| [no-react-specific-props](https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/no-react-specific-props.md) |[noReactSpecificProps](/linter/rules/no-react-specific-props) (inspired) |
 ### eslint-plugin-sonarjs
 | eslint-plugin-sonarjs rule name | Biome rule name |
 | ---- | ---- |

--- a/src/content/docs/linter/rules/no-react-specific-props.mdx
+++ b/src/content/docs/linter/rules/no-react-specific-props.mdx
@@ -17,7 +17,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 :::
 
 Sources: 
-- Same as: <a href="https://github.com/solidjs-community/eslint-plugin-solid/blob/main/docs/no-react-specific-props.md" target="_blank"><code>solidjs/no-react-specific-props</code></a>
+- Same as: <a href="https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/no-react-specific-props.md" target="_blank"><code>solidjs/no-react-specific-props</code></a>
 
 Prevents React-specific JSX properties from being used.
 


### PR DESCRIPTION
## Summary
Update an URL of [eslint-plugin-solid](https://github.com/solidjs-community/eslint-plugin-solid) docs.

### Description
At [Restructure to turbo monorepo](https://github.com/solidjs-community/eslint-plugin-solid/pull/150), docs was moved.

### before:
https://github.com/solidjs-community/eslint-plugin-solid/blob/main/docs/no-react-specific-props.md ❌

### after:
https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/no-react-specific-props.md ✔️
<!-- 
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->