### PR TITLE
feat(playground): remove import sorting tab, rename import sorting to assist, add rule domains

### DIFF
--- a/src/playground/Playground.tsx
+++ b/src/playground/Playground.tsx
@@ -8,7 +8,6 @@ import DiagnosticsConsoleTab from "@/playground/tabs/DiagnosticsConsoleTab";
 import DiagnosticsListTab from "@/playground/tabs/DiagnosticsListTab";
 import FormatterCodeTab from "@/playground/tabs/FormatterCodeTab";
 import FormatterIrTab from "@/playground/tabs/FormatterIrTab";
-import ImportSortingTab from "@/playground/tabs/ImportSortingTab";
 import SettingsTab from "@/playground/tabs/SettingsTab";
 import SyntaxTab from "@/playground/tabs/SyntaxTab";
 import {
@@ -268,16 +267,6 @@ export default function Playground({
 					title: "Control Flow Graph",
 					children: (
 						<ControlFlowTab graph={biomeOutput.analysis.controlFlowGraph} />
-					),
-				},
-				{
-					key: PlaygroundTab.ImportSorting,
-					title: "Import Sorting",
-					children: (
-						<ImportSortingTab
-							code={biomeOutput.importSorting.code}
-							extensions={codeMirrorExtensions}
-						/>
 					),
 				},
 				{

--- a/src/playground/PlaygroundLoader.tsx
+++ b/src/playground/PlaygroundLoader.tsx
@@ -28,6 +28,7 @@ import {
 	isTypeScriptFilename,
 	normalizeFilename,
 } from "@/playground/utils";
+import type { FixFileMode } from "@biomejs/wasm-web";
 import {
 	type Dispatch,
 	type SetStateAction,
@@ -355,9 +356,12 @@ function initState(
 			enabledLinting:
 				searchParams.get("enabledLinting") === "true" ||
 				defaultPlaygroundState.settings.enabledLinting,
-			importSortingEnabled:
-				searchParams.get("importSortingEnabled") === "true" ||
-				defaultPlaygroundState.settings.importSortingEnabled,
+			enabledAssist:
+				searchParams.get("enabledAssist") === "true" ||
+				defaultPlaygroundState.settings.enabledAssist,
+			analyzerFixMode:
+				(searchParams.get("analyzerFixMode") as FixFileMode) ||
+				defaultPlaygroundState.settings.analyzerFixMode,
 			unsafeParameterDecoratorsEnabled:
 				searchParams.get("unsafeParameterDecoratorsEnabled") === "true" ||
 				defaultPlaygroundState.settings.unsafeParameterDecoratorsEnabled,

--- a/src/playground/tabs/ImportSortingTab.tsx
+++ b/src/playground/tabs/ImportSortingTab.tsx
@@ -1,9 +1,0 @@
-import CodeMirror, { type BiomeExtension } from "@/playground/CodeMirror";
-interface Props {
-	code: string;
-	extensions: BiomeExtension[];
-}
-
-export default function ImportSortingTab({ code, extensions }: Props) {
-	return <CodeMirror value={code} extensions={extensions} readOnly={true} />;
-}

--- a/src/playground/types.ts
+++ b/src/playground/types.ts
@@ -1,4 +1,9 @@
-import type { Diagnostic, FixFileMode } from "@biomejs/wasm-web";
+import type {
+	Diagnostic,
+	FixFileMode,
+	RuleDomain,
+	RuleDomainValue,
+} from "@biomejs/wasm-web";
 import type { parser } from "codemirror-lang-rome-ast";
 import type { Dispatch, SetStateAction } from "react";
 
@@ -96,9 +101,6 @@ export interface BiomeOutput {
 		/** The snippet with lint fixes applied. */
 		fixed: string;
 	};
-	importSorting: {
-		code: string;
-	};
 }
 
 export const emptyBiomeOutput: BiomeOutput = {
@@ -118,9 +120,6 @@ export const emptyBiomeOutput: BiomeOutput = {
 		controlFlowGraph: "",
 		fixed: "",
 	},
-	importSorting: {
-		code: "",
-	},
 };
 
 export interface PlaygroundSettings {
@@ -139,9 +138,10 @@ export interface PlaygroundSettings {
 	lintRules: LintRules;
 	enabledLinting: boolean;
 	analyzerFixMode: FixFileMode;
-	importSortingEnabled: boolean;
+	enabledAssist: boolean;
 	unsafeParameterDecoratorsEnabled: boolean;
 	allowComments: boolean;
+	ruleDomains: Record<RuleDomain, RuleDomainValue>;
 }
 
 export interface PlaygroundFileState {
@@ -187,9 +187,10 @@ export const defaultPlaygroundState: PlaygroundState = {
 		lintRules: LintRules.Recommended,
 		enabledLinting: true,
 		analyzerFixMode: "safeFixes",
-		importSortingEnabled: true,
+		enabledAssist: true,
 		unsafeParameterDecoratorsEnabled: true,
 		allowComments: true,
+		ruleDomains: {},
 	},
 };
 

--- a/src/playground/workers/biomeWorker.ts
+++ b/src/playground/workers/biomeWorker.ts
@@ -88,10 +88,11 @@ self.addEventListener("message", async (e) => {
 				arrowParentheses,
 				bracketSpacing,
 				bracketSameLine,
-				importSortingEnabled,
+				enabledAssist,
 				unsafeParameterDecoratorsEnabled,
 				allowComments,
 				attributePosition,
+				ruleDomains,
 			} = e.data.settings as PlaygroundSettings;
 
 			configuration = {
@@ -107,10 +108,11 @@ self.addEventListener("message", async (e) => {
 
 				linter: {
 					enabled: enabledLinting,
+					domains: ruleDomains,
 				},
 
 				assist: {
-					enabled: importSortingEnabled,
+					enabled: enabledAssist,
 				},
 
 				javascript: {
@@ -165,12 +167,16 @@ self.addEventListener("message", async (e) => {
 					break;
 				}
 				case LintRules.All: {
-					// temporary until we update the UI to be able to select rules better.
-					configuration.linter!.domains = {
-						test: "all",
-						react: "all",
-						solid: "all",
-						next: "all",
+					// TODO: not entirely sure what to do here now that we have rule domains, and no longer have a single "all" option
+					configuration.linter!.rules = {
+						a11y: "on",
+						nursery: "on",
+						complexity: "on",
+						correctness: "on",
+						performance: "on",
+						security: "on",
+						style: "on",
+						suspicious: "on",
 					};
 					break;
 				}
@@ -275,10 +281,6 @@ self.addEventListener("message", async (e) => {
 				formatterIr = "Can't format";
 			}
 
-			const importSorting = {
-				code: "Moved to Analyzer Fixes tab",
-			};
-
 			const categories: RuleCategories = [];
 			if (configuration?.formatter?.enabled) {
 				categories.push("syntax");
@@ -362,9 +364,6 @@ self.addEventListener("message", async (e) => {
 				analysis: {
 					controlFlowGraph,
 					fixed: fixed.code,
-				},
-				importSorting: {
-					code: importSorting.code,
 				},
 			};
 


### PR DESCRIPTION
## Summary

<!-- 
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->
This fully removes the import sorting tab and makes the UI changes necessary to show "Assist" instead of "Import sorting".

It also adds UI for being able to specify rule domains. I'm not entirely sure what to do with the `Lint Rules` option though. Open to suggestions.

> [!CAUTION]
> This PR is stacked on the following PRs. **Do not merge it without merging the others and rebasing this branch.** To review this PR, look at the last commit only.
> - #1722
