### PR TITLE
feat(playground): add html formatter options

### DIFF
--- a/src/playground/PlaygroundLoader.tsx
+++ b/src/playground/PlaygroundLoader.tsx
@@ -12,6 +12,7 @@ import {
 	type QuoteStyle,
 	type Semicolons,
 	type TrailingCommas,
+	type WhitespaceSensitivity,
 	defaultPlaygroundState,
 	emptyBiomeOutput,
 	emptyPrettierOutput,
@@ -247,6 +248,14 @@ function buildLocation(state: PlaygroundState): string {
 		}
 	}
 
+	// handle rule domains
+	for (const key in state.settings.ruleDomains) {
+		const value = state.settings.ruleDomains[key];
+		if (value !== undefined && value !== "none") {
+			queryStringObj[`ruleDomains.${key}`] = value;
+		}
+	}
+
 	const queryString = new URLSearchParams(queryStringObj).toString();
 	lastSearchStore.set(queryString);
 
@@ -301,6 +310,19 @@ function initState(
 		files = defaultPlaygroundState.files;
 	}
 
+	// handle rule domains
+	const ruleDomains: Record<string, string> = {};
+	const prefixLength = "ruleDomains.".length;
+	for (const key of searchParams.keys()) {
+		if (key.startsWith("ruleDomains.")) {
+			const domain = key.slice(prefixLength);
+			const value = searchParams.get(key);
+			if (value) {
+				ruleDomains[domain] = value;
+			}
+		}
+	}
+
 	return {
 		cursorPosition: 0,
 		tab:
@@ -350,6 +372,12 @@ function initState(
 			bracketSameLine:
 				searchParams.get("bracketSameLine") === "true" ||
 				defaultPlaygroundState.settings.bracketSameLine,
+			whitespaceSensitivity:
+				(searchParams.get("whitespaceSensitivity") as WhitespaceSensitivity) ??
+				defaultPlaygroundState.settings.whitespaceSensitivity,
+			indentScriptAndStyle:
+				searchParams.get("indentScriptAndStyle") === "true" ||
+				defaultPlaygroundState.settings.indentScriptAndStyle,
 			lintRules:
 				(searchParams.get("lintRules") as LintRules) ??
 				defaultPlaygroundState.settings.lintRules,
@@ -368,6 +396,7 @@ function initState(
 			allowComments:
 				searchParams.get("allowComments") === "true" ||
 				defaultPlaygroundState.settings.allowComments,
+			ruleDomains,
 		},
 	};
 }

--- a/src/playground/tabs/SettingsTab.tsx
+++ b/src/playground/tabs/SettingsTab.tsx
@@ -9,6 +9,7 @@ import {
 	Semicolons,
 	SourceType,
 	TrailingCommas,
+	WhitespaceSensitivity,
 } from "@/playground/types";
 import {
 	classnames,
@@ -54,6 +55,8 @@ export default function SettingsTab({
 			arrowParentheses,
 			bracketSpacing,
 			bracketSameLine,
+			indentScriptAndStyle,
+			whitespaceSensitivity,
 			lintRules,
 			enabledLinting,
 			analyzerFixMode,
@@ -113,6 +116,16 @@ export default function SettingsTab({
 		setPlaygroundState,
 		"bracketSameLine",
 	);
+	const setIndentScriptAndStyle = createPlaygroundSettingsSetter(
+		setPlaygroundState,
+		"indentScriptAndStyle",
+	);
+
+	const setWhitespaceSensitivity = createPlaygroundSettingsSetter(
+		setPlaygroundState,
+		"whitespaceSensitivity",
+	);
+
 	const setLintRules = createPlaygroundSettingsSetter(
 		setPlaygroundState,
 		"lintRules",
@@ -292,6 +305,10 @@ export default function SettingsTab({
 				setBracketSpacing={setBracketSpacing}
 				bracketSameLine={bracketSameLine}
 				setBracketSameLine={setBracketSameLine}
+				indentScriptAndStyle={indentScriptAndStyle}
+				setIndentScriptAndStyle={setIndentScriptAndStyle}
+				whitespaceSensitivity={whitespaceSensitivity}
+				setWhitespaceSensitivity={setWhitespaceSensitivity}
 			/>
 			<LinterSettings
 				lintRules={lintRules}
@@ -631,6 +648,10 @@ function FormatterSettings({
 	setBracketSpacing,
 	bracketSameLine,
 	setBracketSameLine,
+	indentScriptAndStyle,
+	setIndentScriptAndStyle,
+	whitespaceSensitivity,
+	setWhitespaceSensitivity,
 }: {
 	lineWidth: number;
 	setLineWidth: (value: number) => void;
@@ -656,6 +677,10 @@ function FormatterSettings({
 	setBracketSpacing: (value: boolean) => void;
 	bracketSameLine: boolean;
 	setBracketSameLine: (value: boolean) => void;
+	indentScriptAndStyle: boolean;
+	setIndentScriptAndStyle: (value: boolean) => void;
+	whitespaceSensitivity: WhitespaceSensitivity;
+	setWhitespaceSensitivity: (value: WhitespaceSensitivity) => void;
 }) {
 	return (
 		<>
@@ -808,6 +833,33 @@ function FormatterSettings({
 						checked={bracketSameLine}
 						onChange={(e) => setBracketSameLine(e.target.checked)}
 					/>
+				</div>
+
+				<h3>HTML</h3>
+				<div className="field-row">
+					<label htmlFor="indentScriptAndStyle">Indent Script And Style</label>
+					<input
+						id="indentScriptAndStyle"
+						name="indentScriptAndStyle"
+						type="checkbox"
+						checked={indentScriptAndStyle}
+						onChange={(e) => setIndentScriptAndStyle(e.target.checked)}
+					/>
+				</div>
+				<div className="field-row">
+					<label htmlFor="whitespaceSensitivity">Whitespace Sensitivity</label>
+					<select
+						id="whitespaceSensitivity"
+						name="whitespaceSensitivity"
+						value={whitespaceSensitivity}
+						onChange={(e) =>
+							setWhitespaceSensitivity(e.target.value as WhitespaceSensitivity)
+						}
+					>
+						<option value={WhitespaceSensitivity.Css}>CSS</option>
+						<option value={WhitespaceSensitivity.Strict}>Strict</option>
+						<option value={WhitespaceSensitivity.Ignore}>Ignore</option>
+					</select>
 				</div>
 			</section>
 		</>

--- a/src/playground/types.ts
+++ b/src/playground/types.ts
@@ -73,6 +73,12 @@ export enum AttributePosition {
 	Multiline = "multiline",
 }
 
+export enum WhitespaceSensitivity {
+	Css = "css",
+	Strict = "strict",
+	Ignore = "ignore",
+}
+
 export type PrettierOutput =
 	| { type: "SUCCESS"; code: string; ir: string }
 	| { type: "ERROR"; stack: string };
@@ -142,6 +148,8 @@ export interface PlaygroundSettings {
 	unsafeParameterDecoratorsEnabled: boolean;
 	allowComments: boolean;
 	ruleDomains: Record<RuleDomain, RuleDomainValue>;
+	indentScriptAndStyle: boolean;
+	whitespaceSensitivity: WhitespaceSensitivity;
 }
 
 export interface PlaygroundFileState {
@@ -191,6 +199,8 @@ export const defaultPlaygroundState: PlaygroundState = {
 		unsafeParameterDecoratorsEnabled: true,
 		allowComments: true,
 		ruleDomains: {},
+		indentScriptAndStyle: false,
+		whitespaceSensitivity: WhitespaceSensitivity.Css,
 	},
 };
 

--- a/src/playground/workers/biomeWorker.ts
+++ b/src/playground/workers/biomeWorker.ts
@@ -88,6 +88,8 @@ self.addEventListener("message", async (e) => {
 				arrowParentheses,
 				bracketSpacing,
 				bracketSameLine,
+				indentScriptAndStyle,
+				whitespaceSensitivity,
 				enabledAssist,
 				unsafeParameterDecoratorsEnabled,
 				allowComments,
@@ -153,6 +155,12 @@ self.addEventListener("message", async (e) => {
 				json: {
 					parser: {
 						allowComments,
+					},
+				},
+				html: {
+					formatter: {
+						indentScriptAndStyle,
+						whitespaceSensitivity,
 					},
 				},
 			};

--- a/src/playground/workers/prettierWorker.ts
+++ b/src/playground/workers/prettierWorker.ts
@@ -20,6 +20,7 @@ import {
 	isTypeScriptFilename,
 	isVueFilename,
 } from "@/playground/utils";
+import type { WhitespaceSensitivity } from "@biomejs/wasm-web";
 import * as prettier from "prettier";
 // @ts-expect-error
 import * as pluginSvelte from "prettier-plugin-svelte/browser";
@@ -57,6 +58,8 @@ self.addEventListener("message", async (e) => {
 				bracketSpacing,
 				bracketSameLine,
 				attributePosition,
+				indentScriptAndStyle,
+				whitespaceSensitivity,
 			} = settings;
 			const code = e.data.code as string;
 			const filename = e.data.filename as string;
@@ -76,6 +79,8 @@ self.addEventListener("message", async (e) => {
 				bracketSameLine,
 				singleAttributePerLine:
 					attributePosition === AttributePosition.Multiline,
+				vueIndentScriptAndStyle: indentScriptAndStyle,
+				whitespaceSensitivity,
 			});
 
 			self.postMessage({
@@ -108,6 +113,8 @@ async function formatWithPrettier(
 		bracketSpacing: boolean;
 		bracketSameLine: boolean;
 		singleAttributePerLine?: boolean;
+		vueIndentScriptAndStyle: boolean;
+		whitespaceSensitivity: WhitespaceSensitivity;
 	},
 ): Promise<PrettierOutput> {
 	try {
@@ -138,6 +145,8 @@ async function formatWithPrettier(
 			bracketSameLine: options.bracketSameLine,
 			singleAttributePerLine: options.singleAttributePerLine ?? false,
 			embeddedLanguageFormatting: "off",
+			vueIndentScriptAndStyle: options.vueIndentScriptAndStyle,
+			htmlWhitespaceSensitivity: options.whitespaceSensitivity,
 		};
 
 		// @ts-expect-error


### PR DESCRIPTION
## Summary

<!-- 
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

Adds HTML specific formatter options to the playground's settings. I've verified that they get passed into both biome and prettier's configuration. It won't be obvious it's working for biome's formatter because the logic for these options isn't entirely complete in biome.

> [!CAUTION]
> This PR is stacked on the following PRs. **Do not merge it without merging the others and rebasing this branch.** To review this PR, look at the last commit only.
> - #1727
