### PR TITLE
fix(gitignore): add `.pnpm-store` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ target/
 .netlify/
 /test-results/
 /playwright-report/
+.pnpm-store
 /blob-report/
 /playwright/.cache/


### PR DESCRIPTION
## Summary

Depending on your checkout method and setup (for example, within a VS Code DevContainer), `pnpm` creates a `.pnpm-store` folder at the root of your workspace that should be ignored by `git`.

Not ignoring it can cause quite a headache and >10,000 untracked changes due to files in `.pnpm-store`.