### PR TITLE
docs: update override snippet for partial vue/svelte/astro support

### DIFF
--- a/src/content/docs/es/internals/language-support.mdx
+++ b/src/content/docs/es/internals/language-support.mdx
@@ -74,12 +74,16 @@ A partir de la versión `1.6.0`, estos idiomas están soportados **parcialmente*
   {
     "overrides": [
       {
-        "include": ["*.svelte", "*.astro", "*.vue"],
+        "includes": ["**/*.svelte", "**/*.astro", "**/*.vue"],
         "linter": {
           "rules": {
             "style": {
               "useConst": "off",
               "useImportType": "off"
+            },
+            "correctness": {
+              "noUnusedVariables": "off",
+              "noUnusedImports": "off"
             }
           }
         }

--- a/src/content/docs/fr/internals/language-support.mdx
+++ b/src/content/docs/fr/internals/language-support.mdx
@@ -69,19 +69,23 @@ Veuillez noter que certains fichiers bien connus comme `tsconfig.json` et `.babe
 - lors du **linting** des fichiers `.svelte`, `.astro` ou `.vue`, il est conseillé de désactiver certaines règles additionnelles pour empêcher des erreurs du compilateur. Pour cela, utilisez l’option `overrides`&nbsp;:
 
   ```json
-    {
-      "overrides": [
-        {
-          "include": ["*.svelte", "*.astro", "*.vue"],
-          "linter": {
-            "rules": {
-              "style": {
-                "useConst": "off",
-                "useImportType": "off"
-              }
+  {
+    "overrides": [
+      {
+        "includes": ["**/*.svelte", "**/*.astro", "**/*.vue"],
+        "linter": {
+          "rules": {
+            "style": {
+              "useConst": "off",
+              "useImportType": "off"
+            },
+            "correctness": {
+              "noUnusedVariables": "off",
+              "noUnusedImports": "off"
             }
           }
         }
-      ]
-    }
-    ```
+      }
+    ]
+  }
+  ```

--- a/src/content/docs/internals/language-support.mdx
+++ b/src/content/docs/internals/language-support.mdx
@@ -67,18 +67,22 @@ As of version `1.6.0`, these languages are **partially** supported. Biome will g
   </script>
   ```
 
-- When **linting** `.svelte`, `.astro` or `.vue` files, it's advised to turn off a few additional rules to prevent compiler errors. Use the option `overrides` for that:
+- When **linting** `.svelte`, `.astro` or `.vue` files, it's advised to turn off a few additional rules to prevent false positive linting errors caused by our partial support. Use the option `overrides` for that:
 
   ```json
   {
     "overrides": [
       {
-        "include": ["*.svelte", "*.astro", "*.vue"],
+        "includes": ["**/*.svelte", "**/*.astro", "**/*.vue"],
         "linter": {
           "rules": {
             "style": {
               "useConst": "off",
               "useImportType": "off"
+            },
+            "correctness": {
+              "noUnusedVariables": "off",
+              "noUnusedImports": "off"
             }
           }
         }

--- a/src/content/docs/ja/internals/language-support.mdx
+++ b/src/content/docs/ja/internals/language-support.mdx
@@ -67,19 +67,23 @@ JSONCは「コメント付きJSON」の略です。この形式は、[VS Code](h
 - `.svelte` 、`.astro` 、 `.vue` ファイルを**静的解析**する際、コンパイラエラーを防ぐためにいくつかのルールをオフにすることをお勧めします。オプション `overrides` を使用します：
 
   ```json
-    {
-      "overrides": [
-        {
-          "include": ["*.svelte", "*.astro", "*.vue"],
-          "linter": {
-            "rules": {
-              "style": {
-                "useConst": "off",
-                "useImportType": "off"
-              }
+  {
+    "overrides": [
+      {
+        "includes": ["**/*.svelte", "**/*.astro", "**/*.vue"],
+        "linter": {
+          "rules": {
+            "style": {
+              "useConst": "off",
+              "useImportType": "off"
+            },
+            "correctness": {
+              "noUnusedVariables": "off",
+              "noUnusedImports": "off"
             }
           }
         }
-      ]
-    }
-    ```
+      }
+    ]
+  }
+  ```


### PR DESCRIPTION
## Summary

<!-- 
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

https://github.com/biomejs/biome/issues/6049 alerted us that this page was outdated. I've fixed the snippet at the end to use the new `includes` and the correct globs. I've also added a couple new rules that I've found need to be disabled via dogfooding biome on my own projects.

