### PR TITLE
Remove duplicate code block in JA docs

### DIFF
--- a/src/content/docs/ja/reference/configuration.mdx
+++ b/src/content/docs/ja/reference/configuration.mdx
@@ -668,14 +668,6 @@ JSXを解釈するために使用されるランタイムまたは変換のタ�
 }
 ```
 
-```json title="biome.json"
-{
-  "javascript": {
-    "jsxRuntime": "reactClassic"
-  }
-}
-```
-
 古いJSXランタイムと新しいJSXランタイムについての詳細は、以下をご覧ください。
 https://legacy.reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html
 


### PR DESCRIPTION
## Summary

<!-- 
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

![image](https://github.com/user-attachments/assets/3b76fa8d-5e6e-4dc7-8925-6e4cbe0785d6)

I read Japanese docs and found jsxRuntime codeBlock write twice. So I remove that.