### PR TITLE
docs: update CLI examples for clarity and consistency

### DIFF
--- a/src/content/docs/reference/cli.mdx
+++ b/src/content/docs/reference/cli.mdx
@@ -1027,14 +1027,11 @@ EXPERIMENTAL: Searches for Grit patterns across a project.
 
 Note: GritQL escapes code snippets using backticks, but most shells interpret backticks as command invocations. To avoid this, it's best to put single quotes around your Grit queries.
 
-## Example
-
-  ```shell
-  biome search '`console.log($message)`' # find all `console.log` invocations
-  ```
-
-
 **Usage**: **`biome`** **`search`** _`PATTERN`_ \[_`PATH`_\]...
+
+```shell
+biome search '`console.log($message)`' # find all `console.log` invocations
+```
 
 **Global options applied to all commands**
 - **`    --colors`**=_`<off|force>`_ &mdash; 
@@ -1123,19 +1120,15 @@ Note: GritQL escapes code snippets using backticks, but most shells interpret ba
 
 Shows documentation of various aspects of the CLI.
 
-## Examples
-
-  ```shell
-  biome explain noDebugger
-  ```
-
-
-  ```shell
-  biome explain daemon-logs
-  ```
-
-
 **Usage**: **`biome`** **`explain`** _`NAME`_
+
+```shell
+# show documentation for lint/suspicious/noDebugger
+biome explain noDebugger 
+
+# obtain the precise path of daemon-logs
+biome explain daemon-logs
+```
 
 **Available positional items:**
 - _`NAME`_ &mdash; 


### PR DESCRIPTION
## Summary

<!-- 
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->
1. remove `examples` section and move code blocks to the `usage` section
2. make the page outline clearer

![CleanShot 2025-01-18 at 11 29 51](https://github.com/user-attachments/assets/7595d67c-38b2-4495-8b29-f3873e907664)
