### PR TITLE
Add Chinese Translation of editor extensions integration

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -183,6 +183,7 @@ export default defineConfig({
 									translations: {
 										fr: "Extensions officielles",
 										ja: "Biome 公式拡張機能",
+										"zh-CN": "官方扩展",
 										uk: "Офіційні розширення",
 									},
 								},
@@ -192,6 +193,7 @@ export default defineConfig({
 									translations: {
 										fr: "Extensions tierces",
 										ja: "サードパーティの拡張機能",
+										"zh-CN": "第三方扩展",
 										uk: "Розширення сторонніх розробників",
 									},
 								},

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -203,6 +203,7 @@ export default defineConfig({
 									translations: {
 										fr: "Intégrer Biome à une extension pour un éditeur",
 										ja: "エディタ拡張機能への Biome の統合",
+										"zh-CN": "在编辑器扩展中集成 Biome",
 										uk: "Інтеграція Biome в розширення редактора",
 									},
 								},

--- a/src/content/docs/zh-CN/guides/editors/create-a-extension.mdx
+++ b/src/content/docs/zh-CN/guides/editors/create-a-extension.mdx
@@ -1,0 +1,79 @@
+---
+title: 在编辑器扩展中集成 Biome
+description: 学习如何将 Biome 与编辑器和 IDE 集成
+---
+
+Biome 对 [LSP](https://microsoft.github.io/language-server-protocol/) 提供一流的支持。如果你的编辑器实现了 LSP，那么 Biome 的集成应该是无缝的。
+
+### 使用 LSP 代理
+
+Biome 有一个名为 `lsp-proxy` 的命令。当执行时，Biome 将启动两个进程：
+- 一个[守护进程](/internals/architecture#daemon)，用于执行请求的操作；
+- 一个服务器，充当客户端 - 编辑器 - 和服务器 - 守护程序的请求之间的代理；
+
+如果你的编辑器能够与服务器交互并发送 [JSON-RPC](https://www.jsonrpc.org/) 请求，你只需要配置编辑器运行该命令。
+
+你可以参考 [`neo-vim biome 扩展`](https://github.com/neovim/nvim-lspconfig/blob/master/lua/lspconfig/configs/biome.lua) 的实现方式。
+
+### 使用 `stdin`
+
+如果你的编辑器不支持 LSP，你可以直接使用 `biome` 二进制文件，并通过[标准输入](https://en.wikipedia.org/wiki/Standard_streams#Standard_input_(stdin))调用它。
+
+以下命令可以通过标准输入调用：
+- [`format`](/reference/cli/#biome-format)
+- [`lint`](/reference/cli/#biome-lint)
+- [`check`](/reference/cli/#biome-check)
+
+Biome 会将新的输出（如果没有发生更改则为原始输出）返回到[标准输出](https://en.wikipedia.org/wiki/Standard_streams#Standard_output_(stdout))，并将诊断信息返回到[标准错误](https://en.wikipedia.org/wiki/Standard_streams#Standard_error_(stderr))。
+
+当使用 `stdin` 时，你必须传递 `--stdin-file-path` 选项。文件`路径`**不需要实际存在**于你的文件系统中，可以是任何名称。**重要的是**提供正确的文件扩展名，这样 Biome 就知道**如何处理**你的文件。
+
+编辑器负责定位和解析二进制文件的路径，并在需要时调用它。二进制文件根据我们支持的架构和操作系统发布到 npm：
+
+- `@biomejs/cli-darwin-arm64`
+- `@biomejs/cli-darwin-x64`
+- `@biomejs/cli-linux-arm64`
+- `@biomejs/cli-linux-x64`
+- `@biomejs/cli-win32-arm64`
+- `@biomejs/cli-win32-x64`
+
+二进制文件名是 `biome` 或 `biome.exe`，可以在库的根目录中找到，例如：`@biomejs/cli-darwin-arm64/biome`，`@biomejs/cli-win32-x64/biome.exe`。
+
+### 通过二进制文件使用守护进程
+
+通过 CLI 使用二进制文件非常高效，但你无法为用户提供[日志](#daemon-logs)。CLI 允许你引导守护进程，然后通过守护进程本身使用 CLI 命令。
+
+要实现这一点，你首先需要使用 [`start`](/reference/cli#biome-start) 命令启动守护进程：
+
+```shell
+biome start
+```
+然后，每个命令都需要添加 `--use-server` 选项，例如：
+
+```shell
+echo "console.log('')" | biome format --use-server --stdin-file-path=dummy.js
+```
+
+:::note
+如果你决定使用守护进程，你也需要负责使用 [`stop`](/reference/cli#biome-stop) 命令重启/终止进程，以避免出现幽灵进程。
+:::
+
+:::caution
+通过守护进程执行的操作比 CLI 本身要慢得多，因此建议仅对单个文件执行操作。
+:::
+
+### 守护进程日志
+
+Biome 守护进程在你的文件系统中保存日志。日志存储在名为 `biome-logs` 的文件夹中。该文件夹的路径根据你的操作系统而变化：
+-  Linux：`~/.cache/biome`；
+-  Windows：`C:\Users\<UserName>\AppData\Local\biomejs\biome\cache`
+-  macOS：`/Users/<UserName>/Library/Caches/dev.biomejs.biome`
+
+对于其他操作系统，你可以在系统的临时目录中找到该文件夹。
+
+要获取确切的路径，执行以下命令：
+```shell
+biome explain daemon-logs
+```
+
+日志文件每小时轮换一次。

--- a/src/content/docs/zh-CN/guides/editors/first-party-extensions.mdx
+++ b/src/content/docs/zh-CN/guides/editors/first-party-extensions.mdx
@@ -1,0 +1,52 @@
+---
+title: 官方扩展
+description: 学习如何设置官方扩展
+---
+
+这些扩展由 Biome 团队维护，并且是 Biome 组织的一部分。
+
+### VS Code
+
+通过 Biome 编辑器集成，您可以：
+
+* 在保存时或发出 Format 命令时格式化文件。
+* Lint 文件并应用代码修复
+
+从 Visual Studio Marketplace 安装我们的官方 [Biome VS Code 扩展](https://marketplace.visualstudio.com/items?itemName=biomejs.biome).
+
+要将 Biome 设为默认格式化程序，请打开一个 [受支持的文件](/internals/language-support/)，然后:
+
+1. 打开*命令面板* (通过应用程序菜单中的查看-命令面板或快捷键 <kbd>Ctrl</kbd>/<kbd title="Cmd">⌘</kbd>+<kbd title="Shift">⇧</kbd>+<kbd>P</kbd>)
+1. 选择*使用...格式化文档*
+1. 选择*配置默认格式化程序*
+1. 选择 *Biome*。
+
+您可以在[参考页面](/reference/vscode)中阅读更多内容。
+
+### IntelliJ
+
+要安装Biome IntelliJ plugin, 请前往[官方插件页面](https://plugins.jetbrains.com/plugin/22761-biome)或按照以下步骤:
+
+**从 JetBrains IDE 安装:**
+
+1. 打开 IntelliJ IDEA
+2. 前往**Settings/Preferences**
+3. 在左侧菜单中选择**Plugins**
+4. 点击**Marketplace**标签页
+5. 搜索”Biome“并点击**Install**
+6. 重启 IDE 以激活插件
+
+**从本地硬盘安装:**
+
+1. 从[版本](https://plugins.jetbrains.com/plugin/22761-biome/versions)标签页中下载扩展程序的 .zip 包.
+2. 按下 `⌘Сmd,` 可打开 IDE 设置，然后选择 **Plugins**.
+3. 在扩展页面上, 点击 **Settings** 按钮，然后点击 **Plugin from Disk…**.
+
+### Zed
+
+1. 打开 *命令面板* (通过应用程序菜单中的查看-命令面板或快捷键 <kbd>Ctrl</kbd>/<kbd title="Cmd">⌘</kbd>+<kbd title="Shift">⇧</kbd>+<kbd>P</kbd>)
+2. 选择 **zed: extensions**
+3. 搜索 **Biome**
+4. 选择 **Install**
+
+您可以在[参考页面](/reference/zed)中阅读更多内容.

--- a/src/content/docs/zh-CN/guides/editors/third-party-extensions.mdx
+++ b/src/content/docs/zh-CN/guides/editors/third-party-extensions.mdx
@@ -1,0 +1,65 @@
+---
+title: 第三方扩展
+description: 学习如何设置第三方扩展
+---
+
+这些是由其他社区维护的编辑器扩展，你可以在编辑器中安装它们:
+- [`vim`](https://www.vim.org/): [`ALE`](https://github.com/dense-analysis/ale) 支持 Biome，按照安装说明操作即可
+- [`neovim`](https://neovim.io/): 你需要安装 [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig/)，并按照[说明](https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#biome)进行操作。[`ALE`](https://github.com/dense-analysis/ale) 同样支持 Biome。
+- [`helix`](https://helix-editor.com/): 按照[这个手册](#helix)的说明进行操作
+- [`coc-biome`](https://github.com/fannheyward/coc-biome): [`coc.nvim`](https://github.com/neoclide/coc.nvim) 的 Biome 扩展
+- [`sublime text`](https://www.sublimetext.com/): 按照 [`LSP-biome`](https://github.com/sublimelsp/LSP-biome) 的安装说明进行操作
+- [`Emacs`](https://www.gnu.org/software/emacs/): 确保已安装 [`lsp-mode`](https://github.com/emacs-lsp/lsp-mode)，按照 [`lsp-biome`](https://github.com/cxa/lsp-biome) 的安装说明启用 `lsp-mode` 中的 Biome 支持
+
+:::note
+这里没有列出你使用的编辑器的扩展？请提交一个 PR，我们很乐意将其添加到列表中
+:::
+
+### Helix
+
+目前，biome 支持以下文件扩展名：`js`、`jsx`、`ts`、`tsx`、`d.ts`、`json` 和 `jsonc`。
+
+Biome 有一个 `lsp-proxy` 命令，它通过标准输入/输出作为语言服务器协议的服务器。
+
+#### Helix 23.10
+
+Helix 23.10 [支持多个语言服务器](https://github.com/helix-editor/helix/pull/2507)。现在你可以同时使用 biome 和 `typescript-language-server`。
+
+```toml
+[language-server]
+biome = { command = "biome", args = ["lsp-proxy"] }
+
+[[language]]
+name = "javascript"
+language-servers = [ { name = "typescript-language-server", except-features = [ "format" ] }, "biome" ]
+auto-format = true
+
+[[language]]
+name = "typescript"
+language-servers = [ { name = "typescript-language-server", except-features = [ "format" ] }, "biome" ]
+auto-format = true
+
+[[language]]
+name = "tsx"
+auto-format = true
+language-servers = [ { name = "typescript-language-server", except-features = [ "format" ] }, "biome" ]
+
+[[language]]
+name = "jsx"
+auto-format = true
+language-servers = [ { name = "typescript-language-server", except-features = [ "format" ] }, "biome" ]
+
+[[language]]
+name = "json"
+language-servers = [ { name = "vscode-json-language-server", except-features = [ "format" ] }, "biome" ]
+```
+
+### 视频演示
+
+#### 代码操作
+
+<video src="https://user-images.githubusercontent.com/17974631/190205045-aeb86f87-1915-4d8b-8aad-2c046443ba83.mp4" width="720" controls></video>
+
+#### 格式化
+
+<video src="https://user-images.githubusercontent.com/17974631/190205065-ddfde866-5f7c-4f53-8a62-b6cbb577982f.mp4" width="720" controls></video>


### PR DESCRIPTION
## Summary

<!-- 
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

Add the translation into Chinese of the editor extension page.

Added:

- guides/editors/first-party-extensions.mdx
- guides/editors/third-party-extensions.mdx
- guides/editors/create-a-extension.mdx

And translated related sidebar menu in `astro.config.ts`