### PR TITLE
ci: enable ja-translation workflow for next branch

### DIFF
--- a/.github/workflows/ja-translation.yaml
+++ b/.github/workflows/ja-translation.yaml
@@ -3,7 +3,7 @@ name: Checks for Japanese documentation
 on:
   workflow_dispatch:
   pull_request:
-    branches: [main]
+    branches: [main, next]
     paths:
       - "src/content/docs/ja/**"
 


### PR DESCRIPTION
## Summary

Documentation for Biome v2 #1737 is going on, we should have textlint checks before merging to the `next` branch.