### PR TITLE
fix: correct key in overrides in monorepo docs

### DIFF
--- a/src/content/docs/guides/big-projects.mdx
+++ b/src/content/docs/guides/big-projects.mdx
@@ -115,7 +115,7 @@ In the following example we disable the rule `suspicious/noConsoleLog` inside th
     }
   },
   "overrides": [{
-      "include": ["packages/logger/**"],
+      "includes": ["packages/logger/**"],
       "linter": {
         "rules": {
           "suspicious": {


### PR DESCRIPTION
## Summary

The docs suggest using the key `include` in the `overrides` array in the monorepo section. The correct key is `includes` (with a s)