### PR TITLE
refactor(playground): upgrade playground to be compatible with biome 2.0

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -4,8 +4,6 @@ on:
     branches:
       - main
   pull_request:
-    branches:
-      - main
 env:
   E2E: true
 jobs:

--- a/src/playground/tabs/SettingsTab.tsx
+++ b/src/playground/tabs/SettingsTab.tsx
@@ -852,12 +852,12 @@ function LinterSettings({
 						aria-describedby="analyzer-fix-mode-description"
 						name="analyzer-fix-mode"
 						disabled={!enabledLinting}
-						value={analyzerFixMode ?? "SafeFixes"}
+						value={analyzerFixMode ?? "safeFixes"}
 						onChange={(e) => setAnalyzerFixMode(e.target.value as FixFileMode)}
 					>
-						<option value={"SafeFixes"}>Safe Fixes</option>
-						<option value={"SafeAndUnsafeFixes"}>Safe and Unsafe Fixes</option>
-						<option value={"ApplySuppressions"}>Apply Suppressions</option>
+						<option value={"safeFixes"}>Safe Fixes</option>
+						<option value={"safeAndUnsafeFixes"}>Safe and Unsafe Fixes</option>
+						<option value={"applySuppressions"}>Apply Suppressions</option>
 					</select>
 				</div>
 			</section>

--- a/src/playground/types.ts
+++ b/src/playground/types.ts
@@ -186,7 +186,7 @@ export const defaultPlaygroundState: PlaygroundState = {
 		bracketSameLine: false,
 		lintRules: LintRules.Recommended,
 		enabledLinting: true,
-		analyzerFixMode: "SafeFixes",
+		analyzerFixMode: "safeFixes",
 		importSortingEnabled: true,
 		unsafeParameterDecoratorsEnabled: true,
 		allowComments: true,


### PR DESCRIPTION
## Summary

<!-- 
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

This PR updates the playground so that it's compatible with the changes currently on `next` in the main Biome repo. It needs to be merged after biomejs/biome#4760. The goal for this PR is to simply make the playground functional for 2.0, not to add new features to support new 2.0 functionality.

To test this, I've been using the following command to build the wasm bin and copy over to this repo's `node_modules`:
```
wasm-pack build --dev --out-dir ../../packages/@biomejs/wasm-web --target web --scope biomejs crates/biome_wasm --features experimental-html && cp -v packages/@biomejs/wasm-web/* ../biome-website/node_modules/@biomejs/wasm-web
```
