### PR TITLE
Better instructions for import sorting

### DIFF
--- a/src/content/docs/analyzer/import-sorting.mdx
+++ b/src/content/docs/analyzer/import-sorting.mdx
@@ -147,10 +147,15 @@ import React from "react";         // Import group 4
 
 ## Import sorting via CLI
 
-Using the command `check`, with the option `--apply`.
+Using the command `check`, with the option `--apply`. If you want only order the imports, you can use check like so:
 
 ```shell
-biome check --apply ./path/to/src
+biome check \
+    --formatter-enabled=false\
+    --linter-enabled=false \
+    --organize-imports-enabled=true \
+    --write \
+    ./path/to/src
 ```
 
 ## Import sorting via VSCode extension


### PR DESCRIPTION
- Instructions would have done all formatting and safe lining fixes before.
- Use `--write` instead of `--apply` because `--apply` has been deprecated in favor of `--write`.

## Summary

<!-- 
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->
Instructions would have done all formatting and safe lining fixes before this change. Now, it describes how to just apply the formatting changes.

Use `--write` instead of `--apply` because `--apply` has been deprecated in favor of `--write`.
