### PR TITLE
docs: add French translation of guides/editors/first-party-extensions.mdx

### DIFF
--- a/src/content/docs/fr/guides/editors/first-party-extensions.mdx
+++ b/src/content/docs/fr/guides/editors/first-party-extensions.mdx
@@ -1,0 +1,52 @@
+---
+title: Extensions officielles
+description: Apprenez à installer des extensions officielles
+---
+
+Voici les extensions qui sont maintenues par l’équipe de Biome et une partie de [l’organisation de Biome](https://github.com/biomejs).
+
+## VS Code
+
+L’intégration de Biome à l’éditeur vous permet&nbsp;:
+
+* de formater les fichiers à leur enregistrement ou lors de l’émission de la commande _Mettre en forme le document,_
+* d’analyser les fichiers et faire appliquer les corrections de code.
+
+Installez notre [extension Biome officielle pour VS Code](https://marketplace.visualstudio.com/items?itemName=biomejs.biome) depuis la Marketplace de Visual Studio.
+
+Pour faire de Biome l’outil de formatage par défaut, ouvrez un [fichier pris en charge](/fr/internals/language-support/) et&nbsp;:
+
+1. ouvrez la *palette de commandes* (Affichage ou <kbd>Ctrl</kbd>/<kbd title="Pomme">⌘</kbd>+<kbd title="Majuscule">⇧</kbd>+<kbd>P</kbd>),
+1. sélectionnez *Mettre en forme le document avec…,*
+1. sélectionnez *Configurer le formateur par défaut,*
+1. sélectionnez *Biome.*
+
+En savoir plus sur la [page de référence](/fr/reference/vscode).
+
+## IntelliJ
+
+Pour installer le plug-in Biome pour IntelliJ, rendez-vous sur la [page officielle du plug-in](https://plugins.jetbrains.com/plugin/22761-biome) ou suivez les étapes suivantes&nbsp;:
+
+**Depuis les IDEs de JetBrains&nbsp;:**
+
+1. ouvrez IntelliJ IDEA,
+2. allez vers **Settings/Preferences,**
+3. sélectionnez **Plugins** dans le menu de gauche,
+4. cliquez sur l’onglet **Marketplace,**
+5. cherchez «&nbsp;Biome&nbsp;» et cliquez sur **Install,**
+6. redémarrez l’IDE pour activer le plug-in.
+
+**Depuis le disque dur&nbsp;:**
+
+1. téléchargez l’extension en .zip depuis l’onglet **Versions&nbsp;;**
+2. tapez <kbd>Ctrl</kbd>+<kbd>Alt</kbd>+<kbd>S</kbd>/<kbd title="Pomme">⌘</kbd>+<kbd title="Virgule">,</kbd> pour ouvrir les réglages de l’IDE, puis sélectionnez **Plugins&nbsp;;**
+3. sur la page des extensions, cliquez sur le bouton des réglages, puis sur **Install Plugin from Disk.**
+
+## Zed
+
+1. Ouvrez la *palette de commandes* (Affichage ou <kbd>Ctrl</kbd>/<kbd title="Pomme">⌘</kbd>+<kbd title="Majuscule">⇧</kbd>+<kbd>P</kbd>),
+2. sélectionnez **zed: extensions,**
+3. cherchez **Biome,**
+4. sélectionnez **Installer.**
+
+En savoir plus sur la [page de référence](/fr/reference/zed).


### PR DESCRIPTION
## Summary

Add the translation into French of the “First-party-extensions” page.

Added:
- the `guides/editors/first-party-extensions.mdx` file translated into French.