### PR TITLE
Commercial support page

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -94,6 +94,11 @@ export default defineConfig({
 					},
 				},
 				{
+					label: "Support",
+					link: "../support",
+					translations: {},
+				},
+				{
 					label: "Guides",
 					translations: { ja: "ガイド", "zh-CN": "指南", "pt-BR": "Guias" },
 					items: [

--- a/src/components/starlight/SiteTitle.astro
+++ b/src/components/starlight/SiteTitle.astro
@@ -4,6 +4,7 @@ import type { Props } from "@astrojs/starlight/props";
 
 const menuItems = [
 	{ name: "Docs", href: "/guides/getting-started" },
+  { name: "Support", href: "/support" },
 	{ name: "Playground", href: "/playground" },
 ];
 

--- a/src/components/starlight/SiteTitle.astro
+++ b/src/components/starlight/SiteTitle.astro
@@ -4,7 +4,7 @@ import type { Props } from "@astrojs/starlight/props";
 
 const menuItems = [
 	{ name: "Docs", href: "/guides/getting-started" },
-  { name: "Support", href: "/support" },
+	{ name: "Support", href: "/support" },
 	{ name: "Playground", href: "/playground" },
 ];
 

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -26,14 +26,14 @@ hero:
       variant: secondary
 ---
 
-import {Card, CardGrid} from "@astrojs/starlight/components";
+import { Card, CardGrid } from "@astrojs/starlight/components";
 import Inputf from "@/components/formatter/input.md";
 import Outputf from "@/components/formatter/output.md";
 import ProgressBarContainer from "@/playground/components/Progress.tsx";
 import Community from "@/components/generated/Community.astro";
-import {Icon} from "@astrojs/starlight/components";
+import { Icon } from "@astrojs/starlight/components";
 import arrow from "@/assets/svg/arrow-right.svg";
-import {Image} from "astro:assets";
+import { Image } from "astro:assets";
 import "@/styles/_performance.css";
 import "@/styles/_installation.css";
 import "@/styles/_community.css";
@@ -153,10 +153,6 @@ import AwardBanner from "@/components/AwardBanner.astro"
             Designed to handle codebases of any size. Focus on growing product instead
             of your tools.
         </Card>
-        <Card title="Optimized" icon="setting">
-            With tight internal integration we are able to reuse previous work and any
-            improvement to one tool improves them all.
-        </Card>
         <Card title="Actionable & Informative" icon="information">
             Avoid obscure error messages, when we tell you something is wrong, we tell
             you exactly where the problem is and how to fix it.
@@ -164,6 +160,10 @@ import AwardBanner from "@/components/AwardBanner.astro"
         <Card title="Batteries Included" icon="add-document">
             Out of the box support for all the language features you use today. First
             class support for TypeScript and JSX.
+        </Card>
+        <Card title="Commercial Support" icon="phone">
+            We offer <a href="/support/">commercial support</a> to organizations that
+            need it through our community of contributors.
         </Card>
     </CardGrid>
 </div>

--- a/src/pages/support.astro
+++ b/src/pages/support.astro
@@ -37,7 +37,7 @@ import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
         </div>
     </div>
     <div class="sponsorship">
-        <Icon color="red" name="heart" size="6rem" />
+        <Icon class="logo" color="red" name="heart" size="6rem" />
         <div>
             <h2>Were you looking to support Biome instead?</h2>
             <p>
@@ -51,7 +51,7 @@ import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
     <p class="fineprint">
         Support requests are subject to contributor availability. For terms and
         conditions, please see our
-        <a href="https://github.com/biomejs/biome/blob/main/GOVERNANCE.md">Governance document</a>.
+        <a href="https://github.com/biomejs/biome/blob/main/GOVERNANCE.md#paid-contracting">Governance document</a>.
     </p>
 </StarlightPage>
 
@@ -91,5 +91,18 @@ import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
     .fineprint {
         color: var(--sl-color-gray-3);
         text-align: center;
+    }
+
+    @media screen and (max-width: 480px) {
+        .ctas {
+            flex-direction: column;
+        }
+
+        .sponsorship {
+            margin: 7rem 2rem 4rem;
+        }
+        .sponsorship>.logo {
+            display: none;
+        }
     }
 </style>

--- a/src/pages/support.astro
+++ b/src/pages/support.astro
@@ -1,0 +1,95 @@
+---
+import { Icon, LinkButton } from "@astrojs/starlight/components";
+import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
+---
+
+<StarlightPage
+  frontmatter={{
+    title: "Commercial Support",
+    description: "Commercial support for Biome",
+    template: "splash",
+    editUrl: false,
+  }}
+>
+    <p>
+        Biome has an active community and a team of Maintainers, Core
+        Contributors, and Leads, all ready to support our users.
+    </p>
+    <p>
+        Some of our contributors are freelancers, and may offer their (paid)
+        services for organizations that are looking to adopt Biome. If you need
+        commercial help with Biome, please reach out to us!
+    </p>
+    <div class="ctas">
+        <div class="cta">
+            <p>
+                <LinkButton href="https://biomejs.dev/chat" target="_blank">Contact us on Discord</LinkButton>
+            </p>
+            <p>Reach out to us through the <b><code>Community > #funding</code></b>
+                channel for enquiries related to commercial support.</p>
+        </div>
+        <div class="cta">
+            <p>
+                <LinkButton href="https://github.com/biomejs/biome/issues/new/choose" target="_blank">Create an issue on GitHub</LinkButton>
+            </p>
+            <p>Create an issue and choose <b>Financial Support Request</b> and
+                we'll get back to you.</p>
+        </div>
+    </div>
+    <div class="sponsorship">
+        <Icon color="red" name="heart" size="6rem" />
+        <div>
+            <h2>Were you looking to support Biome instead?</h2>
+            <p>
+                Biome is an open-source project and can also use <i>your</i> support.
+            </p>
+            <p>
+                Sponsorship options are available through <a href="https://opencollective.com/biome">OpenCollective</a> and <a href="https://github.com/sponsors/biomejs">GitHub Sponsors</a>.
+            </p>
+        </div>
+    </div>
+    <p class="fineprint">
+        Support requests are subject to contributor availability. For terms and
+        conditions, please see our
+        <a href="https://github.com/biomejs/biome/blob/main/GOVERNANCE.md">Governance document</a>.
+    </p>
+</StarlightPage>
+
+<style>
+    .ctas {
+        width: 100%;
+        padding: 1rem;
+        display: flex;
+        gap: 1rem;
+        vertical-align: start;
+    }
+
+    .cta {
+        margin-top: 0 !important;
+        text-align: center;
+        flex-grow: 1;
+    }
+
+    .sponsorship {
+        position: relative;
+        border: 1px solid var(--sl-color-gray-5);
+        font-size: 80%;
+        overflow: hidden;
+        margin: 7rem 4rem 4rem;
+        padding: 1rem;
+        display: flex;
+        gap: 1rem;
+        background: radial-gradient(
+                hsla(var(--sl-hue-red), 16%, 52%, 68%),
+                transparent 40%
+            )
+            no-repeat -60vw -50vh / 105vw 200vh,
+            radial-gradient(var(--sl-color-blue-low), transparent 40%) no-repeat 30vw
+            -100vh / 105vw 200vh;
+    }
+
+    .fineprint {
+        color: var(--sl-color-gray-3);
+        text-align: center;
+    }
+</style>

--- a/src/pages/support.astro
+++ b/src/pages/support.astro
@@ -32,7 +32,7 @@ import StarlightPage from "@astrojs/starlight/components/StarlightPage.astro";
             <p>
                 <LinkButton href="https://github.com/biomejs/biome/issues/new/choose" target="_blank">Create an issue on GitHub</LinkButton>
             </p>
-            <p>Create an issue and choose <b>Financial Support Request</b> and
+            <p>Create an issue and choose <b>Commercial Support Request</b> and
                 we'll get back to you.</p>
         </div>
     </div>


### PR DESCRIPTION
## Summary

This adds a page for commercial support to our website:

![commercial_support](https://github.com/user-attachments/assets/1694ab04-c0ce-401b-b3b1-06e03c48911d)

The page is also linked to from the front page (I've removed the rather non-specific "Optimized" section):

![commercial_support_card](https://github.com/user-attachments/assets/8dc8302c-b65b-465a-8e91-a44f274db642)

Note that the link in the card for this doesn't work yet. I suspect it's a CSS issue, but I didn't yet see the source of the issue :thinking: 

Let me know what you think!