### PR TITLE
fix: remove unnecessary bullets from the playground tabs

### DIFF
--- a/src/styles/playground/_tabs.css
+++ b/src/styles/playground/_tabs.css
@@ -46,6 +46,8 @@
 	overflow-y: hidden;
 	font-size: 14px;
 	background-color: var(--sl-color-bg-nav);
+	padding: 0;
+	list-style: none;
 
 	li {
 		padding: 0 10px;


### PR DESCRIPTION
## Summary

Fixed CSS to remove bullets and unnecessary padding from the tabs list.

Before

<img width="712" alt="image" src="https://github.com/user-attachments/assets/2fab8b09-4af2-4702-9a58-dc59b0e29fe3" />

After

<img width="719" alt="image" src="https://github.com/user-attachments/assets/d3ae52ef-9979-46ff-80a6-1104e2808198" />
