### PR TITLE
ci: clean disk space to fix sync job

### DIFF
--- a/.github/actions/free-disk-space/action.yml
+++ b/.github/actions/free-disk-space/action.yml
@@ -1,0 +1,16 @@
+name: Free Disk Space
+description: Free up disk space on the runner
+runs:
+  using: composite
+  steps:
+    - name: Free Disk Space (Ubuntu)
+      if: runner.os == 'Linux'
+      uses: xc2/free-disk-space@fbe203b3788f2bebe2c835a15925da303eaa5efe # v1.0.0
+      with:
+        # We need to reclaim some space, but uninstalling everyting takes
+        # too long. So we'll just remove some of the larger packages.
+        # https://github.com/jlumbroso/free-disk-space/pull/26
+        android: true
+        dotnet: true
+        haskell: true
+        large-packages: false

--- a/.github/workflows/synchronize.yaml
+++ b/.github/workflows/synchronize.yaml
@@ -7,7 +7,7 @@ on:
         required: true
         type: string
   repository_dispatch:
-    types: [biome-push-on-main-event]
+    types: [ biome-push-on-main-event ]
 
 permissions:
   actions: write
@@ -39,6 +39,9 @@ jobs:
 
       - name: Get short commit ID
         run: echo "SHORT_COMMIT_ID=$(echo ${{ env.COMMIT_ID }} | cut -c 1-7)" >> "$GITHUB_ENV"
+
+      - name: Free Disk Space
+        uses: ./.github/actions/free-disk-space
 
       - name: Install pnpm
         run: corepack enable


### PR DESCRIPTION
## Summary
 Tries to add a clean space CI job. The sync job fails due to not enough disk space