### PR TITLE
fix(playground): extract projectKey from OpenProjectResult

### DIFF
--- a/src/playground/workers/biomeWorker.ts
+++ b/src/playground/workers/biomeWorker.ts
@@ -58,7 +58,7 @@ self.addEventListener("message", async (e) => {
 				projectKey = workspace.openProject({
 					openUninitialized: true,
 					path: "/",
-				});
+				}).projectKey;
 
 				self.postMessage({ type: "init", loadingState: LoadingState.Success });
 			} catch (err) {


### PR DESCRIPTION
## Summary

Fixed the `Workspace#openProject` call to extract the project key from the result, as the interface was recently changed in https://github.com/biomejs/biome/pull/6099.