### PR TITLE
chore: use `/chat` URL

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yaml
+++ b/.github/ISSUE_TEMPLATE/config.yaml
@@ -13,10 +13,10 @@ contact_links:
     url: https://github.com/biomejs/biome/discussions/new
     about: Please use a new Github discussion to propose ideas of feature requests
   - name: 🗣️ Chat
-    url: https://discord.gg/BypW39g6Yc
+    url: https://biomejs.dev/chat
     about: Our Discord server is active and is used for real-time discussions including contribution collaboration, questions, and more!
   - name: 🤔 Support
-    url: https://discord.gg/BypW39g6Yc
+    url: https://biomejs.dev/chat
     about: "This issue tracker is not for support questions. Visit our community Discord and the #support channel for assistance!"
   - name: 🆘 Code of Conduct Reports
     url: https://github.com/biomejs/biome/blob/main/CODE_OF_CONDUCT.md#contributor-covenant-code-of-conduct

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -4,11 +4,10 @@ import starlight from "@astrojs/starlight";
 import { defineConfig } from "astro/config";
 import rehypeSlug from "rehype-slug";
 import { searchForWorkspaceRoot } from "vite";
-import { rehypeAutolink } from "./plugins/rehype-autolink";
-
 import { version as biomeVersion } from "./node_modules/@biomejs/wasm-web/package.json";
 import { version as prettierVersion } from "./node_modules/prettier/package.json";
 import { bundledLanguages } from "./node_modules/shiki";
+import { rehypeAutolink } from "./plugins/rehype-autolink";
 
 const site = "https://biomejs.dev";
 // https://astro.build/config
@@ -412,7 +411,7 @@ export default defineConfig({
 				"./src/styles/index.css",
 			],
 			social: {
-				discord: "https://discord.gg/BypW39g6Yc",
+				discord: "https://biomejs.dev/chat",
 				github: "https://github.com/biomejs/biome",
 				"x.com": "https://twitter.com/biomejs",
 				mastodon: "https://fosstodon.org/@biomejs",

--- a/src/components/ExternalLinks.astro
+++ b/src/components/ExternalLinks.astro
@@ -6,7 +6,7 @@ import InlineSVG from "@/components/InlineSVG.astro";
   <a
     class="foreground-svg external-link"
     target="_blank"
-    href="https://discord.gg/BypW39g6Yc"
+    href="https://biomejs.dev/chat"
   >
     <InlineSVG src="discord" />
     <span class="sr-only">Discord</span>

--- a/src/content/blog/annoucing-biome.mdx
+++ b/src/content/blog/annoucing-biome.mdx
@@ -23,7 +23,7 @@ Biome is **led and maintained** by the same people that maintained Rome so far.
 
 - [Github organization](https://github.com/biomejs)
 - [Official repository](https://github.com/biomejs/biome)
-- [Official discord server](https://discord.gg/BypW39g6Yc)
+- [Official discord server](https://biomejs.dev/chat)
 - [Official twitter account](https://twitter.com/biomejs)
 
 ## Background

--- a/src/content/blog/biome-v1-7.md
+++ b/src/content/blog/biome-v1-7.md
@@ -17,8 +17,7 @@ socialImage: "@/assets/social-logo.png"
 
 Today we’re excited to announce the release of Biome v1.7!
 
-This new version provides an easy path to migrate from ESLint and Prettier.
-It also introduces experimental machine-readable reports for the formatter and the linter, new linter rules, and many fixes.
+This new version provides an easy path to migrate from ESLint and Prettier. It also introduces experimental machine-readable reports for the formatter and the linter, new linter rules, and many fixes.
 
 Update Biome using the following commands:
 
@@ -29,11 +28,9 @@ npx @biomejs/biome migrate
 
 ## Migrate from ESLint with a single command
 
-This release introduces a new subcommand `biome migrate eslint`.
-This command will read your ESLint configuration and attempt to port their settings to Biome.
+This release introduces a new subcommand `biome migrate eslint`. This command will read your ESLint configuration and attempt to port their settings to Biome.
 
-The subcommand is able to handle both the legacy and the flat configuration files.
-It supports the `extends` field of the legacy configuration and loads both shared and plugin configurations!
+The subcommand is able to handle both the legacy and the flat configuration files. It supports the `extends` field of the legacy configuration and loads both shared and plugin configurations!
 The subcommand also migrates `.eslintignore`.
 
 Given the following ESLint configuration:
@@ -73,10 +70,7 @@ And the following Biome configuration:
 }
 ```
 
-Run `biome migrate eslint --write` to migrate your ESLint configuration to Biome.
-The command overwrites your initial Biome configuration.
-For example, it disables `recommended`.
-This results in the following Biome configuration:
+Run `biome migrate eslint --write` to migrate your ESLint configuration to Biome. The command overwrites your initial Biome configuration. For example, it disables `recommended`. This results in the following Biome configuration:
 
 ```json title="biome.json"
 {
@@ -114,14 +108,9 @@ This results in the following Biome configuration:
 }
 ```
 
-The subcommand needs Node.js to load and resolve all the plugins and `extends` configured in the ESLint configuration file.
-For now, `biome migrate eslint` doesn't support configuration written in YAML.
+The subcommand needs Node.js to load and resolve all the plugins and `extends` configured in the ESLint configuration file. For now, `biome migrate eslint` doesn't support configuration written in YAML.
 
-We have a [dedicated page](/linter/rules-sources/) that lists the equivalent Biome rule of a given ESLint rule.
-We handle some ESLint plugins such as [TypeScript ESLint](https://typescript-eslint.io/), [ESLint JSX A11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y), [ESLint React](https://github.com/jsx-eslint/eslint-plugin-react), and [ESLint Unicorn](https://github.com/sindresorhus/eslint-plugin-unicorn).
-Some rules are equivalent to their ESLint counterparts, while others are inspired.
-By default, Biome doesn't migrate inspired rules.
-You can use the CLI flag `--include-inspired` to migrate them.
+We have a [dedicated page](/linter/rules-sources/) that lists the equivalent Biome rule of a given ESLint rule. We handle some ESLint plugins such as [TypeScript ESLint](https://typescript-eslint.io/), [ESLint JSX A11y](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y), [ESLint React](https://github.com/jsx-eslint/eslint-plugin-react), and [ESLint Unicorn](https://github.com/sindresorhus/eslint-plugin-unicorn). Some rules are equivalent to their ESLint counterparts, while others are inspired. By default, Biome doesn't migrate inspired rules. You can use the CLI flag `--include-inspired` to migrate them.
 
 ## Migrate from Prettier with a single command
 
@@ -129,8 +118,7 @@ You can use the CLI flag `--include-inspired` to migrate them.
 
 In Biome v1.7, we add support of [Prettier's `overrides`](https://prettier.io/docs/en/configuration.html#configuration-overrides) and attempts to convert `.prettierignore` glob patterns to globs supported by Biome.
 
-During the migration, Prettier's `overrides` is translated to [Biome's `overrides`](/reference/configuration/#overrides).
-Given the following `.prettierrc.json`
+During the migration, Prettier's `overrides` is translated to [Biome's `overrides`](/reference/configuration/#overrides). Given the following `.prettierrc.json`
 
 ```json title=".prettierrc.json"
 {
@@ -145,8 +133,7 @@ Given the following `.prettierrc.json`
 }
 ```
 
-Run `biome migrate prettier --write` to migrate your Prettier configuration to Biome.
-This results in the following Biome configuration:
+Run `biome migrate prettier --write` to migrate your Prettier configuration to Biome. This results in the following Biome configuration:
 
 ```json title="biome.json"
 {
@@ -188,7 +175,6 @@ This results in the following Biome configuration:
 The subcommand needs Node.js to load JavaScript configurations such as `.prettierrc.js`.
 `biome migrate prettier` doesn't support configuration written in JSON5, TOML, or YAML.
 
-
 ## Emit machine-readable reports
 
 Biome is now able to output JSON reports detailing the diagnostics emitted by a command.
@@ -201,35 +187,31 @@ biome lint --reporter=json-pretty .
 
 For now, we support two report formats: `json` and `json-pretty`.
 
-Note that the report format is **experimental**, and it might change in the future.
-Please try this feature and let us know if any information needs to be added to the reports.
-
+Note that the report format is **experimental
+**, and it might change in the future. Please try this feature and let us know if any information needs to be added to the reports.
 
 ## Check `git` staged files
 
 Biome v1.5 added the `--changed` to format and lint `git` tracked files that have been changed.
 
-Today we are introducing a new option `--staged` which allows you to check only files added to the _Git index_ (_staged files_).
-This is useful for checking that the files you want to commit are formatted and linted:
+Today we are introducing a new option `--staged` which allows you to check only files added to the _Git index_ (_staged
+files_). This is useful for checking that the files you want to commit are formatted and linted:
 
 ```shell
 biome check --staged .
 ```
 
-This is handy for writing your own [pre-commit script](/recipes/git-hooks/#shell-script).
-Note that unstaged changes on a staged file are **not** ignored.
-Thus, we still recommend using a [dedicated pre-commit tool](/recipes/git-hooks/).
+This is handy for writing your own [pre-commit script](/recipes/git-hooks/#shell-script). Note that unstaged changes on a staged file are
+**not** ignored. Thus, we still recommend using a [dedicated pre-commit tool](/recipes/git-hooks/).
 
 Thanks to [@castarco](https://github.com/castarco) for implementing this feature!
-
 
 ## Linter
 
 ### New nursery rules
 
-Since _Biome v1.6_, we added several new rules.
-New rules are incubated in the nursery group.
-Nursery rules are exempt from semantic versioning.
+Since _Biome
+v1.6_, we added several new rules. New rules are incubated in the nursery group. Nursery rules are exempt from semantic versioning.
 
 The new rules are:
 
@@ -242,8 +224,7 @@ The new rules are:
 
 ### Promoted rules
 
-Once stable, a nursery rule is promoted to a stable group.
-The following rules are promoted:
+Once stable, a nursery rule is promoted to a stable group. The following rules are promoted:
 
 - [complexity/noExcessiveNestedTestSuites](/linter/rules/no-excessive-nested-test-suites)
 - [complexity/noUselessTernary](/linter/rules/no-useless-ternary/)
@@ -258,20 +239,15 @@ The following rules are promoted:
 - [suspicious/noSkippedTests](/linter/rules/no-skipped-tests/)
 - [suspicious/noSuspiciousSemicolonInJsx](/linter/rules/no-suspicious-semicolon-in-jsx)
 
-
 ## Miscellaneous
 
-- By default, Biome searches a configuration file in the working directory and parent directories if it doesn't exist.
-  Biome provides a CLI option `--config-path` and an environment variable `BIOME_CONFIG_PATH` that allows which can be used to override this behavior.
-  Previously, they required a directory containing a Biome configuration file.
-  For example, the following command uses the Biome configuration file in `./config/`.
+- By default, Biome searches a configuration file in the working directory and parent directories if it doesn't exist. Biome provides a CLI option `--config-path` and an environment variable `BIOME_CONFIG_PATH` that allows which can be used to override this behavior. Previously, they required a directory containing a Biome configuration file. For example, the following command uses the Biome configuration file in `./config/`.
 
   ```shell
   biome format --config-path=./config/ ./src
   ```
 
-  This wasn't very clear for many users who are used to specifying the configuration file path directly.
-  They now accept a file, so the following command is valid:
+  This wasn't very clear for many users who are used to specifying the configuration file path directly. They now accept a file, so the following command is valid:
 
   ```shell
   biome format --config-path=./config/biome.json ./src
@@ -279,26 +255,19 @@ The following rules are promoted:
 
 - You can now ignore `React` imports in the rules [noUnusedImports](/linter/rules/no-unused-imports/#options) and [useImportType](/linter/rules/use-import-type/#options) by setting [`javascript.jsxRuntime`](/reference/configuration/#javascriptjsxruntime) to `reactClassic`.
 
-- Biome applies specific settings to [well-known files](/guides/configure-biome/#well-known-files).
-  It now recognizes more files and distinguishes between JSON files that only allow comments and JSON files that allow both comments and trailing commas.
+- Biome applies specific settings to [well-known files](/guides/configure-biome/#well-known-files). It now recognizes more files and distinguishes between JSON files that only allow comments and JSON files that allow both comments and trailing commas.
 
-- In the React ecosystem, files ending in `.js` are allowed to contain JSX syntax.
-  The Biome extension is now able to parse JSX syntax in files that are associated with the JavaScript language identifier.
+- In the React ecosystem, files ending in `.js` are allowed to contain JSX syntax. The Biome extension is now able to parse JSX syntax in files that are associated with the JavaScript language identifier.
 
 - [useExhaustiveDependencies](/linter/rules/use-exhaustive-dependencies/) now supports Preact.
 
 See the [changelog](/internals/changelog/#170-2024-04-15) for more details.
 
-
 ## What’s Next?
 
-We have started work on the CSS formatter and linter.
-Early implementation towards a [plugin system](https://github.com/biomejs/biome/discussions/2286) is also underway.
-Some of our contributors have started preliminary work for [_GraphQL_](https://github.com/biomejs/biome/issues/1927) and [YAML](https://github.com/biomejs/biome/issues/2365).
-Any help is welcome!
+We have started work on the CSS formatter and linter. Early implementation towards a [plugin system](https://github.com/biomejs/biome/discussions/2286) is also underway. Some of our contributors have started preliminary work for [
+_GraphQL_](https://github.com/biomejs/biome/issues/1927) and [YAML](https://github.com/biomejs/biome/issues/2365). Any help is welcome!
 
-If Biome is valuable to you or your company, consider donating monthly to our [Open Collective](https://opencollective.com/biome).
-You can also [sponsor us on GitHub](https://github.com/sponsors/biomejs).
-This is important for the sustainability of the project.
+If Biome is valuable to you or your company, consider donating monthly to our [Open Collective](https://opencollective.com/biome). You can also [sponsor us on GitHub](https://github.com/sponsors/biomejs). This is important for the sustainability of the project.
 
-Follow us on [our Twitter](https://twitter.com/home) and join [our Discord community](https://discord.gg/BypW39g6Yc).
+Follow us on [our Twitter](https://twitter.com/home) and join [our Discord community](https://biomejs.dev/chat).

--- a/src/content/docs/guides/getting-started.mdx
+++ b/src/content/docs/guides/getting-started.mdx
@@ -91,4 +91,4 @@ Success! You're now ready to use Biome. 🥳
 - Learn more about how to use and configure the [linter](/linter)
 - Get familiar with the [CLI options](/reference/cli)
 - Get familiar with the [configuration options](/reference/configuration)
-- Join our [community on Discord](https://discord.gg/BypW39g6Yc)
+- Join our [community on Discord](https://biomejs.dev/chat)

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -193,7 +193,7 @@ import NumberOfRules from "@/components/generated/NumberOfRules.astro";
       Powered by our open-source contributors
     </div>
     <div class="community-links">
-      <a href="https://discord.gg/BypW39g6Yc" class="discord">
+      <a href="https://biomejs.dev/chat" class="discord">
         <Icon name="discord" />
         <p>Discord</p>
       </a>

--- a/src/content/docs/internals/philosophy.mdx
+++ b/src/content/docs/internals/philosophy.mdx
@@ -12,7 +12,7 @@ This list is not comprehensive. Some of these are obvious but are stated for com
   Nothing should be a surprise.
 
 - **Clear messaging of decisions.** The team might evaluate options and make decisions using private channels.
-  Team will try to keep discussions using public channels like [GitHub discussions](https://github.com/biomejs/biome/discussions) or [Discord](https://discord.gg/BypW39g6Yc). Frequent private check-ins might happen.
+  Team will try to keep discussions using public channels like [GitHub discussions](https://github.com/biomejs/biome/discussions) or [Discord](https://biomejs.dev/chat). Frequent private check-ins might happen.
   When decisions occur via private channels, the team has to commit to communicate these decisions using the public channels.
 
 ## Technical

--- a/src/content/docs/ja/guides/getting-started.mdx
+++ b/src/content/docs/ja/guides/getting-started.mdx
@@ -97,4 +97,4 @@ Node.jsを使用している場合、BiomeをCIで実行するには、[お気�
 - [Linter](/ja/linter)の使い方と設定方法について詳しく知る
 - [CLIオプション](/ja/reference/cli)を使いこなす
 - [設定オプション](/ja/reference/configuration)を使いこなす
-- [Discordのコミュニティ](https://discord.gg/BypW39g6Yc)に参加する
+- [Discordのコミュニティ](https://biomejs.dev/chat)に参加する

--- a/src/content/docs/ja/index.mdx
+++ b/src/content/docs/ja/index.mdx
@@ -188,7 +188,7 @@ import LinterExample from "@/components/linter/example.md";
       OSSコントリビューターにより支えられています
     </div>
     <div class="community-links">
-      <a href="https://discord.gg/BypW39g6Yc" class="discord">
+      <a href="https://biomejs.dev/chat" class="discord">
         <Icon name="discord" />
         <p>Discord</p>
       </a>

--- a/src/content/docs/ja/internals/philosophy.mdx
+++ b/src/content/docs/ja/internals/philosophy.mdx
@@ -12,7 +12,7 @@ description: Biomeを構築する際の私たちの考え方
   予期せぬことは何も起こらないようにするべきです。
 
 - **決定事項を明確に伝える。** チームは、プライベートチャンネルを使って選択肢を評価し、決定を下すことがあります。
-  チームは[GitHub discussions](https://github.com/biomejs/biome/discussions)や[Discord](https://discord.gg/BypW39g6Yc)のようなパブリックチャンネルを使用して議論を行おうとしますが、通常の企業ではしばしばプライベートなチャンネルで議論してしまいがちです。
+  チームは[GitHub discussions](https://github.com/biomejs/biome/discussions)や[Discord](https://biomejs.dev/chat)のようなパブリックチャンネルを使用して議論を行おうとしますが、通常の企業ではしばしばプライベートなチャンネルで議論してしまいがちです。
   プライベートチャンネルで決定が行われた場合、チームはこれらの決定をパブリックチャンネルを使用して伝える必要があります。
 
 ## 技術的なこと

--- a/src/content/docs/pt-br/guides/getting-started.mdx
+++ b/src/content/docs/pt-br/guides/getting-started.mdx
@@ -99,4 +99,4 @@ Parabéns! Agora você está pronto para utilizar o Biome. 🥳
 - Saiba mais sobre como usar e configurar o [linter](/pt-br/linter)
 - Familiarize-se com as [opções do CLI](/reference/cli)
 - Familiarize-se com as [opções de configuração](/reference/configuration)
-- Entre na nossa [comunidade do Discord](https://discord.gg/BypW39g6Yc)
+- Entre na nossa [comunidade do Discord](https://biomejs.dev/chat)

--- a/src/content/docs/pt-br/index.mdx
+++ b/src/content/docs/pt-br/index.mdx
@@ -188,7 +188,7 @@ import LinterExample from "@/components/linter/example.md";
       Desenvolvido pela nossa incrível comunidade
     </div>
     <div class="community-links">
-      <a href="https://discord.gg/BypW39g6Yc" class="discord">
+      <a href="https://biomejs.dev/chat" class="discord">
         <Icon name="discord" />
         <p>Discord</p>
       </a>

--- a/src/content/docs/pt-br/internals/philosophy.mdx
+++ b/src/content/docs/pt-br/internals/philosophy.mdx
@@ -12,7 +12,7 @@ A lista não é abrangente. Alguns desses princípios são óbvios, mas são men
   Nada deve ser uma surpresa.
 
 - **Comunicação clara das decisões.** A equipe pode avaliar opções e tomar decisões por meio de canais privados.
-  Embora a equipe tente manter discussões em canais públicos como [discussões no Github](https://github.com/biomejs/biome/discussions) ou no [Discord](https://discord.gg/BypW39g6Yc), verificações privadas frequentes são comuns, dada a natureza de uma empresa privada.
+  Embora a equipe tente manter discussões em canais públicos como [discussões no Github](https://github.com/biomejs/biome/discussions) ou no [Discord](https://biomejs.dev/chat), verificações privadas frequentes são comuns, dada a natureza de uma empresa privada.
   Quando decisões ocorrem por meio de canais privados, a equipe precisa se comprometer a comunicar essas decisões usando canais públicos.
 
 ## Técnico

--- a/src/content/docs/zh-cn/guides/getting-started.mdx
+++ b/src/content/docs/zh-cn/guides/getting-started.mdx
@@ -95,4 +95,4 @@ Biome CLI提供了许多命令和选项，因此您可以只使用您需要的�
 - 了解如何使用和配置[代码检查器](/linter)
 - 熟悉[CLI选项](/reference/cli)
 - 熟悉[配置选项](/reference/configuration)
-- 加入我们的[Discord社区](https://discord.gg/BypW39g6Yc)
+- 加入我们的[Discord社区](https://biomejs.dev/chat)

--- a/src/content/docs/zh-cn/index.mdx
+++ b/src/content/docs/zh-cn/index.mdx
@@ -180,7 +180,7 @@ import LinterExample from "@/components/linter/example.md";
   <div class="community-connect">
     <div class="community-description">由我们的开源贡献者提供支持</div>
     <div class="community-links">
-      <a href="https://discord.gg/BypW39g6Yc" class="discord">
+      <a href="https://biomejs.dev/chat" class="discord">
         <Icon name="discord" />
         <p>Discord</p>
       </a>

--- a/src/content/docs/zh-cn/internals/philosophy.mdx
+++ b/src/content/docs/zh-cn/internals/philosophy.mdx
@@ -12,7 +12,7 @@ description: 我们如何思考构建 Biome。
   没有什么应该是出人意料的。
 
 - **清晰地传达决策。** 团队可能会通过私有渠道评估选项并做出决策。
-  尽管团队会尽量使用像[GitHub discussions](https://github.com/biomejs/biome/discussions)或者[Discord](https://discord.gg/BypW39g6Yc)这样的公开渠道进行讨论，但由于私营公司的性质，频繁的私人检查是常态。
+  尽管团队会尽量使用像[GitHub discussions](https://github.com/biomejs/biome/discussions)或者[Discord](https://biomejs.dev/chat)这样的公开渠道进行讨论，但由于私营公司的性质，频繁的私人检查是常态。
   当决策通过私有渠道发生时，团队必须承诺使用公开渠道传达这些决策。
 
 ## 技术


### PR DESCRIPTION
## Summary

This PR replaces the discord invite link to `https://biomejs.dev/chat`, which is a simple redirect to the discord link