### PR TITLE
fix(docs): fix the incorrect Chinese translation

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -128,7 +128,7 @@ export default defineConfig({
 							translations: {
 								fr: "Configurer Biome",
 								ja: "Biome の設定",
-								"zh-CN": "配置生物群落",
+								"zh-CN": "配置 Biome",
 								"pt-BR": "Configurar Bioma",
 							},
 						},


### PR DESCRIPTION
## Summary

<!-- 
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

While reading the documentation on the Biome website, I noticed that the phrase "配置生物群落" in the left-side menu seemed quite odd and out of context. Upon checking the original English text, I found that it was meant to be "Configure Biome." This discrepancy suggests that the translation may have been inaccurately generated by a machine translation tool. 
