### PR TITLE
refactor: remove unused lifetime `'a`

### DIFF
--- a/codegen/src/lintdoc.rs
+++ b/codegen/src/lintdoc.rs
@@ -426,7 +426,7 @@ fn generate_rule(payload: GenRule) -> Result<Vec<Event<'static>>> {
     Ok(summary)
 }
 
-fn generate_rule_content<'a>(
+fn generate_rule_content(
     language: &'static str,
     group: &'static str,
     rule_name: &'static str,


### PR DESCRIPTION
## Summary

Fixes #1389

<!-- 
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->