### PR TITLE
Update migrate-eslint-prettier.mdx

### DIFF
--- a/src/content/docs/guides/migrate-eslint-prettier.mdx
+++ b/src/content/docs/guides/migrate-eslint-prettier.mdx
@@ -28,6 +28,8 @@ To ease the migration, Biome provides the `biome migrate eslint` subcommand.
 This subcommand will read your ESLint configuration and attempt to port its settings to Biome.
 The subcommand is able to handle both the legacy and the flat configuration files.
 It supports the `extends` field of the legacy configuration and loads both shared and plugin configurations.
+For flat configuration files, the subcommand will attempt to search for JavaScript extension only (`js`, `cjs`, `mjs`) to be loaded into Node.js.
+The subcommand needs Node.js to load and resolve all the plugins and `extends` configured in the ESLint configuration file.
 The subcommand also migrates `.eslintignore`.
 
 Given the following ESLint configuration:
@@ -111,7 +113,6 @@ This results in the following Biome configuration:
 }
 ```
 
-The subcommand needs Node.js to load and resolve all the plugins and `extends` configured in the ESLint configuration file.
 For now, `biome migrate eslint` doesn't support configuration written in YAML.
 
 By default, Biome doesn't migrate inspired rules.


### PR DESCRIPTION
Clarify ESLint flat config file migration process earlier with added context. Currently, it is only implied that Biome will only search for JavaScript file extension by mentioning that the config is loaded by Node.js. This make it more explicit that Biome will attempt to search JS extension only (`js`,`cjs`,mts``)

## Summary

[As per this issue](https://github.com/biomejs/biome/issues/5353#issuecomment-2725119751), this is confusing since ESLint docs said the valid flat config file is `eslint.config,{js,ts,mjs,mts,cjs,cts}`. But when the we use TS file, Biome failed to search for the config file while mentioning that it does support flat file config. The implication that Biome does not search TS file since it requires the file to be loaded by Node.js is now hopefully more clear.