### PR TITLE
docs(linter/plugins): Correct available names of the severity diagnostic

### DIFF
--- a/src/content/docs/es/linter/plugins.mdx
+++ b/src/content/docs/es/linter/plugins.mdx
@@ -90,4 +90,4 @@ Apoya tres argumentos:
   normalmente de una variable que se empareja dentro de un fragmento de código.
 - `message` (obligatorio): El mensaje a mostrar con el diagnóstico.
 - `severity`: La gravedad del diagnóstico. Los valores permitidos son: `hint`,
-  `information`, `warning`, y `error`. Por defecto, se utiliza`error`.
+  `info`, `warn`, y `error`. Por defecto, se utiliza`error`.

--- a/src/content/docs/ja/linter/plugins.mdx
+++ b/src/content/docs/ja/linter/plugins.mdx
@@ -27,7 +27,7 @@ GritQLスニペットはプロジェクト内のどこにでも配置できま�
 
 ```json name="biome.json"
 {
-    "plugins": ["./path-to-plugin.grit"]
+  "plugins": ["./path-to-plugin.grit"]
 }
 ```
 
@@ -84,5 +84,5 @@ Biomeは現在、追加の関数を1つサポートしています：
 
 - `span`（必須）: 診断をアタッチするシンタックスノード。これは通常、コードスニペットの中でマッチした変数です。
 - `message`（必須）: 診断とともに表示するメッセージ。
-- `severity`: 診断の重大度。許容される値は `hint`、`information`、`warning`、`error` です。
+- `severity`: 診断の重大度。許容される値は `hint`、`info`、`warn`、`error` です。
   デフォルトでは、 `error` が使われます。

--- a/src/content/docs/linter/plugins.mdx
+++ b/src/content/docs/linter/plugins.mdx
@@ -91,4 +91,4 @@ Supports three arguments:
   typically a variable that you matched within a code snippet.
 - `message` (required): The message to show with the diagnostic.
 - `severity`: The severity of the diagnostic. Allowed values are: `hint`,
-  `information`, `warning`, and `error`. By default, `error` is used.
+  `info`, `warn`, and `error`. By default, `error` is used.


### PR DESCRIPTION
## Summary

I'm playing around with the plugin API in the beta version of `v2`.

I noticed a small discrepancy in the documentation after testing the following GritQL code:

```gritql
language js;

`describe($object.$property, $rest)`
where {
	$property <: `name`,
	register_diagnostic(
        span = $property,
        message = "Don't use `.name` - Vitest will use this property automatically",
	severity = "information"
    )
}
=> `describe($object, $rest)`
```

The compilation part didn't work because of the value in `severity`.

Following the source code:
https://github.com/biomejs/biome/blob/2333c7ad5ab1cd626dcc5dfe6049633340cd7252/crates/biome_diagnostics/src/diagnostic.rs#L137-L151

Renaming:
`information` -> `info`
`warning` -> `warn`

I also renamed it in the other languages, which have already translated the page, so I hope it avoids the confusion for others in advance.
