### PR TITLE
chore: add Spanish i18n support to config

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -76,6 +76,10 @@ export default defineConfig({
 					label: "English",
 					lang: "en",
 				},
+				es: {
+					label: "Español",
+					lang: "es",
+				},
 				fr: {
 					label: "Français",
 					lang: "fr",

--- a/lunaria.config.json
+++ b/lunaria.config.json
@@ -38,6 +38,10 @@
   },
   "locales": [
     {
+      "label": "Español",
+      "lang": "es"
+    },
+    {
       "label": "Français",
       "lang": "fr"
     },


### PR DESCRIPTION
## Summary

Adding i18n support for Spanish (#2018) to the projects config files.