### PR TITLE
fix: example config was using a deprecated key

### DIFF
--- a/src/content/blog/biome-v1-6.mdx
+++ b/src/content/blog/biome-v1-6.mdx
@@ -207,7 +207,7 @@ Given a `prettier.json` file, Biome will **modify** the existing configuration f
     "formatter": {
       "jsxQuoteStyle": "double",
       "quoteProperties": "asNeeded",
-      "trailingComma": "all",
+      "trailingCommas": "all",
       "semicolons": "always",
       "arrowParentheses": "always",
       "bracketSpacing": true,


### PR DESCRIPTION
## Summary

`The property trailingComma is deprecated. Use javascript.formatter.trailingCommas instead. biome(deserialize)`

This commit updates the code sample to be up-to-date.

<img width="1044" alt="Screenshot showing the warning in VScode" src="https://github.com/user-attachments/assets/c959280a-19d9-4e61-bfa6-cc3cfcbb4854">