### PR TITLE
fix: changes text for multiline attributePosition

### DIFF
--- a/src/content/docs/reference/configuration.mdx
+++ b/src/content/docs/reference/configuration.mdx
@@ -649,8 +649,8 @@ Choose whether spaces should be added between brackets and inner values
 ### `javascript.formatter.attributePosition`
 
 The attribute position style in jsx elements.
-- `"auto"`, the attributes are automatically formatted, and they will collapse in multiple lines only when they hit certain criteria;
-- `"multiline"`, the attributes will collapse in multiple lines if more then 1 attribute is used.
+- `"auto"`, do not enforce single attribute per line.
+- `"multiline"`, enforce single attribute per line.
 
 > Default: `"auto"`
 

--- a/src/content/docs/reference/configuration.mdx
+++ b/src/content/docs/reference/configuration.mdx
@@ -421,7 +421,7 @@ How many characters can be written on a single line.
 
 The attribute position style in HTMLish languages.
 - `"auto"`, the attributes are automatically formatted, and they will collapse in multiple lines only when they hit certain criteria;
-- `"multiline"`, the attributes are always formatted on multiple lines, regardless.
+- `"multiline"`, the attributes will collapse in multiple lines if more then 1 attribute is used.
 
 > Default: `"auto"`
 
@@ -650,7 +650,7 @@ Choose whether spaces should be added between brackets and inner values
 
 The attribute position style in jsx elements.
 - `"auto"`, the attributes are automatically formatted, and they will collapse in multiple lines only when they hit certain criteria;
-- `"multiline"`, the attributes are always formatted on multiple lines, regardless.
+- `"multiline"`, the attributes will collapse in multiple lines if more then 1 attribute is used.
 
 > Default: `"auto"`
 


### PR DESCRIPTION
## Summary

This fixes a incorrectly documented option for `formatter.attributePosition` and `javascript.formatter.attributePosition`

Currently it says it will always format the attributes to multiline, however if only 1 attribute is used it will format it inline rather then multiline.

This changes explicitly explains that it will only format and collapse to multiline if more then 1 attribute is used.

closes #1682