### PR TITLE
fix: update WASM API usages for Biome v2.0

### DIFF
--- a/src/playground/Playground.tsx
+++ b/src/playground/Playground.tsx
@@ -8,7 +8,6 @@ import DiagnosticsConsoleTab from "@/playground/tabs/DiagnosticsConsoleTab";
 import DiagnosticsListTab from "@/playground/tabs/DiagnosticsListTab";
 import FormatterCodeTab from "@/playground/tabs/FormatterCodeTab";
 import FormatterIrTab from "@/playground/tabs/FormatterIrTab";
-import ImportSortingTab from "@/playground/tabs/ImportSortingTab";
 import SettingsTab from "@/playground/tabs/SettingsTab";
 import SyntaxTab from "@/playground/tabs/SyntaxTab";
 import {
@@ -268,16 +267,6 @@ export default function Playground({
 					title: "Control Flow Graph",
 					children: (
 						<ControlFlowTab graph={biomeOutput.analysis.controlFlowGraph} />
-					),
-				},
-				{
-					key: PlaygroundTab.ImportSorting,
-					title: "Import Sorting",
-					children: (
-						<ImportSortingTab
-							code={biomeOutput.importSorting.code}
-							extensions={codeMirrorExtensions}
-						/>
 					),
 				},
 				{

--- a/src/playground/PlaygroundLoader.tsx
+++ b/src/playground/PlaygroundLoader.tsx
@@ -28,6 +28,7 @@ import {
 	isTypeScriptFilename,
 	normalizeFilename,
 } from "@/playground/utils";
+import type { FixFileMode } from "@biomejs/wasm-web";
 import {
 	type Dispatch,
 	type SetStateAction,
@@ -355,9 +356,12 @@ function initState(
 			enabledLinting:
 				searchParams.get("enabledLinting") === "true" ||
 				defaultPlaygroundState.settings.enabledLinting,
-			importSortingEnabled:
-				searchParams.get("importSortingEnabled") === "true" ||
-				defaultPlaygroundState.settings.importSortingEnabled,
+			analyzerFixMode:
+				(searchParams.get("analyzerFixMode") as FixFileMode) ??
+				defaultPlaygroundState.settings.analyzerFixMode,
+			enabledAssist:
+				searchParams.get("enabledAssist") === "true" ||
+				defaultPlaygroundState.settings.enabledAssist,
 			unsafeParameterDecoratorsEnabled:
 				searchParams.get("unsafeParameterDecoratorsEnabled") === "true" ||
 				defaultPlaygroundState.settings.unsafeParameterDecoratorsEnabled,

--- a/src/playground/components/DiagnosticsPane.tsx
+++ b/src/playground/components/DiagnosticsPane.tsx
@@ -18,7 +18,7 @@ export default function DiagnosticsPane({
 	console,
 	code,
 }: Props) {
-	const [tab, setTab] = useState("diagnostics");
+	const [tab, setTab] = useState<"diagnostics" | "console">("diagnostics");
 
 	return (
 		<Tabs

--- a/src/playground/components/Tabs.tsx
+++ b/src/playground/components/Tabs.tsx
@@ -12,16 +12,16 @@ interface Tab<K> {
 interface Props<K> {
 	className?: string;
 	selectedTab: string;
-	onSelect: (key: string) => void;
+	onSelect: (key: K) => void;
 	tabs: Tab<K>[];
 }
 
-export default function Tabs({
+export default function Tabs<K extends string = PlaygroundTab>({
 	className,
 	tabs,
 	selectedTab,
 	onSelect,
-}: Props<PlaygroundTab>) {
+}: Props<K>) {
 	return (
 		<div className={className}>
 			<ul className="react-tabs__tab-list" role="tablist">

--- a/src/playground/tabs/ImportSortingTab.tsx
+++ b/src/playground/tabs/ImportSortingTab.tsx
@@ -1,9 +1,0 @@
-import CodeMirror, { type BiomeExtension } from "@/playground/CodeMirror";
-interface Props {
-	code: string;
-	extensions: BiomeExtension[];
-}
-
-export default function ImportSortingTab({ code, extensions }: Props) {
-	return <CodeMirror value={code} extensions={extensions} readOnly={true} />;
-}

--- a/src/playground/tabs/SettingsTab.tsx
+++ b/src/playground/tabs/SettingsTab.tsx
@@ -53,7 +53,7 @@ export default function SettingsTab({
 			lintRules,
 			enabledLinting,
 			analyzerFixMode,
-			importSortingEnabled,
+			enabledAssist,
 			unsafeParameterDecoratorsEnabled,
 			allowComments,
 			attributePosition,
@@ -121,9 +121,9 @@ export default function SettingsTab({
 		"analyzerFixMode",
 	);
 
-	const setImportSorting = createPlaygroundSettingsSetter(
+	const setEnabledAssist = createPlaygroundSettingsSetter(
 		setPlaygroundState,
-		"importSortingEnabled",
+		"enabledAssist",
 	);
 
 	const setUnsafeParameterDecoratorsEnabled = createPlaygroundSettingsSetter(
@@ -291,9 +291,9 @@ export default function SettingsTab({
 				analyzerFixMode={analyzerFixMode}
 				setAnalyzerFixMode={setAnalyzerFixMode}
 			/>
-			<ImportSortingSettings
-				importSortingEnabled={importSortingEnabled}
-				setImportSorting={setImportSorting}
+			<AssistSettings
+				enabledAssist={enabledAssist}
+				setEnabledAssist={setEnabledAssist}
 			/>
 			<SyntaxSettings
 				filename={currentFile}
@@ -852,12 +852,12 @@ function LinterSettings({
 						aria-describedby="analyzer-fix-mode-description"
 						name="analyzer-fix-mode"
 						disabled={!enabledLinting}
-						value={analyzerFixMode ?? "SafeFixes"}
+						value={analyzerFixMode ?? "safeFixes"}
 						onChange={(e) => setAnalyzerFixMode(e.target.value as FixFileMode)}
 					>
-						<option value={"SafeFixes"}>Safe Fixes</option>
-						<option value={"SafeAndUnsafeFixes"}>Safe and Unsafe Fixes</option>
-						<option value={"ApplySuppressions"}>Apply Suppressions</option>
+						<option value={"safeFixes"}>Safe Fixes</option>
+						<option value={"safeAndUnsafeFixes"}>Safe and Unsafe Fixes</option>
+						<option value={"applySuppressions"}>Apply Suppressions</option>
 					</select>
 				</div>
 			</section>
@@ -865,26 +865,26 @@ function LinterSettings({
 	);
 }
 
-export function ImportSortingSettings({
-	importSortingEnabled,
-	setImportSorting,
+export function AssistSettings({
+	enabledAssist,
+	setEnabledAssist,
 }: {
-	importSortingEnabled: boolean;
-	setImportSorting: (value: boolean) => void;
+	enabledAssist: boolean;
+	setEnabledAssist: (value: boolean) => void;
 }) {
 	return (
 		<>
-			<h2>Import sorting options</h2>
+			<h2>Assist options</h2>
 			<section>
 				<div className="field-row">
 					<input
-						id="import-sorting-enabled"
-						name="import-sorting-enabled"
+						id="assist-enabled"
+						name="assist-enabled"
 						type="checkbox"
-						checked={importSortingEnabled}
-						onChange={(e) => setImportSorting(e.target.checked)}
+						checked={enabledAssist}
+						onChange={(e) => setEnabledAssist(e.target.checked)}
 					/>
-					<label htmlFor="import-sorting-enabled">Import sorting enabled</label>
+					<label htmlFor="assist-enabled">Assist enabled</label>
 				</div>
 			</section>
 		</>

--- a/src/playground/types.ts
+++ b/src/playground/types.ts
@@ -9,7 +9,6 @@ export enum PlaygroundTab {
 	FormatterIr = "formatter-ir",
 	Syntax = "syntax",
 	ControlFlowGraph = "control-flow-graph",
-	ImportSorting = "import-sorting",
 	Console = "console",
 	Settings = "settings",
 	AnalyzerFixes = "analyzer-fixes",
@@ -96,9 +95,6 @@ export interface BiomeOutput {
 		/** The snippet with lint fixes applied. */
 		fixed: string;
 	};
-	importSorting: {
-		code: string;
-	};
 }
 
 export const emptyBiomeOutput: BiomeOutput = {
@@ -118,9 +114,6 @@ export const emptyBiomeOutput: BiomeOutput = {
 		controlFlowGraph: "",
 		fixed: "",
 	},
-	importSorting: {
-		code: "",
-	},
 };
 
 export interface PlaygroundSettings {
@@ -139,7 +132,7 @@ export interface PlaygroundSettings {
 	lintRules: LintRules;
 	enabledLinting: boolean;
 	analyzerFixMode: FixFileMode;
-	importSortingEnabled: boolean;
+	enabledAssist: boolean;
 	unsafeParameterDecoratorsEnabled: boolean;
 	allowComments: boolean;
 }
@@ -186,8 +179,8 @@ export const defaultPlaygroundState: PlaygroundState = {
 		bracketSameLine: false,
 		lintRules: LintRules.Recommended,
 		enabledLinting: true,
-		analyzerFixMode: "SafeFixes",
-		importSortingEnabled: true,
+		analyzerFixMode: "safeFixes",
+		enabledAssist: true,
 		unsafeParameterDecoratorsEnabled: true,
 		allowComments: true,
 	},

--- a/src/playground/workers/biomeWorker.ts
+++ b/src/playground/workers/biomeWorker.ts
@@ -12,13 +12,14 @@ import {
 } from "@/playground/types";
 import init, {
 	DiagnosticPrinter,
-	type PartialConfiguration as Configuration,
+	type Configuration,
 	type BiomePath,
 	type RuleCategories,
 	Workspace,
 } from "@biomejs/wasm-web";
 
 let workspace: Workspace | null = null;
+let projectKey: number | null = null;
 let fileCounter = 0;
 
 type File = {
@@ -34,11 +35,7 @@ let configuration: undefined | Configuration;
 let fullSettings: undefined | PlaygroundSettings;
 
 function getPathForFile(file: File): BiomePath {
-	return {
-		path: file.filename,
-		kind: ["Handleable"],
-		was_written: false,
-	};
+	return file.filename;
 }
 
 self.addEventListener("message", async (e) => {
@@ -54,8 +51,9 @@ self.addEventListener("message", async (e) => {
 				}
 
 				workspace = new Workspace();
-				workspace.registerProjectFolder({
-					setAsCurrentWorkspace: true,
+				projectKey = workspace.openProject({
+					path: "",
+					openUninitialized: true,
 				});
 
 				self.postMessage({ type: "init", loadingState: LoadingState.Success });
@@ -68,7 +66,7 @@ self.addEventListener("message", async (e) => {
 		}
 
 		case "updateSettings": {
-			if (!workspace) {
+			if (!workspace || projectKey == null) {
 				console.error("Workspace was not initialized");
 				break;
 			}
@@ -89,7 +87,7 @@ self.addEventListener("message", async (e) => {
 				arrowParentheses,
 				bracketSpacing,
 				bracketSameLine,
-				importSortingEnabled,
+				enabledAssist,
 				unsafeParameterDecoratorsEnabled,
 				allowComments,
 				attributePosition,
@@ -110,8 +108,8 @@ self.addEventListener("message", async (e) => {
 					enabled: enabledLinting,
 				},
 
-				organizeImports: {
-					enabled: importSortingEnabled,
+				assist: {
+					enabled: enabledAssist,
 				},
 
 				javascript: {
@@ -167,7 +165,14 @@ self.addEventListener("message", async (e) => {
 				}
 				case LintRules.All: {
 					configuration.linter!.rules = {
-						all: true,
+						a11y: "on",
+						complexity: "on",
+						correctness: "on",
+						nursery: "on",
+						performance: "on",
+						security: "on",
+						style: "on",
+						suspicious: "on",
 					};
 					break;
 				}
@@ -175,13 +180,13 @@ self.addEventListener("message", async (e) => {
 
 			workspace.updateSettings({
 				configuration,
-				gitignore_matches: [],
+				projectKey,
 			});
 			break;
 		}
 
 		case "update": {
-			if (!workspace) {
+			if (!workspace || !projectKey) {
 				console.error("Workspace was not initialized");
 				break;
 			}
@@ -198,9 +203,13 @@ self.addEventListener("message", async (e) => {
 				};
 
 				workspace.openFile({
+					projectKey,
 					path: getPathForFile(file),
-					version: 0,
-					content: code,
+					content: {
+						type: "fromClient",
+						content: code,
+						version: 0,
+					},
 				});
 			} else {
 				file = {
@@ -211,21 +220,27 @@ self.addEventListener("message", async (e) => {
 				};
 
 				workspace.openFile({
+					projectKey,
 					path: getPathForFile(file),
-					version: file.version,
-					content: code,
+					content: {
+						type: "fromClient",
+						content: code,
+						version: file.version,
+					},
 				});
 			}
 			files.set(filename, file);
 			const path = getPathForFile(file);
 			const fileFeatures = workspace.fileFeatures({
-				features: ["Debug", "Format", "Lint", "OrganizeImports"],
+				projectKey,
 				path,
+				features: ["debug", "format", "lint", "assist"],
 			});
 
 			const syntaxTree =
-				fileFeatures.features_supported.get("Debug") === "Supported"
+				fileFeatures.featuresSupported.get("debug") === "supported"
 					? workspace.getSyntaxTree({
+							projectKey,
 							path,
 						})
 					: { ast: "Not supported", cst: "Not supported" };
@@ -233,8 +248,9 @@ self.addEventListener("message", async (e) => {
 			let controlFlowGraph = "";
 			try {
 				controlFlowGraph =
-					fileFeatures.features_supported.get("Debug") === "Supported"
+					fileFeatures.featuresSupported.get("debug") === "supported"
 						? workspace.getControlFlowGraph({
+								projectKey,
 								path,
 								cursor: cursorPosition,
 							})
@@ -247,8 +263,9 @@ self.addEventListener("message", async (e) => {
 			let formatterIr = "";
 			try {
 				formatterIr =
-					fileFeatures.features_supported.get("Debug") === "Supported"
+					fileFeatures.featuresSupported.get("debug") === "supported"
 						? workspace.getFormatterIr({
+								projectKey,
 								path,
 							})
 						: "Not supported";
@@ -257,33 +274,25 @@ self.addEventListener("message", async (e) => {
 				formatterIr = "Can't format";
 			}
 
-			const importSorting =
-				fileFeatures.features_supported.get("OrganizeImports") === "Supported"
-					? workspace.organizeImports({
-							path,
-						})
-					: {
-							code:
-								fileFeatures.features_supported.get("OrganizeImports") ??
-								"Not supported",
-						};
+			// TODO: Run assists
 
 			const categories: RuleCategories = [];
 			if (configuration?.formatter?.enabled) {
-				categories.push("Syntax");
+				categories.push("syntax");
 			}
 			if (configuration?.linter?.enabled) {
-				categories.push("Lint");
+				categories.push("lint");
 			}
 			const diagnosticsResult = workspace.pullDiagnostics({
+				projectKey,
 				path,
 				categories: categories,
-				max_diagnostics: Number.MAX_SAFE_INTEGER,
+				maxDiagnostics: Number.MAX_SAFE_INTEGER,
 				only: [],
 				skip: [],
 			});
 
-			const printer = new DiagnosticPrinter(path.path, code);
+			const printer = new DiagnosticPrinter(path, code);
 			for (const diag of diagnosticsResult.diagnostics) {
 				printer.print_verbose(diag);
 			}
@@ -293,8 +302,9 @@ self.addEventListener("message", async (e) => {
 			};
 			try {
 				printed =
-					fileFeatures.features_supported.get("Format") === "Supported"
+					fileFeatures.featuresSupported.get("format") === "supported"
 						? workspace.formatFile({
+								projectKey,
 								path,
 							})
 						: { code: "Not supported" };
@@ -310,14 +320,15 @@ self.addEventListener("message", async (e) => {
 			};
 			try {
 				fixed =
-					fileFeatures.features_supported.get("Lint") === "Supported"
+					fileFeatures.featuresSupported.get("lint") === "supported"
 						? workspace.fixFile({
+								projectKey,
 								path,
 								only: [],
 								skip: [],
-								rule_categories: ["Lint"],
-								should_format: false,
-								fix_file_mode: fullSettings?.analyzerFixMode ?? "SafeFixes",
+								ruleCategories: ["lint"],
+								shouldFormat: false,
+								fixFileMode: fullSettings?.analyzerFixMode ?? "safeFixes",
 							})
 						: { code: "Not supported" };
 			} catch (e) {
@@ -345,9 +356,6 @@ self.addEventListener("message", async (e) => {
 				analysis: {
 					controlFlowGraph,
 					fixed: fixed.code,
-				},
-				importSorting: {
-					code: importSorting.code,
 				},
 			};
 


### PR DESCRIPTION
## Summary

Closes #1785 

The playground is broken now, so I updated it to follow the breaking changes will be introduced in Biome v2.0. I removed the "Import Sorting" tab for now, it will be available again as the "Assist" view.