### PR TITLE
Clarify conditions under which use-exhaustive-dependencies.mdx can be used

### DIFF
--- a/src/content/docs/linter/rules/use-exhaustive-dependencies.mdx
+++ b/src/content/docs/linter/rules/use-exhaustive-dependencies.mdx
@@ -21,9 +21,9 @@ Sources:
 
 Enforce all dependencies are correctly specified in a React hook.
 
-_This rule should be used only in **React** projects._
+_This rule should be used only in **React (or Preact)** projects._
 
-This rule is a port of the rule [react-hooks/exhaustive-deps](https://legacy.reactjs.org/docs/hooks-rules.html#eslint-plugin), and it's meant to target projects that uses React.
+This rule is a port of the rule [react-hooks/exhaustive-deps](https://legacy.reactjs.org/docs/hooks-rules.html#eslint-plugin), and it's meant to target projects that uses React (or Preact).
 
 If your project _doesn't_ use React (or Preact), **you shouldn't use this rule**.
 


### PR DESCRIPTION
## Summary

`only` is a strong word.  If later we refer to Preact in addition to React, this should be included when stating conditions under which this rule can be used.