### PR TITLE
Fix `includes` typo in overrides config

### DIFF
--- a/src/content/docs/guides/big-projects.mdx
+++ b/src/content/docs/guides/big-projects.mdx
@@ -115,7 +115,7 @@ In the following example we disable the rule `suspicious/noConsoleLog` inside th
     }
   },
   "overrides": [{
-      "include": ["packages/logger/**"],
+      "includes": ["packages/logger/**"],
       "linter": {
         "rules": {
           "suspicious": {


### PR DESCRIPTION
## Summary

Fixing the typo in the `includes` config key for `overrides`