### PR TITLE
feat(playground): add language selector for single-file mode

### DIFF
--- a/src/playground/tabs/SettingsTab.tsx
+++ b/src/playground/tabs/SettingsTab.tsx
@@ -3,6 +3,7 @@ import {
 	AttributePosition,
 	Expand,
 	IndentStyle,
+	Language,
 	LintRules,
 	type PlaygroundState,
 	QuoteProperties,
@@ -16,9 +17,8 @@ import {
 	classnames,
 	createPlaygroundSettingsSetter,
 	getFileState,
-	isJsxFilename,
+	guessLanguage,
 	isScriptFilename,
-	isTypeScriptFilename,
 	modifyFilename,
 	normalizeFilename,
 } from "@/playground/utils";
@@ -260,6 +260,18 @@ export default function SettingsTab({
 		}));
 	}
 
+	const currentFileExtension = currentFile.split(".").at(-1);
+	const language =
+		Object.values(Language).find((ext) => ext === currentFileExtension) ??
+		Language.JS;
+
+	function setLanguage(language: Language): void {
+		renameFile(
+			currentFile,
+			`${currentFile.substring(0, currentFile.lastIndexOf("."))}.${language}`,
+		);
+	}
+
 	return (
 		<div className="settings-tab">
 			<section className="settings-tab-buttons">
@@ -276,7 +288,9 @@ export default function SettingsTab({
 				</button>
 			</section>
 
-			{!singleFileMode && (
+			{singleFileMode ? (
+				<LanguageView language={language} setLanguage={setLanguage} />
+			) : (
 				<FileView
 					currentFile={currentFile}
 					files={Object.keys(files)}
@@ -343,6 +357,38 @@ export default function SettingsTab({
 				setAllowComments={setAllowComments}
 			/>
 		</div>
+	);
+}
+
+function LanguageView({
+	language,
+	setLanguage,
+}: { language: Language; setLanguage: (language: Language) => void }) {
+	return (
+		<section>
+			<div className="field-row">
+				<label htmlFor="language">Language</label>
+				<select
+					id="language"
+					name="language"
+					value={language ?? Language.TSX}
+					onChange={(e) => setLanguage(e.target.value as Language)}
+				>
+					<option value={Language.JS}>JavaScript</option>
+					<option value={Language.JSX}>JSX</option>
+					<option value={Language.TS}>TypeScript</option>
+					<option value={Language.TSX}>TSX</option>
+					<option value={Language.JSON}>JSON</option>
+					<option value={Language.GraphQL}>GraphQL</option>
+					<option value={Language.Grit}>Grit</option>
+					<option value={Language.CSS}>CSS</option>
+					<option value={Language.HTML}>HTML</option>
+					<option value={Language.Vue}>Vue</option>
+					<option value={Language.Svelte}>Svelte</option>
+					<option value={Language.Astro}>Astro</option>
+				</select>
+			</div>
+		</section>
 	);
 }
 
@@ -550,8 +596,7 @@ function SyntaxSettings({
 						onChange={(e) => {
 							setFilename(
 								modifyFilename(filename, {
-									jsx: false,
-									typescript: false,
+									language: guessLanguage(filename),
 									script: e.target.value === SourceType.Script,
 								}),
 							);
@@ -560,46 +605,6 @@ function SyntaxSettings({
 						<option value={SourceType.Module}>Module</option>
 						<option value={SourceType.Script}>Script</option>
 					</select>
-				</div>
-
-				<div className="field-row">
-					<input
-						id="typescript"
-						name="typescript"
-						type="checkbox"
-						checked={isTypeScriptFilename(filename)}
-						onChange={(e) => {
-							setFilename(
-								modifyFilename(filename, {
-									jsx: isJsxFilename(filename),
-									typescript: e.target.checked,
-									script: false,
-								}),
-							);
-						}}
-						disabled={isScript}
-					/>
-					<label htmlFor="typescript">TypeScript</label>
-				</div>
-
-				<div className="field-row">
-					<input
-						id="jsx"
-						name="jsx"
-						type="checkbox"
-						checked={isJsxFilename(filename)}
-						onChange={(e) => {
-							setFilename(
-								modifyFilename(filename, {
-									jsx: e.target.checked,
-									typescript: isTypeScriptFilename(filename),
-									script: false,
-								}),
-							);
-						}}
-						disabled={isScript}
-					/>
-					<label htmlFor="jsx">JSX</label>
 				</div>
 
 				<div className="field-row">

--- a/src/playground/tabs/SettingsTab.tsx
+++ b/src/playground/tabs/SettingsTab.tsx
@@ -260,15 +260,15 @@ export default function SettingsTab({
 		}));
 	}
 
-	const currentFileExtension = currentFile.split(".").at(-1);
-	const language =
-		Object.values(Language).find((ext) => ext === currentFileExtension) ??
-		Language.JS;
+	const language = guessLanguage(currentFile);
 
 	function setLanguage(language: Language): void {
 		renameFile(
 			currentFile,
-			`${currentFile.substring(0, currentFile.lastIndexOf("."))}.${language}`,
+			modifyFilename(currentFile, {
+				language,
+				script: isScriptFilename(currentFile),
+			}),
 		);
 	}
 

--- a/src/playground/types.ts
+++ b/src/playground/types.ts
@@ -134,6 +134,21 @@ export const emptyBiomeOutput: BiomeOutput = {
 	},
 };
 
+export enum Language {
+	JS = "js",
+	JSX = "jsx",
+	TS = "ts",
+	TSX = "tsx",
+	JSON = "json",
+	GraphQL = "graphql",
+	Grit = "grit",
+	CSS = "css",
+	HTML = "html",
+	Vue = "vue",
+	Svelte = "svelte",
+	Astro = "astro",
+}
+
 export interface PlaygroundSettings {
 	lineWidth: number;
 	indentStyle: IndentStyle;
@@ -178,7 +193,7 @@ export const defaultPlaygroundState: PlaygroundState = {
 	cursorPosition: 0,
 	tab: PlaygroundTab.Formatter,
 	currentFile: "main.tsx",
-	singleFileMode: false,
+	singleFileMode: true,
 	files: {
 		"main.tsx": {
 			content: "",

--- a/src/playground/utils.ts
+++ b/src/playground/utils.ts
@@ -1,6 +1,7 @@
 import type { ThemeChanged, ThemeName } from "@/frontend-scripts/util";
 import { getCurrentTheme } from "@/frontend-scripts/util";
 import {
+	Language,
 	type PlaygroundFileState,
 	type PlaygroundSettings,
 	type PlaygroundState,
@@ -265,6 +266,19 @@ export function isAstroFilename(filename: string): boolean {
 	return filename.endsWith(".astro");
 }
 
+export function guessLanguage(filename: string): Language {
+	if (isJsonFilename(filename)) return Language.JSON;
+	if (isGraphqlFilename(filename)) return Language.GraphQL;
+	if (isGritFilename(filename)) return Language.Grit;
+	if (isCssFilename(filename)) return Language.CSS;
+	if (isHtmlFilename(filename)) return Language.HTML;
+	if (isSvelteFilename(filename)) return Language.Svelte;
+	if (isAstroFilename(filename)) return Language.Astro;
+	if (isJsxFilename(filename))
+		return isTypeScriptFilename(filename) ? Language.TSX : Language.JSX;
+	return isTypeScriptFilename(filename) ? Language.TS : Language.JS;
+}
+
 export function modifyFilename(
 	filename: string,
 	opts: ExtensionOptions,
@@ -277,31 +291,41 @@ export function modifyFilename(
 }
 
 type ExtensionOptions = {
-	jsx: boolean;
-	typescript: boolean;
+	language: Language;
 	script: boolean;
 };
 
 export function getExtension(opts: ExtensionOptions): string {
-	let ext = "";
-
-	if (opts.script) {
-		ext = "cjs";
-	} else {
-		ext = "js";
+	switch (opts.language) {
+		case Language.JS:
+			return opts.script ? "cjs" : "js";
+		case Language.JSX:
+			return "jsx";
+		case Language.TS:
+			return "ts";
+		case Language.TSX:
+			return "tsx";
+		case Language.JSON:
+			return "json";
+		case Language.GraphQL:
+			return "graphql";
+		case Language.Grit:
+			return "grit";
+		case Language.CSS:
+			return "css";
+		case Language.HTML:
+			return "html";
+		case Language.Vue:
+			return "vue";
+		case Language.Svelte:
+			return "svelte";
+		case Language.Astro:
+			return "astro";
+		default:
+			throw new Error(
+				`Unsupported language type: ${opts.language satisfies never}`, // must be exhaustive
+			);
 	}
-
-	if (opts.typescript) {
-		if (opts.jsx) {
-			ext = "tsx";
-		} else {
-			ext = "ts";
-		}
-	} else if (opts.jsx) {
-		ext = "jsx";
-	}
-
-	return ext;
 }
 
 export function isValidExtension(filename: string): boolean {


### PR DESCRIPTION
## Summary

In single-file mode, it was not able to change the file language, especially for non JavaScript-like files (JSON, CSS, etc.). I added a language selector to change the file language quickly. Defaults to `TSX`.

<img width="315" alt="image" src="https://github.com/user-attachments/assets/c6730e5e-6634-43d3-914a-665a53ff7044" />
