### PR TITLE
docs: fix small typo in `configuration.mdx`

### DIFF
--- a/src/content/docs/reference/configuration.mdx
+++ b/src/content/docs/reference/configuration.mdx
@@ -421,7 +421,7 @@ How many characters can be written on a single line.
 
 The attribute position style in HTMLish languages.
 - `"auto"`, the attributes are automatically formatted, and they will collapse in multiple lines only when they hit certain criteria;
-- `"multiline"`, the attributes will collapse in multiple lines if more then 1 attribute is used.
+- `"multiline"`, the attributes will collapse in multiple lines if more than 1 attribute is used.
 
 > Default: `"auto"`
 


### PR DESCRIPTION
## Summary

fix small typo in `configuration.mdx`