### PR TITLE
Document `includes` behaviour

### DIFF
--- a/src/content/docs/guides/configure-biome.mdx
+++ b/src/content/docs/guides/configure-biome.mdx
@@ -68,7 +68,7 @@ We disabled the formatter for JSON files.
 ```
 
 :::note
-Biome refers as `javascript` all variants of the JavaScript language.
+Biome refers to all variants of the JavaScript language as `javascript`.
 This includes TypeScript, JSX and TSX.
 :::
 
@@ -101,21 +101,12 @@ Here's an example:
 will use the configuration file `app/frontend/biome.json`;
 
 :::caution
-Biome doesn't support nested `biome.json` files, neither in CLI nor in LSP. [Follow and help the support in the related issue](https://github.com/biomejs/biome/issues/2228)
-:::
-
-:::note
-Biome commands support using the `--config-path` option and the `BIOME_CONFIG_PATH` environment variable.
-This allows you to specify a custom configuration file or a directory where Biome can look for a `biome.json` or `biome.jsonc` file.
-When you use `--config-path` or `BIOME_CONFIG_PATH`, the standard configuration file resolution process is **disabled**.
-
-If `--config-path` or `BIOME_CONFIG_PATH` points directly to a file, you can use names other than `biome.json` or `biome.jsonc`.
-Biome will read a `.json` file using a standard JSON parser.
-For files with other extensions, Biome will treat them as `.jsonc` files, using a more flexible JSON parser that allows comments and trailing commas.
+Biome doesn't yet support nested `biome.json` files, neither in CLI nor in LSP.
+[Follow and help the support in the related issue](https://github.com/biomejs/biome/issues/2228)
 :::
 
 
-## Share a configuration file
+## Sharing a configuration file
 
 The `extends` field allows you to split your configuration across multiple files.
 This way, you can share common settings across different projects or folders.
@@ -170,11 +161,11 @@ To avoid a breaking change with how the existing resolution works, paths startin
 For more information about the resolution algorithm, refer to the [Node.js documentation](https://nodejs.org/api/esm.html#resolution-and-loading-algorithm).
 
 
-## Ignore files
+## Specifying files to process
 
-The first way to control which files and directories are processed by Biome is to list them in the CLI.
-In the following command, we format only `file1.js` and all the files in the `src` directory.
-The directories are recursively traversed.
+The first way to control which files and folders are processed by Biome is to
+list them in the CLI. In the following command, we only format `file1.js` and
+all the files in the `src` folder, because folders are recursively traversed.
 
 ```shell
 biome format file1.js src/
@@ -187,33 +178,36 @@ Some shells don't support the recursive glob `**`.
 :::
 
 The Biome configuration file can be used to refine which files are processed.
-You can explicitly list the files to be processed using `include` and the files not to be processed using `ignore`.
-`include` and `ignore` accepts globs patterns such as `src/**/*.js`.
-See the [related section](#glob-syntax-explained) for which glob syntaxes are supported.
-`include` is always applied first before applying `ignore`.
-This allows you to include some files and to ignore some of the file you included.
+You can explicitly list the files to be processed using
+[the `files.includes` field](/reference/configuration). `files.includes` accepts
+[glob patterns](/reference/configuration#glob-syntax-reference) such as
+`src/**/*.js`. Negated patterns starting with `!` can be used to exclude files.
 
-:::note
-`include` and `ignore` have a slightly different semantics.
-`include` doesn't prevent Biome of traversing a folder.
-This means that if you want to prevent Biome from traversing a folder, you have to add the folder to `ignore`.
+Paths and globs inside Biome's configuration file are always resolved relative
+to the folder the configuration file is in.
+
+`files.includes` applies to all of Biome's tools, meaning the files specified
+here are processed by the linter, the formatter and the assist, unless specified
+otherwise. For the individual tools, you can further refine the matching files
+using `<tool>.includes`.
+
+:::important
+The global `files.includes` has slightly different semantics than the more
+specific `<tool>.includes` fields. Any file or folder that doesn't match
+`files.includes` is excluded from use by any of Biome's tools. This means that
+any tool-specific `includes` field can never match a file that doesn't also
+match `files.includes`.
 :::
-
-Biome provides global `files.include` and `files.ignore` fields that apply to all tools.
-You can also include and ignore files at tool level using `<tool>.include` and `<tool>.ignore`.
-Note that they don't override the global `files.include` and `files.ignore`.
-`files.include` and `files.ignore` are applied first before a tool's `include` and `ignore`.
 
 Let's take the following configuration:
 
 ```json title="biome.json"
 {
   "files": {
-    "include": ["src/**/*.js", "test/**/*.js"],
-    "ignore": ["**/*.min.js"],
+    "includes": ["src/**/*.js", "test/**/*.js", "!**/*.min.js"],
   },
   "linter": {
-    "ignore": ["test"]
+    "includes": ["!test/**"]
   }
 }
 ```
@@ -224,67 +218,17 @@ And run the following command:
 biome format test/
 ```
 
-The command will format the files that end with the `.js` extension and doesn't end with the `.min.js` extension from the `test` directory.
-The files in `src` are not formatted because the directory is not listed in the CLI.
+The command will format the files that end with the `.js` extension and don't
+end with the `.min.js` extension from the `test/` folder.
+The files in `src/` are not formatted because the folder is not listed in the
+CLI.
 
-If we run the following command, no files are linted because the `test` directory is explicitly ignored for the linter.
+If we run the following command, no files are linted because files inside the
+`test/` folder are explicitly ignored for the linter.
 
 ```shell
 biome lint test/
 ```
-
-Biome resolves the globs relatively from the working directory.
-The working directory is the directory where you usually run a CLI command.
-This means that you have to place **particular attention** when the configuration file is placed in
-a different directory from where you execute your command.
-In the case of an editor (LSP) the working directory is the root directory of your project.
-
-Let's take a project that contains two directories `backend/` and `frontend/`, and the Biome configuration file that we introduced earlier.
-Inside the `frontend/` directory, a `package.json` specifies a `format` script that runs the Biome formatter.
-
-<FileTree>
-- backend
-  - ...
-- biome.json
-- frontend
-  - package.json
-  - src
-    - ...
-  - test
-    - ...
-</FileTree>
-
-```json title="frontend/package.json"
-{
-  "name": "frontend-project",
-  "scripts": {
-    "format": "biome format --write ./"
-  }
-}
-```
-
-When you run the script `format` from `frontend/package.json`,
-the working directory resolved by that script will be `frontend/`.
-The globs `src/**/*.js` and `test/**/*.js` will have as "base" directory `frontend/`.
-Thus, only the files from `frontend/src/` and `frontend/test/` will be formatted.
-
-```json title="biome.json"
-{
-  "files": {
-    "include": ["src/**/*.js", "src/**/*.ts"],
-    "ignore": ["test"]
-  },
-  "formatter": {
-    "indentStyle": "space"
-  }
-}
-```
-
-:::caution
-`ignore` and `include` inside `overrides` have a **different** semantics:
-- for `ignore`: if a file matches the globs, **_don't_ apply** the configuration inside this override, and keep apply the next overrides;
-- for `include`: if a file matches the globs, **apply** the configuration inside this override, and keep apply the next overrides;
-:::
 
 :::note
 By default, Biome always ignores some files that are said to be **protected files**.
@@ -353,36 +297,3 @@ The following files are parsed as `JSON` files with the options `json.parser.all
 - `tsconfig.json`
 - `typedoc.json`
 - `typescript.json`
-
-
-## Glob syntax explained
-
-A glob pattern specifies a set of filenames.
-Biome supports the following globs:
-
-- `*` matches zero or more characters. It cannot match the path separator `/`.
-- `**` recursively matches directories and files.
-  This sequence **must** form a single path component,
-  so both `**a` and `b**` are invalid and will result in an error.
-  A sequence of more than two consecutive `*` characters is also invalid.
-- `[...]` matches any character inside the brackets.
-  Ranges of characters can also be specified, as ordered by Unicode, so e.g.
-  `[0-9]` specifies any character between 0 and 9 inclusive.
-- `[!...]` is the negation of `[...]`, i.e. it matches any characters **not** in the brackets.
-
-Some examples:
-
-- `dist/**` matches the dist directory and all files in this directory.
-- `**/test/**` matches all files under any directory named `test`, regardless of where they are. E.g. `dist/test`, `src/test`.
-- `**/*.js` matches all files ending with the extension `.js` in all directories.
-
-Biome uses a glob library that treats all globs as having a `**/` prefix.
-This means that `src/**/*.js` and `**/src/**/*.js` are treated as identical.
-They match both `src/file.js` and `test/src/file.js`.
-
-:::caution
-These patterns can be used in a Biome configuration file.
-Glob patterns used on the command line are not interpreted by Biome.
-They are expanded by your shell.
-Some shells don't support the recursive glob `**`
-:::

--- a/src/content/docs/reference/configuration.mdx
+++ b/src/content/docs/reference/configuration.mdx
@@ -11,7 +11,8 @@ Allows to pass a path to a JSON schema file.
 
 We publish a JSON schema file for our `biome.json`/`biome.jsonc` files.
 
-You can specify a relative path to the schema inside the `@biomejs/biome` NPM package if it is installed in the `node_modules` folder:
+You can specify a relative path to the schema inside the `@biomejs/biome` NPM
+package if it is installed in the `node_modules` folder:
 
 ```json title="biome.json"
 {
@@ -19,7 +20,8 @@ You can specify a relative path to the schema inside the `@biomejs/biome` NPM pa
 }
 ```
 
-If you have problems with resolving the physical file, you can use the one published on this site:
+If you have problems with resolving the physical file, you can use the one
+published on this site:
 
 ```json title="biome.json"
 {
@@ -29,71 +31,74 @@ If you have problems with resolving the physical file, you can use the one publi
 
 ## `extends`
 
-A list of paths to other JSON files. Biome resolves and applies the options of the files contained in the `extends` list, and eventually applies the options contained in the `biome.json` file.
+A list of paths to other Biome configuration files. Biome resolves and applies
+the configuration settings from the files contained in the `extends` list, and
+eventually applies the options contained in this `biome.json`/`biome.jsonc`
+file.
+
+Files are provided in order from least relevant to most relevant, with the
+settings in the current file being leading.
 
 ## `files`
 
-### `files.maxSize`
+### `files.includes`
 
-The maximum allowed size for source code files in bytes. Files above
-this limit will be ignored for performance reasons.
+A list of [glob patterns](#glob-syntax-reference) of files to process.
 
-> Default: `1048576` (1024*1024, 1MB)
+If a folder matches a glob pattern, all files inside that folder will be
+processed.
 
-### `files.ignore`
-
-A list of Unix shell style patterns. Biome ignores files and folders that
-match these patterns.
-
+The following example matches all files with a `.js` extension inside the `src`
+folder:
 
 ```json title="biome.json"
 {
   "files": {
-    "ignore": ["scripts/*.js"]
+    "includes": ["src/**/*.js"]
   }
 }
 ```
 
+`*` is used to match _all files in a folder_, while `**` _recursively_ matches
+all files and subfolders in a folder. For more information on globs, see the
+[glob syntax reference](#glob-syntax-reference)
 
-### `files.include`
+`includes` also supports negated patterns, or exceptions. These are patterns
+that start with `!` and they can be used to instruct Biome to process all files
+_except_ those matching the negated pattern.
 
-A list of Unix shell style patterns. Biome handles only the files and folders that match these patterns.
+Note that exceptions are processed in order, allowing you to specify exceptions
+to exceptions.
 
-
+Consider the following example:
 
 ```json title="biome.json"
 {
   "files": {
-    "include": ["scripts/*.js"]
+    "includes": ["**", "!**/*.test.js", "**/special.test.js", "!test"]
   }
 }
 ```
 
-:::caution
-When both `include` and `ignore` are specified, `ignore` takes **precedence** over `include`
-:::
+This example specifies that:
 
-Given the following example:
+1. All files inside all (sub)folders are processed, thanks to the `**` pattern...
+2. ... _except_ when those files have a `.test.js` extension...
+3. ... but the file `special.test.ts` _is_ still processed...
+4. ... _except_ when it occurs in the folder named `test`, because _no_ files
+   inside that folder are processed.
 
+This means that:
 
-
-```json title="biome.json"
-{
-  "files": {
-    "include": ["scripts/**/*.js", "src/**/*.js"],
-    "ignore": ["scripts/**/*.js"]
-  }
-}
-```
-
-Only the files that match the pattern `src/**/*.js` will be handled, while the files that match the pattern
-`scripts/**/*.js` will be ignored.
+* `src/app.js` **is** processed.
+* `src/app.test.js` **is not** processed.
+* `src/special.test.js` **is* processed.
+* `test/special.test.js` **is not* processed.
 
 ### `files.ignoreUnknown`
 
-Biome won't emit diagnostics if it encounters files that can't handle.
-
-
+If `true`, Biome won't emit diagnostics if it encounters files that it can't
+handle.
 
 ```json title="biome.json"
 {
@@ -104,6 +109,13 @@ Biome won't emit diagnostics if it encounters files that can't handle.
 ```
 
 > Default: `false`
+
+### `files.maxSize`
+
+The maximum allowed size for source code files in bytes. Files above
+this limit will be ignored for performance reasons.
+
+> Default: `1048576` (1024*1024, 1MB)
 
 ## `vcs`
 
@@ -144,59 +156,82 @@ The main branch of the project. Biome will use this branch when evaluating the c
 
 ### `linter.enabled`
 
-Enables Biome's linter
+Enables Biome's linter.
 
 > Default: `true`
 
-### `linter.ignore`
+### `linter.includes`
 
-An array of Unix shell style patterns.
+A list of [glob patterns](#glob-syntax-reference) of files to lint.
 
-
-
-```json title="biome.json"
-{
-  "linter": {
-    "ignore": ["scripts/*.js"]
-  }
-}
-```
-
-
-### `linter.include`
-
-A list of Unix shell style patterns. Biome handles only the files and folders that
-match these patterns.
-
-
+The following example lints all files with a `.js` extension inside the `src`
+folder:
 
 ```json title="biome.json"
 {
   "linter": {
-    "include": ["scripts/*.js"]
+    "includes": ["src/**/*.js"]
   }
 }
 ```
 
-:::caution
-When both `include` and `ignore` are specified, `ignore` takes **precedence** over `include`
+`*` is used to match _all files in a folder_, while `**` _recursively_ matches
+all files and subfolders in a folder. For more information on globs, see the
+[glob syntax reference](#glob-syntax-reference)
+
+`includes` also supports negated patterns, or exceptions. These are patterns
+that start with `!` and they can be used to instruct Biome to process all files
+_except_ those matching the negated pattern.
+
+Note that exceptions are processed in order, allowing you to specify exceptions
+to exceptions.
+
+Consider the following example:
+
+```json title="biome.json"
+{
+  "linter": {
+    "includes": ["**", "!**/*.test.js", "**/special.test.js"]
+  }
+}
+```
+
+This example specifies that:
+
+1. All files inside all (sub)folders are linted, thanks to the `**` pattern...
+2. ... _except_ when those files have a `.test.js` extension...
+3. ... but the file `special.test.ts` _is_ still linted.
+
+This means that:
+
+* `src/app.js` **is** linted.
+* `src/app.test.js` **is not** linted.
+* `src/special.test.js` **is* linted.
+
+Note that `linter.includes` is applied *after* `files.includes`. This means
+that any file that is not matched by `files.includes` can no longer be matched
+`linter.includes`. This means the following example **doesn't work**:
+
+```json5 title="biome.jsonc"
+{
+  "files": {
+    "includes": "src/**"
+  },
+  "linter": {
+    // This matches nothing because there is no overlap with `files.includes`:
+    "includes": "scripts/**"
+  }
+}
+```
+
+If `linter.includes` is not specified, all files matched by
+[`files.includes`](#filesincludes) are linted.
+
+:::note
+Due to a technical limitation, `linter.includes` also cannot match folders
+while `files.includes` can. If you want to match all files inside a folder,
+you should explicitly add `/**` at the end.
 :::
-
-Given the following example:
-
-
-
-```json title="biome.json"
-{
-  "linter": {
-    "include": ["scripts/**/*.js", "src/**/*.js"],
-    "ignore": ["scripts/**/*.js"]
-  }
-}
-```
-
-Only the files that match the patter `src/**/*.js` will be linted, while the files that match the pattern
-`scripts/**/*.js` will be ignored.
 
 ### `linter.rules.recommended`
 
@@ -233,7 +268,7 @@ For example, you can configure the `a11y` group to emit information diagnostics:
 }
 ```
 
-Here's the accepted values:
+Here are the accepted values:
 - `"on"`: each rule that belongs to the group will emit a diagnostic with the default severity of the rule. Refer to the documentation of the rule, or use the `explain` command:
     ```shell showLineNumbers=false
     biome explain noDebugger
@@ -269,58 +304,82 @@ These options apply to all languages. There are additional language-specific for
 
 ### `formatter.enabled`
 
-Enables Biome's formatter
+Enables Biome's formatter.
 
 > Default: `true`
 
-### `formatter.ignore`
+### `formatter.includes`
 
-An array of Unix shell style patterns.
+A list of [glob patterns](#glob-syntax-reference) of files to format.
 
-
-
-```json title="biome.json"
-{
-  "formatter": {
-    "ignore": ["scripts/*.js"]
-  }
-}
-```
-
-### `formatter.include`
-
-A list of Unix shell style patterns. Biome handles only the files and folders that
-match these patterns.
-
-
+The following example formats all files with a `.js` extension inside the `src`
+folder:
 
 ```json title="biome.json"
 {
   "formatter": {
-    "include": ["scripts/*.js"]
+    "includes": ["src/**/*.js"]
   }
 }
 ```
 
-:::caution
-When both `include` and `ignore` are specified, `ignore` takes **precedence** over `include`
+`*` is used to match _all files in a folder_, while `**` _recursively_ matches
+all files and subfolders in a folder. For more information on globs, see the
+[glob syntax reference](#glob-syntax-reference)
+
+`includes` also supports negated patterns, or exceptions. These are patterns
+that start with `!` and they can be used to instruct Biome to process all files
+_except_ those matching the negated pattern.
+
+Note that exceptions are processed in order, allowing you to specify exceptions
+to exceptions.
+
+Consider the following example:
+
+```json title="biome.json"
+{
+  "formatter": {
+    "includes": ["**", "!**/*.test.js", "**/special.test.js"]
+  }
+}
+```
+
+This example specifies that:
+
+1. All files inside all (sub)folders are formatted, thanks to the `**` pattern...
+2. ... _except_ when those files have a `.test.js` extension...
+3. ... but the file `special.test.ts` _is_ still formatted.
+
+This means that:
+
+* `src/app.js` **is** formatted.
+* `src/app.test.js` **is not** formatted.
+* `src/special.test.js` **is* formatted.
+
+Note that `formatter.includes` is applied *after* `files.includes`. This means
+that any file that is not matched by `files.includes` can no longer be matched
+`formatter.includes`. This means the following example **doesn't work**:
+
+```json5 title="biome.jsonc"
+{
+  "files": {
+    "includes": "src/**"
+  },
+  "formatter": {
+    // This matches nothing because there is no overlap with `files.includes`:
+    "includes": "scripts/**"
+  }
+}
+```
+
+If `formatter.includes` is not specified, all files matched by
+[`files.includes`](#filesincludes) are formatted.
+
+:::note
+Due to a technical limitation, `formatter.includes` also cannot match folders
+while `files.includes` can. If you want to match all files inside a folder,
+you should explicitly add `/**` at the end.
 :::
-
-Given the following example:
-
-
-
-```json title="biome.json"
-{
-  "formatter": {
-    "include": ["scripts/**/*.js", "src/**/*.js"],
-    "ignore": ["scripts/**/*.js"]
-  }
-}
-```
-
-Only the files that match the patter `src/**/*.js` will be formatted, while the files that match the pattern
-`scripts/**/*.js` will be ignored.
 
 ### `formatter.formatWithErrors`
 
@@ -399,65 +458,6 @@ The config files `.editorconfig` and `biome.json` will follow the follwing rules
 - Nested `.editorconfig` files aren't supported currently.
 
 > Default: `true`
-
-## `organizeImports`
-
-### `organizeImports.enabled`
-
-Enables Biome's sort imports.
-
-> Default: `true`
-
-### `organizeImports.ignore`
-
-
-A list of Unix shell style patterns. Biome ignores files and folders that match these patterns.
-
-
-
-```json title="biome.json"
-{
-  "organizeImports": {
-    "ignore": ["scripts/*.js"]
-  }
-}
-```
-
-
-### `organizeImports.include`
-
-A list of Unix shell style patterns. Biome handles only the files and folders that
-match these patterns.
-
-
-
-```json title="biome.json"
-{
-  "organizeImports": {
-    "include": ["scripts/*.js"]
-  }
-}
-```
-
-:::caution
-When both `include` and `ignore` are specified, `ignore` takes **precedence** over `include`
-:::
-
-Given the following example:
-
-
-
-```json title="biome.json"
-{
-  "organizeImports": {
-    "include": ["scripts/**/*.js", "src/**/*.js"],
-    "ignore": ["scripts/**/*.js"]
-  }
-}
-```
-
-Only the files that match the patter `src/**/*.js` will have their imports sorted, while the files that match the pattern
-`scripts/**/*.js` will be ignored.
 
 
 ## `javascript`
@@ -1109,30 +1109,16 @@ When a file is matched against an override pattern, the configuration specified 
 
 The order of the patterns matter. If a file *can* match three patterns, only the first one is used.
 
-### `overrides.<ITEM>.ignore`
+### `overrides.<ITEM>.includes`
 
-A list of Unix shell style patterns. Biome will not apply the override to files that match the pattern.
+A list of [glob patterns](https://en.wikipedia.org/wiki/Glob_(programming)) of
+files for which to apply customised settings.
 
-
-
-```json title="biome.json"
+```json title="biome.jsonc"
 {
   "overrides": [{
-    "ignore": ["scripts/*.js"]
-  }]
-}
-```
-
-### `overrides.<ITEM>.include`
-
-A list of Unix shell style patterns. Biome will apply the override only to files that match the pattern.
-
-
-
-```json title="biome.json"
-{
-  "overrides": [{
-    "include": ["scripts/*.js"]
+    "includes": ["scripts/*.js"],
+    // settings that should only apply to the files specified in the includes field.
   }]
 }
 ```
@@ -1145,8 +1131,6 @@ It will include the options of [top level formatter](#formatter) configuration, 
 
 For example, it's possible to modify the formatter `lineWidth`, `indentStyle` for certain files that are included in the glob path `generated/**`:
 
-
-
 ```json title="biome.json"
 {
   "formatter": {
@@ -1154,7 +1138,7 @@ For example, it's possible to modify the formatter `lineWidth`, `indentStyle` fo
   },
   "overrides": [
     {
-      "include": ["generated/**"],
+      "includes": ["generated/**"],
       "formatter": {
         "lineWidth": 160,
         "indentStyle": "space"
@@ -1173,8 +1157,6 @@ It will include the options of [top level linter](#linter) configuration, minus 
 
 You can disable certain rules for certain glob paths, and disable the linter for other glob paths:
 
-
-
 ```json title="biome.json"
 {
   "linter": {
@@ -1185,7 +1167,7 @@ You can disable certain rules for certain glob paths, and disable the linter for
   },
   "overrides": [
     {
-      "include": ["lib/**"],
+      "includes": ["lib/**"],
       "linter": {
         "rules": {
           "suspicious": {
@@ -1195,7 +1177,7 @@ You can disable certain rules for certain glob paths, and disable the linter for
       }
     },
     {
-      "include": ["shims/**"],
+      "includes": ["shims/**"],
       "linter": {
         "enabled": false
       }
@@ -1216,8 +1198,6 @@ It will include the options of [top level javascript](#javascript) configuration
 
 You can change the formatting behaviour of JavaScript files in certain folders:
 
-
-
 ```json title="biome.json"
 {
   "formatter": {
@@ -1230,7 +1210,7 @@ You can change the formatting behaviour of JavaScript files in certain folders:
   },
   "overrides": [
     {
-      "include": ["lib/**"],
+      "includes": ["lib/**"],
       "javascript": {
         "formatter": {
           "quoteStyle": "double"
@@ -1251,8 +1231,6 @@ It will include the options of [top level json](#json) configuration.
 
 You can enable parsing features for certain JSON files:
 
-
-
 ```json title="biome.json"
 {
   "linter": {
@@ -1263,7 +1241,7 @@ You can enable parsing features for certain JSON files:
   },
   "overrides": [
     {
-      "include": [".vscode/**"],
+      "includes": [".vscode/**"],
       "json": {
         "parser": {
           "allowComments": true,
@@ -1274,3 +1252,37 @@ You can enable parsing features for certain JSON files:
   ]
 }
 ```
+
+## Glob syntax reference
+
+Glob patterns are used to match paths of files and folders. Biome supports the
+following syntax in globs:
+
+- `*` matches zero or more characters. It cannot match the path separator `/`.
+- `**` recursively matches directories and files. This sequence must be used as
+  an entire path component, so both `**a` and `b**` are invalid and will result
+  in an error. A sequence of more than two consecutive `*` characters is also
+  invalid.
+- `[...]` matches any character inside the brackets.
+  Ranges of characters can also be specified, as ordered by Unicode, so e.g.
+  `[0-9]` specifies any character between 0 and 9 inclusive.
+- `[!...]` is the negation of `[...]`, i.e. it matches any characters **not** in
+  the brackets.
+- If the entire glob starts with `!`, it is a so-called negated pattern. This
+  glob only matches if the path _doesn't_ match the glob. Negated patterns
+  cannot be used alone, they can only be used as _exception_ to a regular glob.
+
+Some examples:
+
+- `dist/**` matches the `dist/` folder and all files inside it.
+- `**/test/**` matches all files under any folder named `test`, regardless of
+  where they are. E.g. `dist/test`, `src/test`.
+- `**/*.js` matches all files ending with the extension `.js` in all folders.
+
+:::caution
+Glob patterns can be used in a Biome configuration file, but they can also be
+specified from the command line. When you specify a glob on the command line,
+it is interpreted by your shell rather than by Biome. Shells may support
+slightly different syntax for globs. For instance, some shells do not support
+the recursive pattern `**`.
+:::


### PR DESCRIPTION
## Summary

Updated both the reference and the configuration guide to update the docs on how `includes` works.

I've removed the `organizeImports` section, because it was mostly about the old `include` and `ignore`, but I didn't yet add a new reference on the `assist` options.