### PR TITLE
feat: add version selector as the link to next.biomejs.dev

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -563,6 +563,7 @@ export default defineConfig({
 				SiteTitle: "./src/components/starlight/SiteTitle.astro",
 				Hero: "./src/components/starlight/Hero.astro",
 				Head: "./src/components/starlight/Head.astro",
+				LanguageSelect: "./src/components/starlight/LanguageSelect.astro",
 			},
 		}),
 	],

--- a/src/components/starlight/LanguageSelect.astro
+++ b/src/components/starlight/LanguageSelect.astro
@@ -1,0 +1,43 @@
+---
+import Default from "@astrojs/starlight/components/LanguageSelect.astro";
+import Select from "@astrojs/starlight/components/Select.astro";
+---
+
+<Default><slot /></Default>
+<version-select>
+    <Select
+        icon="biome"
+        label="Version"
+        value="v1"
+        width="fit-content"
+        options={[
+            { label: "v1.x", value: "v1", selected: true },
+            { label: "beta", value: "v2", selected: false },
+        ]}
+    />
+</version-select>
+
+<script>
+    class VersionSelect extends HTMLElement {
+        constructor() {
+            super();
+
+            this.querySelector('select')?.addEventListener('change', (e) => {
+                const value = (e.currentTarget as HTMLSelectElement).value;
+
+                let url: URL;
+                if (value === "v2") {
+                    url = new URL("https://next.biomejs.dev/");
+                } else {
+                    url = new URL("https://biomejs.dev/"); 
+                }
+
+                url.pathname = window.location.pathname;
+
+                window.location.href = url.toString();
+            });
+        }
+    }
+
+    customElements.define('version-select', VersionSelect);
+</script>


### PR DESCRIPTION
## Summary

Add a version selector for redirecting to the v2.0 beta documentation.
Not sure this is the right way in Astro + Starlight, I added the selector into the `LanguageSelect` component as `starlight-blog` does for [`ThemeSelect`](https://github.com/HiDeoo/starlight-blog/blob/3f9e45506b240a6c837e0f601b9cf865ca6473e1/packages/starlight-blog/overrides/ThemeSelect.astro).