### PR TITLE
fix(playground): use generated `RuleDomains` type to fix typing issues

### DIFF
--- a/.github/workflows/integrate.yaml
+++ b/.github/workflows/integrate.yaml
@@ -12,7 +12,20 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
       - name: Setup Biome
         uses: biomejs/setup-biome@c016c38f26f2c4a6eb3662679143614a254263fd # v2.3.0
+
       - name: Run Biome
         run: biome ci
+
+      - name: Setup Node.js
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
+        with:
+          node-version: lts/*
+
+      - name: Install dependencies
+        run: npm install -g pnpm && pnpm install
+
+      - name: Run tsc
+        run: pnpm run tsc

--- a/codegen/src/domains.rs
+++ b/codegen/src/domains.rs
@@ -62,13 +62,7 @@ impl DocDomains {
 
     fn write_description(self, buffer: &mut Vec<u8>) -> anyhow::Result<()> {
         let mut domains = self.domain_to_rules.into_iter().collect::<Vec<_>>();
-        domains.sort_by(|a, b| {
-            // this is gross
-            // TODO: remove once RuleDomain implements Ord and PartialOrd
-            let a = format!("{:?}", a.0);
-            let b = format!("{:?}", b.0);
-            a.cmp(&b)
-        });
+        domains.sort_by_key(|(domain, _)| *domain);
         for (domain, rules) in &domains {
             let name = Case::Pascal.convert(format!("{domain:?}").as_str());
             match domain {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "dev": "astro dev",
     "format": "pnpm biome format --write",
     "check": "pnpm biome check --write",
-    "tsc": "tsc --skipLibCheck",
+    "tsc": "astro sync && tsc --skipLibCheck",
     "build": "astro build",
     "build:no-og": "SKIP_OG=true astro build",
     "preview": "astro preview",

--- a/src/playground/PlaygroundLoader.tsx
+++ b/src/playground/PlaygroundLoader.tsx
@@ -29,7 +29,11 @@ import {
 	guessLanguage,
 	normalizeFilename,
 } from "@/playground/utils";
-import type { FixFileMode } from "@biomejs/wasm-web";
+import type {
+	FixFileMode,
+	RuleDomain,
+	RuleDomainValue,
+} from "@biomejs/wasm-web";
 import {
 	type Dispatch,
 	type SetStateAction,
@@ -243,7 +247,7 @@ function buildLocation(state: PlaygroundState): string {
 
 	// handle rule domains
 	for (const key in state.settings.ruleDomains) {
-		const value = state.settings.ruleDomains[key];
+		const value = state.settings.ruleDomains[key as RuleDomain];
 		if (value !== undefined && value !== "none") {
 			queryStringObj[`ruleDomains.${key}`] = value;
 		}
@@ -303,12 +307,12 @@ function initState(
 	}
 
 	// handle rule domains
-	const ruleDomains: Record<string, string> = {};
+	const ruleDomains = defaultPlaygroundState.settings.ruleDomains;
 	const prefixLength = "ruleDomains.".length;
 	for (const key of searchParams.keys()) {
 		if (key.startsWith("ruleDomains.")) {
-			const domain = key.slice(prefixLength);
-			const value = searchParams.get(key);
+			const domain = key.slice(prefixLength) as RuleDomain;
+			const value = searchParams.get(key) as RuleDomainValue;
 			if (value) {
 				ruleDomains[domain] = value;
 			}

--- a/src/playground/tabs/SettingsTab.tsx
+++ b/src/playground/tabs/SettingsTab.tsx
@@ -27,6 +27,7 @@ import type {
 	FixFileMode,
 	RuleDomain,
 	RuleDomainValue,
+	RuleDomains,
 } from "@biomejs/wasm-web";
 import type React from "react";
 import { type Dispatch, type SetStateAction, useState } from "react";
@@ -913,8 +914,8 @@ function LinterSettings({
 	setEnabledLinting: (value: boolean) => void;
 	analyzerFixMode: FixFileMode;
 	setAnalyzerFixMode: (value: FixFileMode) => void;
-	ruleDomains: Record<RuleDomain, RuleDomainValue>;
-	setRuleDomains: (value: Record<RuleDomain, RuleDomainValue>) => void;
+	ruleDomains: RuleDomains;
+	setRuleDomains: (value: RuleDomains) => void;
 }) {
 	const updateDomain = (domain: RuleDomain, value: RuleDomainValue) => {
 		setRuleDomains({

--- a/src/playground/types.ts
+++ b/src/playground/types.ts
@@ -1,9 +1,4 @@
-import type {
-	Diagnostic,
-	FixFileMode,
-	RuleDomain,
-	RuleDomainValue,
-} from "@biomejs/wasm-web";
+import type { Diagnostic, FixFileMode, RuleDomains } from "@biomejs/wasm-web";
 import type { parser } from "codemirror-lang-rome-ast";
 import type { Dispatch, SetStateAction } from "react";
 
@@ -169,7 +164,7 @@ export interface PlaygroundSettings {
 	enabledAssist: boolean;
 	unsafeParameterDecoratorsEnabled: boolean;
 	allowComments: boolean;
-	ruleDomains: Record<RuleDomain, RuleDomainValue>;
+	ruleDomains: RuleDomains;
 	indentScriptAndStyle: boolean;
 	whitespaceSensitivity: WhitespaceSensitivity;
 }


### PR DESCRIPTION
## Summary

Synced to pull the changes from biomejs/biome#5306 and biomejs/biome#5308, then fixed typing issues using the generated `RuleDomains` type. Plus, I added a `tsc` step to the workflow to ensure the code is valid in TypeScript on every PR.