### PR TITLE
docs(vscode): suggest faster source.fixAll.biome setting instead of quickfix.biome for vscode config

### DIFF
--- a/src/content/docs/ja/reference/vscode.mdx
+++ b/src/content/docs/ja/reference/vscode.mdx
@@ -76,7 +76,7 @@ Biomeは、VS Codeの _保存時のコードアクション_ 設定を尊重し�
 ```json title="settings.json"
 {
   "editor.codeActionsOnSave": {
-    "quickfix.biome": "explicit"
+    "source.fixAll.biome": "explicit"
   }
 }
 ```

--- a/src/content/docs/pt-BR/reference/vscode.mdx
+++ b/src/content/docs/pt-BR/reference/vscode.mdx
@@ -78,7 +78,7 @@ O Biome respeita a configuração _Ações de Código ao Salvar_ do VS Code. Par
 ```json title="settings.json"
 {
   "editor.codeActionsOnSave": {
-    "quickfix.biome": "explicit"
+    "source.fixAll.biome": "explicit"
   }
 }
 ```

--- a/src/content/docs/reference/vscode.mdx
+++ b/src/content/docs/reference/vscode.mdx
@@ -76,7 +76,7 @@ Biome respects VS Code's _Code Actions On Save_ setting. To enable fix on save, 
 ```json title="settings.json"
 {
   "editor.codeActionsOnSave": {
-    "quickfix.biome": "explicit"
+    "source.fixAll.biome": "explicit"
   }
 }
 ```

--- a/src/content/docs/zh-CN/reference/vscode.mdx
+++ b/src/content/docs/zh-CN/reference/vscode.mdx
@@ -76,7 +76,7 @@ Biome 尊重 VS Code 的 _Code Actions On Save_ 设置。要启用保存时修�
 ```json title="settings.json"
 {
   "editor.codeActionsOnSave": {
-    "quickfix.biome": "explicit"
+    "source.fixAll.biome": "explicit"
   }
 }
 ```


### PR DESCRIPTION
## Summary
Our company recently added biome, and set up vscode autofixes as described in the [existing docs](https://biomejs.dev/reference/vscode/#fix-on-save). We immediately hit the issue described here https://github.com/biomejs/biome-vscode/issues/229, which was very painful in a repo of our size.

It seems like `source.fixAll.biome` is a strictly better setting to recommend than `quickfix.biome`, so this PR swaps all existing references out for the former.