### PR TITLE
feat(playground): add the `expand` option to the playground

### DIFF
--- a/src/playground/PlaygroundLoader.tsx
+++ b/src/playground/PlaygroundLoader.tsx
@@ -3,10 +3,10 @@ import LoadingScreen from "@/playground/components/LoadingScreen";
 import {
 	type ArrowParentheses,
 	type AttributePosition,
+	type Expand,
 	type IndentStyle,
 	type LintRules,
 	LoadingState,
-	type ObjectWrap,
 	type PlaygroundSettings,
 	type PlaygroundState,
 	type QuoteProperties,
@@ -373,9 +373,9 @@ function initState(
 			bracketSameLine:
 				searchParams.get("bracketSameLine") === "true" ||
 				defaultPlaygroundState.settings.bracketSameLine,
-			objectWrap:
-				(searchParams.get("objectWrap") as ObjectWrap) ??
-				defaultPlaygroundState.settings.objectWrap,
+			expand:
+				(searchParams.get("expand") as Expand) ??
+				defaultPlaygroundState.settings.expand,
 			whitespaceSensitivity:
 				(searchParams.get("whitespaceSensitivity") as WhitespaceSensitivity) ??
 				defaultPlaygroundState.settings.whitespaceSensitivity,

--- a/src/playground/tabs/SettingsTab.tsx
+++ b/src/playground/tabs/SettingsTab.tsx
@@ -1,9 +1,9 @@
 import {
 	ArrowParentheses,
 	AttributePosition,
+	Expand,
 	IndentStyle,
 	LintRules,
-	ObjectWrap,
 	type PlaygroundState,
 	QuoteProperties,
 	QuoteStyle,
@@ -56,7 +56,7 @@ export default function SettingsTab({
 			arrowParentheses,
 			bracketSpacing,
 			bracketSameLine,
-			objectWrap,
+			expand,
 			indentScriptAndStyle,
 			whitespaceSensitivity,
 			lintRules,
@@ -118,9 +118,9 @@ export default function SettingsTab({
 		setPlaygroundState,
 		"bracketSameLine",
 	);
-	const setObjectWrap = createPlaygroundSettingsSetter(
+	const setExpand = createPlaygroundSettingsSetter(
 		setPlaygroundState,
-		"objectWrap",
+		"expand",
 	);
 	const setIndentScriptAndStyle = createPlaygroundSettingsSetter(
 		setPlaygroundState,
@@ -311,8 +311,8 @@ export default function SettingsTab({
 				setBracketSpacing={setBracketSpacing}
 				bracketSameLine={bracketSameLine}
 				setBracketSameLine={setBracketSameLine}
-				objectWrap={objectWrap}
-				setObjectWrap={setObjectWrap}
+				expand={expand}
+				setExpand={setExpand}
 				indentScriptAndStyle={indentScriptAndStyle}
 				setIndentScriptAndStyle={setIndentScriptAndStyle}
 				whitespaceSensitivity={whitespaceSensitivity}
@@ -656,8 +656,8 @@ function FormatterSettings({
 	setBracketSpacing,
 	bracketSameLine,
 	setBracketSameLine,
-	objectWrap,
-	setObjectWrap,
+	expand,
+	setExpand,
 	indentScriptAndStyle,
 	setIndentScriptAndStyle,
 	whitespaceSensitivity,
@@ -687,8 +687,8 @@ function FormatterSettings({
 	setBracketSpacing: (value: boolean) => void;
 	bracketSameLine: boolean;
 	setBracketSameLine: (value: boolean) => void;
-	objectWrap: ObjectWrap;
-	setObjectWrap: (value: ObjectWrap) => void;
+	expand: Expand;
+	setExpand: (value: Expand) => void;
 	indentScriptAndStyle: boolean;
 	setIndentScriptAndStyle: (value: boolean) => void;
 	whitespaceSensitivity: WhitespaceSensitivity;
@@ -847,15 +847,16 @@ function FormatterSettings({
 					/>
 				</div>
 				<div className="field-row">
-					<label htmlFor="objectWrap">Object Wrap</label>
+					<label htmlFor="expand">Expand</label>
 					<select
-						id="objectWrap"
-						name="objectWrap"
-						value={objectWrap ?? ObjectWrap.Preserve}
-						onChange={(e) => setObjectWrap(e.target.value as ObjectWrap)}
+						id="expand"
+						name="expand"
+						value={expand ?? Expand.Auto}
+						onChange={(e) => setExpand(e.target.value as Expand)}
 					>
-						<option value={ObjectWrap.Preserve}>Preserve</option>
-						<option value={ObjectWrap.Collapse}>Collapse</option>
+						<option value={Expand.Auto}>Auto</option>
+						<option value={Expand.Always}>Always</option>
+						<option value={Expand.Never}>Never</option>
 					</select>
 				</div>
 

--- a/src/playground/types.ts
+++ b/src/playground/types.ts
@@ -73,9 +73,10 @@ export enum AttributePosition {
 	Multiline = "multiline",
 }
 
-export enum ObjectWrap {
-	Preserve = "preserve",
-	Collapse = "collapse",
+export enum Expand {
+	Auto = "auto",
+	Always = "always",
+	Never = "never",
 }
 
 export enum WhitespaceSensitivity {
@@ -146,7 +147,7 @@ export interface PlaygroundSettings {
 	attributePosition: AttributePosition;
 	bracketSpacing: boolean;
 	bracketSameLine: boolean;
-	objectWrap: ObjectWrap;
+	expand: Expand;
 	lintRules: LintRules;
 	enabledLinting: boolean;
 	analyzerFixMode: FixFileMode;
@@ -198,7 +199,7 @@ export const defaultPlaygroundState: PlaygroundState = {
 		attributePosition: AttributePosition.Auto,
 		bracketSpacing: true,
 		bracketSameLine: false,
-		objectWrap: ObjectWrap.Preserve,
+		expand: Expand.Auto,
 		lintRules: LintRules.Recommended,
 		enabledLinting: true,
 		analyzerFixMode: "safeFixes",

--- a/src/playground/workers/biomeWorker.ts
+++ b/src/playground/workers/biomeWorker.ts
@@ -2,10 +2,10 @@ import {
 	ArrowParentheses,
 	AttributePosition,
 	type BiomeOutput,
+	Expand,
 	IndentStyle,
 	LintRules,
 	LoadingState,
-	ObjectWrap,
 	type PlaygroundSettings,
 	QuoteProperties,
 	QuoteStyle,
@@ -89,7 +89,7 @@ self.addEventListener("message", async (e) => {
 				arrowParentheses,
 				bracketSpacing,
 				bracketSameLine,
-				objectWrap,
+				expand,
 				indentScriptAndStyle,
 				whitespaceSensitivity,
 				enabledAssist,
@@ -108,8 +108,12 @@ self.addEventListener("message", async (e) => {
 					indentWidth,
 					attributePosition:
 						attributePosition === AttributePosition.Auto ? "auto" : "multiline",
-					objectWrap:
-						objectWrap === ObjectWrap.Preserve ? "preserve" : "collapse",
+					expand:
+						expand === Expand.Auto
+							? "auto"
+							: expand === Expand.Always
+								? "always"
+								: "never",
 				},
 
 				linter: {

--- a/src/playground/workers/prettierWorker.ts
+++ b/src/playground/workers/prettierWorker.ts
@@ -1,8 +1,8 @@
 import {
 	ArrowParentheses,
 	AttributePosition,
+	Expand,
 	IndentStyle,
-	type ObjectWrap,
 	type PlaygroundSettings,
 	type PrettierOptions,
 	type PrettierOutput,
@@ -59,7 +59,7 @@ self.addEventListener("message", async (e) => {
 				bracketSpacing,
 				bracketSameLine,
 				attributePosition,
-				objectWrap,
+				expand,
 				indentScriptAndStyle,
 				whitespaceSensitivity,
 			} = settings;
@@ -81,7 +81,7 @@ self.addEventListener("message", async (e) => {
 				bracketSameLine,
 				singleAttributePerLine:
 					attributePosition === AttributePosition.Multiline,
-				objectWrap,
+				expand,
 				vueIndentScriptAndStyle: indentScriptAndStyle,
 				whitespaceSensitivity,
 			});
@@ -116,7 +116,7 @@ async function formatWithPrettier(
 		bracketSpacing: boolean;
 		bracketSameLine: boolean;
 		singleAttributePerLine?: boolean;
-		objectWrap: ObjectWrap;
+		expand: Expand;
 		vueIndentScriptAndStyle: boolean;
 		whitespaceSensitivity: WhitespaceSensitivity;
 	},
@@ -148,7 +148,7 @@ async function formatWithPrettier(
 			bracketSpacing: options.bracketSpacing,
 			bracketSameLine: options.bracketSameLine,
 			singleAttributePerLine: options.singleAttributePerLine ?? false,
-			objectWrap: options.objectWrap,
+			objectWrap: options.expand === Expand.Never ? "collapse" : "preserve",
 			embeddedLanguageFormatting: "off",
 			vueIndentScriptAndStyle: options.vueIndentScriptAndStyle,
 			htmlWhitespaceSensitivity: options.whitespaceSensitivity,


### PR DESCRIPTION
## Summary

Added a new option `expand` to the playground settings.
Removed `objectWrap` as it was merged into `expand`.

See https://github.com/biomejs/biome/pull/5262 for details.