### PR TITLE
feat: add objectWrap option to the playground

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
 		"mermaid": "10.9.3",
 		"postcss": "8.4.49",
 		"postcss-mixins": "11.0.3",
-		"prettier": "3.4.2",
+		"prettier": "3.5.1",
 		"prettier-plugin-svelte": "3.3.2",
 		"react": "18.3.1",
 		"react-dom": "18.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,11 +133,11 @@ importers:
         specifier: 11.0.3
         version: 11.0.3(postcss@8.4.49)
       prettier:
-        specifier: 3.4.2
-        version: 3.4.2
+        specifier: 3.5.1
+        version: 3.5.1
       prettier-plugin-svelte:
         specifier: 3.3.2
-        version: 3.3.2(prettier@3.4.2)(svelte@4.2.19)
+        version: 3.3.2(prettier@3.5.1)(svelte@4.2.19)
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -405,7 +405,7 @@ packages:
 
   '@biomejs/wasm-web@https://pkg.pr.new/biomejs/biome/@biomejs/wasm-web@main':
     resolution: {tarball: https://pkg.pr.new/biomejs/biome/@biomejs/wasm-web@main}
-    version: 0.0.0-rev.e3ededb0979930aa5467d9d2e13f4cec1f79444b
+    version: 0.0.0-rev.177f005aa8c6f71c2034b2a266125e461ac2a9f5
 
   '@braintree/sanitize-url@6.0.4':
     resolution: {integrity: sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A==}
@@ -3421,8 +3421,8 @@ packages:
       prettier: ^3.0.0
       svelte: ^3.2.0 || ^4.0.0-next.0 || ^5.0.0-next.0
 
-  prettier@3.4.2:
-    resolution: {integrity: sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==}
+  prettier@3.5.1:
+    resolution: {integrity: sha512-hPpFQvHwL3Qv5AdRvBFMhnKo4tYxp0ReXiPn2bxkiohEX6mBeBwEpBSQTkD458RaaDKQMYSp4hX4UtfUTA5wDw==}
     engines: {node: '>=14'}
     hasBin: true
 
@@ -8440,12 +8440,12 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier-plugin-svelte@3.3.2(prettier@3.4.2)(svelte@4.2.19):
+  prettier-plugin-svelte@3.3.2(prettier@3.5.1)(svelte@4.2.19):
     dependencies:
-      prettier: 3.4.2
+      prettier: 3.5.1
       svelte: 4.2.19
 
-  prettier@3.4.2: {}
+  prettier@3.5.1: {}
 
   prh@5.4.4:
     dependencies:

--- a/src/playground/PlaygroundLoader.tsx
+++ b/src/playground/PlaygroundLoader.tsx
@@ -6,6 +6,7 @@ import {
 	type IndentStyle,
 	type LintRules,
 	LoadingState,
+	type ObjectWrap,
 	type PlaygroundSettings,
 	type PlaygroundState,
 	type QuoteProperties,
@@ -372,6 +373,9 @@ function initState(
 			bracketSameLine:
 				searchParams.get("bracketSameLine") === "true" ||
 				defaultPlaygroundState.settings.bracketSameLine,
+			objectWrap:
+				(searchParams.get("objectWrap") as ObjectWrap) ??
+				defaultPlaygroundState.settings.objectWrap,
 			whitespaceSensitivity:
 				(searchParams.get("whitespaceSensitivity") as WhitespaceSensitivity) ??
 				defaultPlaygroundState.settings.whitespaceSensitivity,

--- a/src/playground/tabs/SettingsTab.tsx
+++ b/src/playground/tabs/SettingsTab.tsx
@@ -3,6 +3,7 @@ import {
 	AttributePosition,
 	IndentStyle,
 	LintRules,
+	ObjectWrap,
 	type PlaygroundState,
 	QuoteProperties,
 	QuoteStyle,
@@ -55,6 +56,7 @@ export default function SettingsTab({
 			arrowParentheses,
 			bracketSpacing,
 			bracketSameLine,
+			objectWrap,
 			indentScriptAndStyle,
 			whitespaceSensitivity,
 			lintRules,
@@ -115,6 +117,10 @@ export default function SettingsTab({
 	const setBracketSameLine = createPlaygroundSettingsSetter(
 		setPlaygroundState,
 		"bracketSameLine",
+	);
+	const setObjectWrap = createPlaygroundSettingsSetter(
+		setPlaygroundState,
+		"objectWrap",
 	);
 	const setIndentScriptAndStyle = createPlaygroundSettingsSetter(
 		setPlaygroundState,
@@ -305,6 +311,8 @@ export default function SettingsTab({
 				setBracketSpacing={setBracketSpacing}
 				bracketSameLine={bracketSameLine}
 				setBracketSameLine={setBracketSameLine}
+				objectWrap={objectWrap}
+				setObjectWrap={setObjectWrap}
 				indentScriptAndStyle={indentScriptAndStyle}
 				setIndentScriptAndStyle={setIndentScriptAndStyle}
 				whitespaceSensitivity={whitespaceSensitivity}
@@ -648,6 +656,8 @@ function FormatterSettings({
 	setBracketSpacing,
 	bracketSameLine,
 	setBracketSameLine,
+	objectWrap,
+	setObjectWrap,
 	indentScriptAndStyle,
 	setIndentScriptAndStyle,
 	whitespaceSensitivity,
@@ -677,6 +687,8 @@ function FormatterSettings({
 	setBracketSpacing: (value: boolean) => void;
 	bracketSameLine: boolean;
 	setBracketSameLine: (value: boolean) => void;
+	objectWrap: ObjectWrap;
+	setObjectWrap: (value: ObjectWrap) => void;
 	indentScriptAndStyle: boolean;
 	setIndentScriptAndStyle: (value: boolean) => void;
 	whitespaceSensitivity: WhitespaceSensitivity;
@@ -833,6 +845,18 @@ function FormatterSettings({
 						checked={bracketSameLine}
 						onChange={(e) => setBracketSameLine(e.target.checked)}
 					/>
+				</div>
+				<div className="field-row">
+					<label htmlFor="objectWrap">Object Wrap</label>
+					<select
+						id="objectWrap"
+						name="objectWrap"
+						value={objectWrap ?? ObjectWrap.Preserve}
+						onChange={(e) => setObjectWrap(e.target.value as ObjectWrap)}
+					>
+						<option value={ObjectWrap.Preserve}>Preserve</option>
+						<option value={ObjectWrap.Collapse}>Collapse</option>
+					</select>
 				</div>
 
 				<h3>HTML</h3>

--- a/src/playground/types.ts
+++ b/src/playground/types.ts
@@ -68,9 +68,15 @@ export enum ArrowParentheses {
 	Always = "always",
 	AsNeeded = "as-needed",
 }
+
 export enum AttributePosition {
 	Auto = "auto",
 	Multiline = "multiline",
+}
+
+export enum ObjectWrap {
+	Preserve = "preserve",
+	Collapse = "collapse",
 }
 
 export enum WhitespaceSensitivity {
@@ -141,6 +147,7 @@ export interface PlaygroundSettings {
 	attributePosition: AttributePosition;
 	bracketSpacing: boolean;
 	bracketSameLine: boolean;
+	objectWrap: ObjectWrap;
 	lintRules: LintRules;
 	enabledLinting: boolean;
 	analyzerFixMode: FixFileMode;
@@ -192,6 +199,7 @@ export const defaultPlaygroundState: PlaygroundState = {
 		attributePosition: AttributePosition.Auto,
 		bracketSpacing: true,
 		bracketSameLine: false,
+		objectWrap: ObjectWrap.Preserve,
 		lintRules: LintRules.Recommended,
 		enabledLinting: true,
 		analyzerFixMode: "safeFixes",

--- a/src/playground/workers/biomeWorker.ts
+++ b/src/playground/workers/biomeWorker.ts
@@ -5,6 +5,7 @@ import {
 	IndentStyle,
 	LintRules,
 	LoadingState,
+	ObjectWrap,
 	type PlaygroundSettings,
 	QuoteProperties,
 	QuoteStyle,
@@ -88,6 +89,7 @@ self.addEventListener("message", async (e) => {
 				arrowParentheses,
 				bracketSpacing,
 				bracketSameLine,
+				objectWrap,
 				indentScriptAndStyle,
 				whitespaceSensitivity,
 				enabledAssist,
@@ -106,6 +108,8 @@ self.addEventListener("message", async (e) => {
 					indentWidth,
 					attributePosition:
 						attributePosition === AttributePosition.Auto ? "auto" : "multiline",
+					objectWrap:
+						objectWrap === ObjectWrap.Preserve ? "preserve" : "collapse",
 				},
 
 				linter: {

--- a/src/playground/workers/prettierWorker.ts
+++ b/src/playground/workers/prettierWorker.ts
@@ -2,6 +2,7 @@ import {
 	ArrowParentheses,
 	AttributePosition,
 	IndentStyle,
+	type ObjectWrap,
 	type PlaygroundSettings,
 	type PrettierOptions,
 	type PrettierOutput,
@@ -58,6 +59,7 @@ self.addEventListener("message", async (e) => {
 				bracketSpacing,
 				bracketSameLine,
 				attributePosition,
+				objectWrap,
 				indentScriptAndStyle,
 				whitespaceSensitivity,
 			} = settings;
@@ -79,6 +81,7 @@ self.addEventListener("message", async (e) => {
 				bracketSameLine,
 				singleAttributePerLine:
 					attributePosition === AttributePosition.Multiline,
+				objectWrap,
 				vueIndentScriptAndStyle: indentScriptAndStyle,
 				whitespaceSensitivity,
 			});
@@ -113,6 +116,7 @@ async function formatWithPrettier(
 		bracketSpacing: boolean;
 		bracketSameLine: boolean;
 		singleAttributePerLine?: boolean;
+		objectWrap: ObjectWrap;
 		vueIndentScriptAndStyle: boolean;
 		whitespaceSensitivity: WhitespaceSensitivity;
 	},
@@ -144,6 +148,7 @@ async function formatWithPrettier(
 			bracketSpacing: options.bracketSpacing,
 			bracketSameLine: options.bracketSameLine,
 			singleAttributePerLine: options.singleAttributePerLine ?? false,
+			objectWrap: options.objectWrap,
 			embeddedLanguageFormatting: "off",
 			vueIndentScriptAndStyle: options.vueIndentScriptAndStyle,
 			htmlWhitespaceSensitivity: options.whitespaceSensitivity,


### PR DESCRIPTION
## Summary

Added `objectWrap` options to the playground. Also I updated Prettier to v3.5.1 (latest) to get `objectWrap` support on Prettier that was introduced in v3.5.0.

<img width="1414" alt="image" src="https://github.com/user-attachments/assets/681ed58c-d8df-442b-8e40-7499843f0494" />
