### PR TITLE
fix(docs): move Analyzer Plugins to Linter Plugins

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -262,11 +262,6 @@ export default defineConfig({
 										uk: "Сортування імпортів",
 									},
 								},
-								{
-									label: "Plugins",
-									link: "/analyzer/plugins",
-									badge: "beta",
-								},
 							],
 							translations: {
 								fr: "Analyseur",
@@ -349,6 +344,11 @@ export default defineConfig({
 									translations: {
 										fr: "Sources des règles",
 									},
+								},
+								{
+									label: "Plugins",
+									link: "/linter/plugins",
+									badge: "beta",
 								},
 							],
 							translations: {

--- a/src/content/docs/blog/biome-v2-0-beta.md
+++ b/src/content/docs/blog/biome-v2-0-beta.md
@@ -46,7 +46,7 @@ While the final 2.0 release may still have small changes in its final feature se
 
 ### Plugins
 
-Biome 2.0 comes with our first iteration of [Analyzer Plugins](/analyzer/plugins).
+Biome 2.0 comes with our first iteration of [Linter Plugins](/linter/plugins).
 
 These plugins are still limited in scope: They allow for matching code snippets and reporting diagnostics on them.
 

--- a/src/content/docs/linter/plugins.mdx
+++ b/src/content/docs/linter/plugins.mdx
@@ -1,13 +1,13 @@
 ---
-title: Analyzer Plugins
-description: An overview of how to use Biome's Analyzer Plugins
+title: Linter Plugins
+description: An overview of how to use Biome's Linter Plugins
 ---
 
 :::note
 Plugins are currently only available in the [2.0 beta release](/blog/biome-v2-0-beta).
 :::
 
-Biome Analyzer supports [GritQL](/reference/gritql/) plugins. Currently, these
+Biome Linter supports [GritQL](/reference/gritql/) plugins. Currently, these
 plugins allow you to match specific code patterns and register customized
 diagnostic messages for them.
 
@@ -33,7 +33,7 @@ the following configuration:
 }
 ```
 
-The plugin will now be enabled on all supported files the analyzer runs on. You
+The plugin will now be enabled on all supported files the linter runs on. You
 can see its results when running `biome lint` or `biome check`. For example:
 
 ```shell


### PR DESCRIPTION
## Summary

As we no longer have the analyzer section in Biome v2.0, plugins should have the new place to live in. I renamed "Analyzer Plugins" to "Linter Plugins" and moved to the linter section.