### PR TITLE
feat: add docker instructions

### DIFF
--- a/src/content/docs/guides/manual-installation.mdx
+++ b/src/content/docs/guides/manual-installation.mdx
@@ -32,6 +32,33 @@ Biome is available as a [Homebrew formula](https://formulae.brew.sh/formula/biom
 brew install biome
 ```
 
+## Docker
+
+Biome publishes [official Docker images](https://github.com/biomejs/docker) that support 
+the **amd64** and **arm64** architectures for all Biome versions starting from `v1.7.0`.
+
+```
+ghcr.io/biomejs/biome:{major}
+ghcr.io/biomejs/biome:{major}{minor}
+ghcr.io/biomejs/biome:{major}{minor}{patch}
+```
+
+Here are a couple examples on how to use the Docker image:
+
+:::note
+The default workdir is `/code` in the Docker image.
+:::
+
+```shell
+# Lint files
+docker run -v $(pwd):/code ghcr.io/biomejs/biome lint
+docker run -v $(pwd):/code ghcr.io/biomejs/biome lint --write
+
+# Format files
+docker run -v $(pwd):/code ghcr.io/biomejs/biome format
+docker run -v $(pwd):/code ghcr.io/biomejs/biome format --write
+```
+
 ## Using a published binary
 
 To install Biome, grab the executable for your platform from the [latest CLI release](https://github.com/biomejs/biome/releases) on GitHub and give it execution permission.

--- a/src/content/docs/guides/manual-installation.mdx
+++ b/src/content/docs/guides/manual-installation.mdx
@@ -34,7 +34,7 @@ brew install biome
 
 ## Docker
 
-Biome publishes [official Docker images](https://github.com/biomejs/docker) that support 
+Biome publishes [official Docker images](https://github.com/biomejs/docker/pkgs/container/biome) that support 
 the **amd64** and **arm64** architectures for all Biome versions starting from `v1.7.0`.
 
 ```

--- a/src/content/docs/guides/manual-installation.mdx
+++ b/src/content/docs/guides/manual-installation.mdx
@@ -39,8 +39,8 @@ the **amd64** and **arm64** architectures for all Biome versions starting from `
 
 ```
 ghcr.io/biomejs/biome:{major}
-ghcr.io/biomejs/biome:{major}{minor}
-ghcr.io/biomejs/biome:{major}{minor}{patch}
+ghcr.io/biomejs/biome:{major}.{minor}
+ghcr.io/biomejs/biome:{major}.{minor}.{patch}
 ```
 
 Here are a couple examples on how to use the Docker image:


### PR DESCRIPTION
## Summary

This PR adds instructions for using the official Docker images for Biome.

Ref: https://github.com/biomejs/docker