### PR TITLE
fix(lunaria): remove error root dir

### DIFF
--- a/lunaria.config.json
+++ b/lunaria.config.json
@@ -3,7 +3,6 @@
   "repository": {
     "name": "biomejs/website",
     "branch": "main",
-    "rootDir": "src/content/docs",
     "hosting": "github"
   },
   "dashboard": {


### PR DESCRIPTION
## Summary

This issue is caused by #1600. The `rootDir` in `lunaria.config.json` is set to `src/content/docs`, which results in all commit history URLs in the [i18n dashboard](https://biomejs.dev/i18n-dashboard/) being incorrect. For example:

```
https://github.com/biomejs/website/blob/main/src/content/docs/src/content/docs/ja/guides/editors/third-party-extensions.mdx
```

(Note the duplicated `src/content/docs`.)
