### PR TITLE
feat(playground): add semantic model tab

### DIFF
--- a/src/playground/Playground.tsx
+++ b/src/playground/Playground.tsx
@@ -49,6 +49,7 @@ import {
 	useState,
 } from "react";
 import AnalyzerFixesTab from "./tabs/AnalyzerFixesTab";
+import SemanticModelTab from "./tabs/SemanticModelTab";
 
 export default function Playground({
 	setPlaygroundState,
@@ -289,6 +290,16 @@ export default function Playground({
 					children: (
 						<TyeInfoTab
 							code={biomeOutput.types.registered}
+							extensions={codeMirrorExtensions}
+						/>
+					),
+				},
+				{
+					key: PlaygroundTab.SemanticModel,
+					title: "Semantic Model",
+					children: (
+						<SemanticModelTab
+							code={biomeOutput.analysis.semanticModel}
 							extensions={codeMirrorExtensions}
 						/>
 					),

--- a/src/playground/tabs/SemanticModelTab.tsx
+++ b/src/playground/tabs/SemanticModelTab.tsx
@@ -1,0 +1,18 @@
+import CodeMirror, { type BiomeExtension } from "@/playground/CodeMirror";
+
+interface Props {
+	code: string;
+	extensions: BiomeExtension[];
+}
+
+export default function SemanticModelTab({ code, extensions }: Props) {
+	return (
+		<CodeMirror
+			value={code}
+			readOnly={true}
+			extensions={extensions}
+			placeholder="Semantic model not available"
+			data-testid="semantic-model-tab"
+		/>
+	);
+}

--- a/src/playground/types.ts
+++ b/src/playground/types.ts
@@ -14,6 +14,7 @@ export enum PlaygroundTab {
 	AnalyzerFixes = "analyzer-fixes",
 	TypesIr = "types-ir",
 	TypesRegistered = "types-registered",
+	SemanticModel = "semantic-model",
 }
 
 export type { Options as PrettierOptions } from "prettier";
@@ -114,6 +115,7 @@ export interface BiomeOutput {
 	};
 	analysis: {
 		controlFlowGraph: string;
+		semanticModel: string;
 		/** The snippet with lint fixes applied. */
 		fixed: string;
 	};
@@ -138,6 +140,7 @@ export const emptyBiomeOutput: BiomeOutput = {
 	},
 	analysis: {
 		controlFlowGraph: "",
+		semanticModel: "",
 		fixed: "",
 	},
 	types: {

--- a/src/playground/workers/biomeWorker.ts
+++ b/src/playground/workers/biomeWorker.ts
@@ -283,6 +283,20 @@ self.addEventListener("message", async (e) => {
 				controlFlowGraph = "";
 			}
 
+			let semanticModel = "";
+			try {
+				semanticModel =
+					fileFeatures.featuresSupported.get("debug") === "supported"
+						? workspace.getSemanticModel({
+								projectKey,
+								path,
+							})
+						: "";
+			} catch (e) {
+				console.warn("Failed to get semantic model:", e);
+				semanticModel = "";
+			}
+
 			let typesIr = "";
 			try {
 				typesIr =
@@ -407,6 +421,7 @@ self.addEventListener("message", async (e) => {
 				},
 				analysis: {
 					controlFlowGraph,
+					semanticModel,
 					fixed: fixed.code,
 				},
 				types: {


### PR DESCRIPTION
## Summary

<!-- 
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

Expose a new tab for the semantic model debug printer. This will not work until https://github.com/biomejs/biome/pull/5821 is merged, and this PR is rebased to include it.

