### PR TITLE
fix(index): make progress colors more accessible

### DIFF
--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -73,8 +73,8 @@ import AwardBanner from "@/components/AwardBanner.astro"
                         <ProgressBarContainer
                             client:visible
                             data={[
-                                {duration: 0.41, label: "Biome", color: "#33ff66"},
-                                {duration: 14.35, label: "Prettier", color: "#ff0033"}
+                                {duration: 0.41, label: "Biome", color: "MediumSeaGreen"},
+                                {duration: 14.35, label: "Prettier", color: "LightSalmon"}
                             ]}
                         />
                     </div>

--- a/src/styles/_progress.css
+++ b/src/styles/_progress.css
@@ -34,6 +34,7 @@
 	right: 2%;
 	top: 0%;
 	font-size: 0.7rem;
+	font-weight: 600;
 }
 
 @media only screen and (max-width: 1080px) {


### PR DESCRIPTION
## Summary

<!-- 
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

I found that the existing colors of progress bars on the index page were very bright and didn't have sufficient contrast with the text on them, which made that text hard to read. I propose a different set of colors and also increased font weight for durations to reach contrast targets set by WCAG.

Before (https://webaim.org/resources/contrastchecker/?fcolor=353841&bcolor=FFA07A):
<img width="1108" alt="image" src="https://github.com/user-attachments/assets/0130da4c-e9d0-441f-a945-d2eaa5ed9194" />


After (https://webaim.org/resources/contrastchecker/?fcolor=353841&bcolor=FFA07A):
<img width="1097" alt="image" src="https://github.com/user-attachments/assets/13dfd289-982a-40be-b394-3804c573cd4b" />

-----
<a href="https://stackblitz.com/~/github.com/illright/website/tree/illright/patch-52892"><img src="https://developer.stackblitz.com/img/review_pr_small.svg" alt="Review PR in StackBlitz" align="left" width="103" height="20"></a> _Submitted with [StackBlitz](https://stackblitz.com/~/github.com/illright/website/tree/illright/patch-52892)._