### PR TITLE
docs: add nova extension

### DIFF
--- a/src/content/docs/guides/editors/third-party-extensions.mdx
+++ b/src/content/docs/guides/editors/third-party-extensions.mdx
@@ -10,6 +10,7 @@ These are extension maintained by other communities, that you install in your ed
 - [`coc-biome`](https://github.com/fannheyward/coc-biome): Biome extension for [`coc.nvim`](https://github.com/neoclide/coc.nvim)
 - [`sublime text`](https://www.sublimetext.com/): follow the [`LSP-biome`](https://github.com/sublimelsp/LSP-biome) installation instructions
 - [`Emacs`](https://www.gnu.org/software/emacs/): ensure you have [`lsp-mode`](https://github.com/emacs-lsp/lsp-mode) installed, follow the [`lsp-biome`](https://github.com/cxa/lsp-biome) installation instructions to enable Biome support in `lsp-mode`
+- [`Nova`](https://nova.app): install [`Biome`](https://extensions.panic.com/extensions/besya/besya.biome/) extension and follow the instructions
 
 :::note
 Is there a extension for an editor that isn't listed here? Please file a PR and we will be happy to add it to the list


### PR DESCRIPTION
## Summary

Add an extension for Nova in the Third-party extensions list

Updated:
 - src/content/docs/guides/editors/third-party-extensions.mdx