### PR TITLE
Import Sorting Docs - Replace `--write` with '--apply'

### DIFF
--- a/src/content/docs/analyzer/import-sorting.mdx
+++ b/src/content/docs/analyzer/import-sorting.mdx
@@ -147,10 +147,10 @@ import React from "react";         // Import group 4
 
 ## Import sorting via CLI
 
-Using the command `check`, with the option `--write`.
+Using the command `check`, with the option `--apply`.
 
 ```shell
-biome check --write ./path/to/src
+biome check --apply ./path/to/src
 ```
 
 ## Import sorting via VSCode extension


### PR DESCRIPTION
## Summary

Currently, the documentation states that import sorting can be done using the `biome check` command with the `--write` option. As `--write` doesn't exist as a valid option, I changed it to the actual option that does the sorting - `--apply`