### PR TITLE
Add Deno installation script

### DIFF
--- a/src/components/PackageManagerCommand.astro
+++ b/src/components/PackageManagerCommand.astro
@@ -16,6 +16,9 @@ import { TabItem, Tabs } from "@astrojs/starlight/components";
   <TabItem label="bun" icon="bun">
     <Code code={`bun${Astro.props.bun ? "" : "x"} ${Astro.props.bunx ?? Astro.props.bun ?? Astro.props.command}`} lang="bash"  />
   </TabItem>
+  <TabItem label="deno" icon="seti:deno">
+    <Code code={`deno ${Astro.props.deno ?? Astro.props.command}`} lang="bash"  />
+  </TabItem>
 </Tabs>
 
 

--- a/src/components/PackageManagerCommand.astro
+++ b/src/components/PackageManagerCommand.astro
@@ -16,7 +16,7 @@ import { TabItem, Tabs } from "@astrojs/starlight/components";
   <TabItem label="bun" icon="bun">
     <Code code={`bun${Astro.props.bun ? "" : "x"} ${Astro.props.bunx ?? Astro.props.bun ?? Astro.props.command}`} lang="bash"  />
   </TabItem>
-  <TabItem label="deno" icon="seti:deno">
+  <TabItem label="deno" icon="deno">
     <Code code={`deno ${Astro.props.deno ?? Astro.props.command}`} lang="bash"  />
   </TabItem>
 </Tabs>

--- a/src/content/docs/guides/getting-started.mdx
+++ b/src/content/docs/guides/getting-started.mdx
@@ -20,6 +20,7 @@ To install Biome, run the following commands in a directory containing a `packag
   pnpm="add --save-dev --save-exact @biomejs/biome"
   yarn="add --dev --exact @biomejs/biome"
   bun="add --dev --exact @biomejs/biome"
+  deno="add --dev npm:@biomejs/biome"
 />
 
 :::note

--- a/src/content/docs/ja/guides/getting-started.mdx
+++ b/src/content/docs/ja/guides/getting-started.mdx
@@ -20,6 +20,7 @@ Biomeをインストールするには、 `package.json` ファイルが含ま�
   pnpm="add --save-dev --save-exact @biomejs/biome"
   yarn="add --dev --exact @biomejs/biome"
   bun="add --dev --exact @biomejs/biome"
+  deno="add --dev npm:@biomejs/biome"
 />
 
 :::note[注]

--- a/src/content/docs/pt-br/guides/getting-started.mdx
+++ b/src/content/docs/pt-br/guides/getting-started.mdx
@@ -20,6 +20,7 @@ Para instalar o Biome, execute o seguinte comando em um diretório que possua o 
   pnpm="add --save-dev --save-exact @biomejs/biome"
   yarn="add --dev --exact @biomejs/biome"
   bun="add --dev --exact @biomejs/biome"
+  deno="add --dev npm:@biomejs/biome"
 />
 
 :::note

--- a/src/content/docs/zh-cn/guides/getting-started.mdx
+++ b/src/content/docs/zh-cn/guides/getting-started.mdx
@@ -20,6 +20,7 @@ import PackageManagerCommand from "@/components/PackageManagerCommand.astro";
   pnpm="add --save-dev --save-exact @biomejs/biome"
   yarn="add --dev --exact @biomejs/biome"
   bun="add --dev --exact @biomejs/biome"
+  deno="add --dev npm:@biomejs/biome"
 />
 
 :::note


### PR DESCRIPTION
## Summary
Adds the deno install script according to its [documentation](https://docs.deno.com/runtime/reference/cli/install/) to have support for all the package managers.

It does not appear that deno has an equivalent to the --exact flag.