### PR TITLE
docs: Give explicit lspBin example

### DIFF
--- a/src/content/docs/reference/vscode.mdx
+++ b/src/content/docs/reference/vscode.mdx
@@ -52,7 +52,7 @@ The extension automatically loads the `biome.json` file from the workspace’s r
 
 The extension tries to use Biome from your project's local dependencies (`node_modules/@biomejs/biome`). We recommend adding Biome as a project dependency to ensure that NPM scripts and the extension use the same Biome version.
 
-You can also explicitly specify the `Biome` binary the extension should use by configuring the `biome.lspBin` setting in your editor options.
+You can also explicitly specify the `Biome` binary the extension should use by configuring the `biome.lspBin` setting in your editor options to point to the binary. For example `"node_modules/@biomejs/biome/bin/biome"`.
 
 If the project has no dependency on Biome and no explicit path is configured, the extension uses the Biome version included in its bundle.
 


### PR DESCRIPTION
## Summary

I ran into the same issue as the users in #429 and #1713

So I figured I make the information a bit more explicit. Not sure why the binary wasn't found automatically in the first place, but this helps :)