### PR TITLE
Update Docs with EditorConfig support info

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -202,6 +202,10 @@ export default defineConfig({
 										"pt-BR": "Princípios de configuração",
 									},
 								},
+								{
+									label: "EditorConfig support",
+									link: "/formatter/editorconfig-support",
+								},
 							],
 							translations: {
 								"zh-CN": "格式化程序",

--- a/src/content/docs/formatter/editorconfig-support.md
+++ b/src/content/docs/formatter/editorconfig-support.md
@@ -1,0 +1,18 @@
+---
+title: EditorConfig support
+description: How to use the Biome with EditorConfig file.
+---
+
+Biome is able to take the `.editorconfig` of your project into account. This is an opt-in feature.
+
+You have to turn it on in your Biome configuration file.
+
+Example:
+
+```json title="biome.json"
+{
+  "formatter": {
+    "useEditorconfig": true
+  }
+}
+```

--- a/src/content/docs/formatter/index.mdx
+++ b/src/content/docs/formatter/index.mdx
@@ -45,7 +45,6 @@ Biome provides some options to tune the behavior of its formatter.
 Differently from other tools, Biome separates language-agnostic options from language-specific options.
 
 The formatter options can be set on the [CLI](/reference/cli/#biome-format) or via a [Biome configuration file](/guides/configure-biome).
-Biome doesn't support `.editorconfig` [yet](https://github.com/biomejs/biome/issues/1724).
 
 It's recommended to use a [Biome configuration file](/guides/configure-biome) to ensure that both the Biome CLI and the Biome LSP apply the same options.
 The following defaults are applied:

--- a/src/content/docs/reference/configuration.mdx
+++ b/src/content/docs/reference/configuration.mdx
@@ -361,6 +361,22 @@ Given the following example:
 Only the files that match the patter `src/**/*.js` will be formatted, while the files that match the pattern
 `scripts/**/*.js` will be ignored.
 
+### `formatter.useEditorconfig`
+
+Biome is able to take the `.editorconfig` of your project into account. This is an opt-in feature. You have to turn it on in your Biome configuration file.
+
+
+
+```json title="biome.json"
+{
+  "formatter": {
+    "useEditorconfig": true
+  }
+}
+```
+
+> Default: `false`
+
 ### `formatter.formatWithErrors`
 
 Allows to format a document that has syntax errors.


### PR DESCRIPTION
## Summary

`useEditorconfig` is missing in the current Docs version.