### PR TITLE
docs: add @vitest/eslint-plugin as rule source

### DIFF
--- a/src/content/docs/linter/rules-sources.mdx
+++ b/src/content/docs/linter/rules-sources.mdx
@@ -6,43 +6,43 @@
 title: Rules sources
 description: A page that maps lint rules from other sources to Biome
 ---
-    
+
 ## Biome exclusive rules
-- [noAccumulatingSpread](/linter/rules/no-accumulating-spread) 
-- [noConsoleLog](/linter/rules/no-console-log) 
-- [noConstEnum](/linter/rules/no-const-enum) 
-- [noDelete](/linter/rules/no-delete) 
-- [noDuplicateObjectKeys](/linter/rules/no-duplicate-object-keys) 
-- [noDynamicNamespaceImportAccess](/linter/rules/no-dynamic-namespace-import-access) 
-- [noEmptyTypeParameters](/linter/rules/no-empty-type-parameters) 
-- [noEnum](/linter/rules/no-enum) 
-- [noEvolvingTypes](/linter/rules/no-evolving-types) 
-- [noExportedImports](/linter/rules/no-exported-imports) 
-- [noGlobalIsFinite](/linter/rules/no-global-is-finite) 
-- [noGlobalIsNan](/linter/rules/no-global-is-nan) 
-- [noImplicitAnyLet](/linter/rules/no-implicit-any-let) 
-- [noInvalidNewBuiltin](/linter/rules/no-invalid-new-builtin) 
-- [noRedundantUseStrict](/linter/rules/no-redundant-use-strict) 
-- [noRenderReturnValue](/linter/rules/no-render-return-value) 
-- [noShoutyConstants](/linter/rules/no-shouty-constants) 
-- [noSuspiciousSemicolonInJsx](/linter/rules/no-suspicious-semicolon-in-jsx) 
-- [noSvgWithoutTitle](/linter/rules/no-svg-without-title) 
-- [noUndeclaredDependencies](/linter/rules/no-undeclared-dependencies) 
-- [noUnnecessaryContinue](/linter/rules/no-unnecessary-continue) 
-- [noUnusedFunctionParameters](/linter/rules/no-unused-function-parameters) 
-- [noUnusedTemplateLiteral](/linter/rules/no-unused-template-literal) 
-- [noUselessStringRaw](/linter/rules/no-useless-string-raw) 
-- [noValueAtRule](/linter/rules/no-value-at-rule) 
-- [noVoidTypeReturn](/linter/rules/no-void-type-return) 
-- [useImportExtensions](/linter/rules/use-import-extensions) 
-- [useNodeAssertStrict](/linter/rules/use-node-assert-strict) 
-- [useShorthandArrayType](/linter/rules/use-shorthand-array-type) 
-- [useSimpleNumberKeys](/linter/rules/use-simple-number-keys) 
-- [useSimplifiedLogicExpression](/linter/rules/use-simplified-logic-expression) 
-- [useSingleCaseStatement](/linter/rules/use-single-case-statement) 
-- [useSortedClasses](/linter/rules/use-sorted-classes) 
-- [useStrictMode](/linter/rules/use-strict-mode) 
-- [useTopLevelRegex](/linter/rules/use-top-level-regex) 
+- [noAccumulatingSpread](/linter/rules/no-accumulating-spread)
+- [noConsoleLog](/linter/rules/no-console-log)
+- [noConstEnum](/linter/rules/no-const-enum)
+- [noDelete](/linter/rules/no-delete)
+- [noDuplicateObjectKeys](/linter/rules/no-duplicate-object-keys)
+- [noDynamicNamespaceImportAccess](/linter/rules/no-dynamic-namespace-import-access)
+- [noEmptyTypeParameters](/linter/rules/no-empty-type-parameters)
+- [noEnum](/linter/rules/no-enum)
+- [noEvolvingTypes](/linter/rules/no-evolving-types)
+- [noExportedImports](/linter/rules/no-exported-imports)
+- [noGlobalIsFinite](/linter/rules/no-global-is-finite)
+- [noGlobalIsNan](/linter/rules/no-global-is-nan)
+- [noImplicitAnyLet](/linter/rules/no-implicit-any-let)
+- [noInvalidNewBuiltin](/linter/rules/no-invalid-new-builtin)
+- [noRedundantUseStrict](/linter/rules/no-redundant-use-strict)
+- [noRenderReturnValue](/linter/rules/no-render-return-value)
+- [noShoutyConstants](/linter/rules/no-shouty-constants)
+- [noSuspiciousSemicolonInJsx](/linter/rules/no-suspicious-semicolon-in-jsx)
+- [noSvgWithoutTitle](/linter/rules/no-svg-without-title)
+- [noUndeclaredDependencies](/linter/rules/no-undeclared-dependencies)
+- [noUnnecessaryContinue](/linter/rules/no-unnecessary-continue)
+- [noUnusedFunctionParameters](/linter/rules/no-unused-function-parameters)
+- [noUnusedTemplateLiteral](/linter/rules/no-unused-template-literal)
+- [noUselessStringRaw](/linter/rules/no-useless-string-raw)
+- [noValueAtRule](/linter/rules/no-value-at-rule)
+- [noVoidTypeReturn](/linter/rules/no-void-type-return)
+- [useImportExtensions](/linter/rules/use-import-extensions)
+- [useNodeAssertStrict](/linter/rules/use-node-assert-strict)
+- [useShorthandArrayType](/linter/rules/use-shorthand-array-type)
+- [useSimpleNumberKeys](/linter/rules/use-simple-number-keys)
+- [useSimplifiedLogicExpression](/linter/rules/use-simplified-logic-expression)
+- [useSingleCaseStatement](/linter/rules/use-single-case-statement)
+- [useSortedClasses](/linter/rules/use-sorted-classes)
+- [useStrictMode](/linter/rules/use-strict-mode)
+- [useTopLevelRegex](/linter/rules/use-top-level-regex)
 ## Rules from other sources
 :::note
 Some **Biome** rules might **not** have options, compared to the original rule.
@@ -59,6 +59,15 @@ Some **Biome** rules might **not** have options, compared to the original rule.
 | [no-head-element](https://nextjs.org/docs/messages/no-head-element) |[noHeadElement](/linter/rules/no-head-element) |
 | [no-head-import-in-document](https://nextjs.org/docs/messages/no-head-import-in-document) |[noHeadImportInDocument](/linter/rules/no-head-import-in-document) |
 | [no-img-element](https://nextjs.org/docs/messages/no-img-element) |[noImgElement](/linter/rules/no-img-element) |
+### @vitest/eslint-plugin
+| @vitest/eslint-plugin rule name | Biome rule name |
+| ---- | ---- |
+| [max-nested-describe](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/max-nested-describe.md) |[noExcessiveNestedTestSuites](/linter/rules/no-excessive-nested-test-suites) |
+| [no-disabled-tests](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-disabled-tests.md) |[noSkippedTests](/linter/rules/no-skipped-tests) (inspired) |
+| [no-done-callback](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-done-callback.md) |[noDoneCallback](/linter/rules/no-done-callback) (inspired) |
+| [no-duplicate-hooks](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-duplicate-hooks.md) |[noDuplicateTestHooks](/linter/rules/no-duplicate-test-hooks) (inspired) |
+| [no-focused-tests](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-focused-tests.md) |[noFocusedTests](/linter/rules/no-focused-tests) (inspired) |
+| [no-standalone-expect](https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-standalone-expect.md) |[noMisplacedAssertion](/linter/rules/no-misplaced-assertion) (inspired) |
 ### Clippy
 | Clippy rule name | Biome rule name |
 | ---- | ---- |

--- a/src/content/docs/linter/rules/no-done-callback.mdx
+++ b/src/content/docs/linter/rules/no-done-callback.mdx
@@ -12,8 +12,9 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 <Tabs>
 <TabItem label="JavaScript (and super languages)" icon="seti:javascript">
 **Since**: `v1.6.1`
-Sources: 
+Sources:
 - Same as: <a href="https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-done-callback.md" target="_blank"><code>jest/no-done-callback</code></a>
+- Same as: <a href="https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-done-callback.md" target="_blank"><code>vitest/no-done-callback</code></a>
 
 ## Description
 Disallow using a callback in asynchronous tests and hooks.
@@ -75,4 +76,3 @@ test('test-name', () => {
 
 </TabItem>
 </Tabs>
-

--- a/src/content/docs/linter/rules/no-duplicate-test-hooks.mdx
+++ b/src/content/docs/linter/rules/no-duplicate-test-hooks.mdx
@@ -16,8 +16,9 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 - This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
-Sources: 
+Sources:
 - Inspired from: <a href="https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-duplicate-hooks.md" target="_blank"><code>jest/no-duplicate-hooks</code></a>
+- Inspired from: <a href="https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-duplicate-hooks.md" target="_blank"><code>vitest/no-duplicate-hooks</code></a>
 
 ## Description
 A `describe` block should not contain duplicate hooks.
@@ -94,4 +95,3 @@ describe('foo', () => {
 
 </TabItem>
 </Tabs>
-

--- a/src/content/docs/linter/rules/no-excessive-nested-test-suites.mdx
+++ b/src/content/docs/linter/rules/no-excessive-nested-test-suites.mdx
@@ -16,8 +16,9 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 - This rule is recommended by Biome. A diagnostic error will appear when linting your code.
 :::
 
-Sources: 
+Sources:
 - Same as: <a href="https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/max-nested-describe.md" target="_blank"><code>jest/max-nested-describe</code></a>
+- Same as: <a href="https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/max-nested-describe.md" target="_blank"><code>vitest/max-nested-describe</code></a>
 
 ## Description
 This rule enforces a maximum depth to nested `describe()` in test files.
@@ -86,4 +87,3 @@ describe('foo', () => {
 
 </TabItem>
 </Tabs>
-

--- a/src/content/docs/linter/rules/no-focused-tests.mdx
+++ b/src/content/docs/linter/rules/no-focused-tests.mdx
@@ -17,8 +17,9 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 - This rule has an **unsafe** fix.
 :::
 
-Sources: 
+Sources:
 - Inspired from: <a href="https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-focused-tests.md" target="_blank"><code>jest/no-focused-tests</code></a>
+- Inspired from: <a href="https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-focused-tests.mdd" target="_blank"><code>vitest/no-focused-tests</code></a>
 
 ## Description
 Disallow focused tests.
@@ -70,4 +71,3 @@ test("foo", () => {});
 
 </TabItem>
 </Tabs>
-

--- a/src/content/docs/linter/rules/no-misplaced-assertion.mdx
+++ b/src/content/docs/linter/rules/no-misplaced-assertion.mdx
@@ -12,8 +12,9 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 <Tabs>
 <TabItem label="JavaScript (and super languages)" icon="seti:javascript">
 **Since**: `v1.8.0`
-Sources: 
+Sources:
 - Inspired from: <a href="https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-standalone-expect.md" target="_blank"><code>jest/no-standalone-expect</code></a>
+- Inspired from: <a href="https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-standalone-expect.md" target="_blank"><code>vitest/no-standalone-expect</code></a>
 
 ## Description
 Checks that the assertion function, for example `expect`, is placed inside an `it()` function call.
@@ -142,4 +143,3 @@ await waitFor(() => {
 
 </TabItem>
 </Tabs>
-

--- a/src/content/docs/linter/rules/no-skipped-tests.mdx
+++ b/src/content/docs/linter/rules/no-skipped-tests.mdx
@@ -16,8 +16,9 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 - This rule has an **unsafe** fix.
 :::
 
-Sources: 
+Sources:
 - Inspired from: <a href="https://github.com/jest-community/eslint-plugin-jest/blob/main/docs/rules/no-disabled-tests.md" target="_blank"><code>jest/no-disabled-tests</code></a>
+- Inspired from: <a href="https://github.com/vitest-dev/eslint-plugin-vitest/blob/main/docs/rules/no-disabled-tests.md" target="_blank"><code>vitest/no-disabled-tests</code></a>
 
 ## Description
 Disallow disabled tests.
@@ -68,4 +69,3 @@ test("test", () => {});
 
 </TabItem>
 </Tabs>
-

--- a/src/pages/metadata/rules.json.js
+++ b/src/pages/metadata/rules.json.js
@@ -368,7 +368,8 @@ export function GET() {
             "fixKind": "none",
             "sources": [
               {
-                "eslintJest": "max-nested-describe"
+                "eslintJest": "max-nested-describe",
+                "eslintVitest": "max-nested-describe"
               }
             ],
             "sourceKind": "sameLogic",
@@ -1743,7 +1744,8 @@ export function GET() {
             "fixKind": "none",
             "sources": [
               {
-                "eslintJest": "no-done-callback"
+                "eslintJest": "no-done-callback",
+                "eslintVitest": "no-done-callback"
               }
             ],
             "docs": " Disallow using a callback in asynchronous tests and hooks.\n\n This rule checks the function parameter of hooks and tests for use of the `done` argument, suggesting you return a promise instead.\n\n ## Examples\n\n ### Invalid\n\n ```js,expect_diagnostic\n beforeEach((done) => {\n     // ...\n });\n ```\n\n ```js,expect_diagnostic\n test('tets-name', (done) => {\n     // ...\n });\n ```\n\n ### Valid\n\n ```js\n beforeEach(async () => {\n     // ...\n });\n ```\n\n ```js\n test('test-name', () => {\n     expect(myFunction()).toBeTruthy();\n });\n ```\n\n"
@@ -2410,7 +2412,8 @@ export function GET() {
             "fixKind": "none",
             "sources": [
               {
-                "eslintJest": "no-duplicate-hooks"
+                "eslintJest": "no-duplicate-hooks",
+                "eslintVitest": "no-duplicate-hooks"
               }
             ],
             "sourceKind": "inspired",
@@ -2477,7 +2480,8 @@ export function GET() {
             "fixKind": "unsafe",
             "sources": [
               {
-                "eslintJest": "no-focused-tests"
+                "eslintJest": "no-focused-tests",
+                "eslintVitest": "no-focused-tests"
               }
             ],
             "sourceKind": "inspired",
@@ -2580,7 +2584,8 @@ export function GET() {
             "fixKind": "none",
             "sources": [
               {
-                "eslintJest": "no-standalone-expect"
+                "eslintJest": "no-standalone-expect",
+                "eslintVitest": "no-standalone-expect"
               }
             ],
             "sourceKind": "inspired",
@@ -2694,7 +2699,8 @@ export function GET() {
             "fixKind": "unsafe",
             "sources": [
               {
-                "eslintJest": "no-disabled-tests"
+                "eslintJest": "no-disabled-tests",
+                "eslintVitest": "no-disabled-tests"
               }
             ],
             "sourceKind": "inspired",

--- a/src/pages/metadata/schema.json.js
+++ b/src/pages/metadata/schema.json.js
@@ -241,7 +241,14 @@ export function GET() {
 					"required": ["eslintNoSecrets"],
 					"properties": { "eslintNoSecrets": { "type": "string" } },
 					"additionalProperties": false
-				}
+				},
+				{
+					"description": "Rules from [Eslint Plugin Vitest](https://github.com/vitest-dev/eslint-plugin-vitest?)",
+					"type": "object",
+					"required": ["eslintVitest"],
+					"properties": { "eslintVitest": { "type": "string" } },
+					"additionalProperties": false
+				},
 			]
 		},
 		"RuleSourceKind": {


### PR DESCRIPTION
## Summary

`@vitest/eslint-plugin` mirrors `eslint-plugin-jest`, so Biome can count it as a rule source! Add mentions of Vitest to docs everywhere Jest is.

![CleanShot 2025-05-03 at 12 00 33@2x](https://github.com/user-attachments/assets/01b10af5-f7d2-456c-9853-3dca5842fa4e)


> [!NOTE]
> There’s one Jest rule, `no-export`, which does NOT exist in the Vitest plugin (dunno why). So you’ll notice out of 7 Jest rules, only 6 rules added Vitest as a source. This is intentional.

Resolves part of https://github.com/biomejs/biome/discussions/5862.