### PR TITLE
fix(playground): enable html formatter on the playground

### DIFF
--- a/src/playground/workers/biomeWorker.ts
+++ b/src/playground/workers/biomeWorker.ts
@@ -167,6 +167,7 @@ self.addEventListener("message", async (e) => {
 				},
 				html: {
 					formatter: {
+						enabled: true,
 						indentScriptAndStyle,
 						whitespaceSensitivity,
 					},


### PR DESCRIPTION
## Summary

The html formatter has been disabled by default in https://github.com/biomejs/biome/pull/5354, we need to explicitly enable it in the playground.