### PR TITLE
feat(api): add versions endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
   },
   "packageManager": "pnpm@10.10.0",
   "dependencies": {
+    "@biomejs/version-utils": "^0.4.0",
     "starlight-links-validator": "^0.16.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,25 +8,28 @@ importers:
 
   .:
     dependencies:
+      '@biomejs/version-utils':
+        specifier: ^0.4.0
+        version: 0.4.0
       starlight-links-validator:
         specifier: ^0.16.0
-        version: 0.16.0(@astrojs/starlight@0.34.3(astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3)))
+        version: 0.16.0(@astrojs/starlight@0.34.3(astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3)(yaml@2.8.0)))
     devDependencies:
       '@astrojs/netlify':
         specifier: 6.3.4
-        version: 6.3.4(@types/node@20.17.50)(astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3))(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))
+        version: 6.3.4(@types/node@20.17.50)(astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3)(yaml@2.8.0))(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(yaml@2.8.0)
       '@astrojs/prism':
         specifier: 3.3.0
         version: 3.3.0
       '@astrojs/react':
         specifier: 4.3.0
-        version: 4.3.0(@types/node@20.17.50)(@types/react-dom@18.3.7(@types/react@18.3.22))(@types/react@18.3.22)(jiti@1.21.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))
+        version: 4.3.0(@types/node@20.17.50)(@types/react-dom@18.3.7(@types/react@18.3.22))(@types/react@18.3.22)(jiti@1.21.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(yaml@2.8.0)
       '@astrojs/rss':
         specifier: 4.0.11
         version: 4.0.11
       '@astrojs/starlight':
         specifier: 0.34.3
-        version: 0.34.3(astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3))
+        version: 0.34.3(astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3)(yaml@2.8.0))
       '@biomejs/biome':
         specifier: 1.9.4
         version: 1.9.4
@@ -62,7 +65,7 @@ importers:
         version: 0.1.1
       '@lunariajs/starlight':
         specifier: 0.1.1
-        version: 0.1.1(@astrojs/starlight@0.34.3(astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3)))(astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3))
+        version: 0.1.1(@astrojs/starlight@0.34.3(astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3)(yaml@2.8.0)))(astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3)(yaml@2.8.0))
       '@playwright/test':
         specifier: 1.52.0
         version: 1.52.0
@@ -83,13 +86,13 @@ importers:
         version: 4.23.12(@babel/runtime@7.24.4)(@codemirror/autocomplete@6.15.0(@codemirror/language@6.10.1)(@codemirror/state@6.5.2)(@codemirror/view@6.36.8)(@lezer/common@1.2.1))(@codemirror/language@6.10.1)(@codemirror/lint@6.8.5)(@codemirror/search@6.5.6)(@codemirror/state@6.5.2)(@codemirror/theme-one-dark@6.1.2)(@codemirror/view@6.36.8)(codemirror@6.0.1(@lezer/common@1.2.1))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@vitejs/plugin-react':
         specifier: 4.4.1
-        version: 4.4.1(vite@6.3.5(@types/node@20.17.50)(jiti@1.21.7)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3)))
+        version: 4.4.1(vite@6.3.5(@types/node@20.17.50)(jiti@1.21.7)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(yaml@2.8.0))
       astro:
         specifier: 5.8.0
-        version: 5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3)
+        version: 5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3)(yaml@2.8.0)
       astro-og-canvas:
         specifier: 0.7.0
-        version: 0.7.0(astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3))
+        version: 0.7.0(astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3)(yaml@2.8.0))
       autoprefixer:
         specifier: 10.4.21
         version: 10.4.21(postcss@8.5.3)
@@ -143,7 +146,7 @@ importers:
         version: 0.34.2
       starlight-blog:
         specifier: 0.21.0
-        version: 0.21.0(@astrojs/starlight@0.34.3(astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3)))(astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3))
+        version: 0.21.0(@astrojs/starlight@0.34.3(astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3)(yaml@2.8.0)))(astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3)(yaml@2.8.0))
       textlint:
         specifier: 14.7.2
         version: 14.7.2
@@ -158,10 +161,10 @@ importers:
         version: 5.8.3
       vite:
         specifier: 6.3.5
-        version: 6.3.5(@types/node@20.17.50)(jiti@1.21.7)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))
+        version: 6.3.5(@types/node@20.17.50)(jiti@1.21.7)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(yaml@2.8.0)
       vite-plugin-svgr:
         specifier: 4.3.0
-        version: 4.3.0(rollup@4.40.1)(typescript@5.8.3)(vite@6.3.5(@types/node@20.17.50)(jiti@1.21.7)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3)))
+        version: 4.3.0(rollup@4.40.1)(typescript@5.8.3)(vite@6.3.5(@types/node@20.17.50)(jiti@1.21.7)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(yaml@2.8.0))
 
 packages:
 
@@ -426,6 +429,9 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
+
+  '@biomejs/version-utils@0.4.0':
+    resolution: {integrity: sha512-jboDhjZY8/bAPl2kgvjrbbyXyM6uimPsasY3TvFhSpPaNorij0UZROi/NjDQqQeZFSaIK3ieiRZXWwoBZh6rQQ==}
 
   '@biomejs/wasm-web@https://pkg.pr.new/biomejs/biome/@biomejs/wasm-web@07775c7':
     resolution: {tarball: https://pkg.pr.new/biomejs/biome/@biomejs/wasm-web@07775c7}
@@ -4893,6 +4899,10 @@ packages:
   undici-types@6.19.6:
     resolution: {integrity: sha512-e/vggGopEfTKSvj4ihnOLTsqhrKRN3LeO6qSN/GxohhuRv8qH9bNQ4B8W7e/vFL+0XTnmHPB4/kegunZGA4Org==}
 
+  undici@6.21.3:
+    resolution: {integrity: sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==}
+    engines: {node: '>=18.17'}
+
   unicode-properties@1.4.1:
     resolution: {integrity: sha512-CLjCCLQ6UuMxWnbIylkisbRj31qxHPAurvena/0iwSVbQ2G1VY5/HjV0IRabOEbDHlzZlRdCrD4NhB0JtU40Pg==}
 
@@ -5220,6 +5230,11 @@ packages:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
 
+  yaml@2.8.0:
+    resolution: {integrity: sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
@@ -5335,12 +5350,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@4.2.4(astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3))':
+  '@astrojs/mdx@4.2.4(astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3)(yaml@2.8.0))':
     dependencies:
       '@astrojs/markdown-remark': 6.3.1
       '@mdx-js/mdx': 3.1.0(acorn@8.14.1)
       acorn: 8.14.1
-      astro: 5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3)
+      astro: 5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3)(yaml@2.8.0)
       es-module-lexer: 1.6.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -5354,17 +5369,17 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/netlify@6.3.4(@types/node@20.17.50)(astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3))(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))':
+  '@astrojs/netlify@6.3.4(@types/node@20.17.50)(astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3)(yaml@2.8.0))(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(yaml@2.8.0)':
     dependencies:
       '@astrojs/internal-helpers': 0.6.1
       '@astrojs/underscore-redirects': 0.6.1
       '@netlify/blobs': 8.2.0
       '@netlify/functions': 3.1.8(rollup@4.40.1)
       '@vercel/nft': 0.29.2(rollup@4.40.1)
-      astro: 5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3)
+      astro: 5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3)(yaml@2.8.0)
       esbuild: 0.25.4
       tinyglobby: 0.2.13
-      vite: 6.3.5(@types/node@20.17.50)(jiti@1.21.7)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))
+      vite: 6.3.5(@types/node@20.17.50)(jiti@1.21.7)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(yaml@2.8.0)
     transitivePeerDependencies:
       - '@types/node'
       - encoding
@@ -5389,15 +5404,15 @@ snapshots:
     dependencies:
       prismjs: 1.30.0
 
-  '@astrojs/react@4.3.0(@types/node@20.17.50)(@types/react-dom@18.3.7(@types/react@18.3.22))(@types/react@18.3.22)(jiti@1.21.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))':
+  '@astrojs/react@4.3.0(@types/node@20.17.50)(@types/react-dom@18.3.7(@types/react@18.3.22))(@types/react@18.3.22)(jiti@1.21.7)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(yaml@2.8.0)':
     dependencies:
       '@types/react': 18.3.22
       '@types/react-dom': 18.3.7(@types/react@18.3.22)
-      '@vitejs/plugin-react': 4.4.1(vite@6.3.5(@types/node@20.17.50)(jiti@1.21.7)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3)))
+      '@vitejs/plugin-react': 4.4.1(vite@6.3.5(@types/node@20.17.50)(jiti@1.21.7)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(yaml@2.8.0))
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       ultrahtml: 1.6.0
-      vite: 6.3.5(@types/node@20.17.50)(jiti@1.21.7)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))
+      vite: 6.3.5(@types/node@20.17.50)(jiti@1.21.7)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(yaml@2.8.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -5423,17 +5438,17 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 3.24.2
 
-  '@astrojs/starlight@0.34.3(astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3))':
+  '@astrojs/starlight@0.34.3(astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3)(yaml@2.8.0))':
     dependencies:
       '@astrojs/markdown-remark': 6.3.1
-      '@astrojs/mdx': 4.2.4(astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3))
+      '@astrojs/mdx': 4.2.4(astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3)(yaml@2.8.0))
       '@astrojs/sitemap': 3.3.0
       '@pagefind/default-ui': 1.3.0
       '@types/hast': 3.0.4
       '@types/js-yaml': 4.0.9
       '@types/mdast': 4.0.4
-      astro: 5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3)
-      astro-expressive-code: 0.41.1(astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3))
+      astro: 5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3)(yaml@2.8.0)
+      astro-expressive-code: 0.41.1(astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3)(yaml@2.8.0))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.2
@@ -5716,6 +5731,12 @@ snapshots:
 
   '@biomejs/cli-win32-x64@1.9.4':
     optional: true
+
+  '@biomejs/version-utils@0.4.0':
+    dependencies:
+      semver: 7.7.2
+      undici: 6.21.3
+      yaml: 2.8.0
 
   '@biomejs/wasm-web@https://pkg.pr.new/biomejs/biome/@biomejs/wasm-web@07775c7': {}
 
@@ -6276,11 +6297,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@lunariajs/starlight@0.1.1(@astrojs/starlight@0.34.3(astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3)))(astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3))':
+  '@lunariajs/starlight@0.1.1(@astrojs/starlight@0.34.3(astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3)(yaml@2.8.0)))(astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3)(yaml@2.8.0))':
     dependencies:
-      '@astrojs/starlight': 0.34.3(astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3))
+      '@astrojs/starlight': 0.34.3(astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3)(yaml@2.8.0))
       '@lunariajs/core': 0.1.1
-      astro: 5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3)
+      astro: 5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3)(yaml@2.8.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -6991,14 +7012,14 @@ snapshots:
       - rollup
       - supports-color
 
-  '@vitejs/plugin-react@4.4.1(vite@6.3.5(@types/node@20.17.50)(jiti@1.21.7)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3)))':
+  '@vitejs/plugin-react@4.4.1(vite@6.3.5(@types/node@20.17.50)(jiti@1.21.7)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(yaml@2.8.0))':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.10)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.10)
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.3.5(@types/node@20.17.50)(jiti@1.21.7)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))
+      vite: 6.3.5(@types/node@20.17.50)(jiti@1.21.7)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(yaml@2.8.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -7145,14 +7166,14 @@ snapshots:
 
   astring@1.8.6: {}
 
-  astro-expressive-code@0.41.1(astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3)):
+  astro-expressive-code@0.41.1(astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3)(yaml@2.8.0)):
     dependencies:
-      astro: 5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3)
+      astro: 5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3)(yaml@2.8.0)
       rehype-expressive-code: 0.41.1
 
-  astro-og-canvas@0.7.0(astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3)):
+  astro-og-canvas@0.7.0(astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3)(yaml@2.8.0)):
     dependencies:
-      astro: 5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3)
+      astro: 5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3)(yaml@2.8.0)
       canvaskit-wasm: 0.39.1
       deterministic-object-hash: 2.0.2
       entities: 4.5.0
@@ -7165,7 +7186,7 @@ snapshots:
       marked-smartypants: 1.1.9(marked@12.0.2)
       ultrahtml: 1.6.0
 
-  astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3):
+  astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3)(yaml@2.8.0):
     dependencies:
       '@astrojs/compiler': 2.11.0
       '@astrojs/internal-helpers': 0.6.1
@@ -7220,8 +7241,8 @@ snapshots:
       unist-util-visit: 5.0.0
       unstorage: 1.15.0(@netlify/blobs@8.2.0)
       vfile: 6.0.3
-      vite: 6.3.5(@types/node@20.17.50)(jiti@1.21.7)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))
-      vitefu: 1.0.6(vite@6.3.5(@types/node@20.17.50)(jiti@1.21.7)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3)))
+      vite: 6.3.5(@types/node@20.17.50)(jiti@1.21.7)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(yaml@2.8.0)
+      vitefu: 1.0.6(vite@6.3.5(@types/node@20.17.50)(jiti@1.21.7)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(yaml@2.8.0))
       xxhash-wasm: 1.1.0
       yargs-parser: 21.1.1
       yocto-spinner: 0.2.1
@@ -10929,11 +10950,11 @@ snapshots:
 
   stack-trace@0.0.10: {}
 
-  starlight-blog@0.21.0(@astrojs/starlight@0.34.3(astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3)))(astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3)):
+  starlight-blog@0.21.0(@astrojs/starlight@0.34.3(astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3)(yaml@2.8.0)))(astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3)(yaml@2.8.0)):
     dependencies:
-      '@astrojs/mdx': 4.2.4(astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3))
+      '@astrojs/mdx': 4.2.4(astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3)(yaml@2.8.0))
       '@astrojs/rss': 4.0.11
-      '@astrojs/starlight': 0.34.3(astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3))
+      '@astrojs/starlight': 0.34.3(astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3)(yaml@2.8.0))
       astro-remote: 0.3.3
       github-slugger: 2.0.0
       marked: 15.0.4
@@ -10943,9 +10964,9 @@ snapshots:
       - astro
       - supports-color
 
-  starlight-links-validator@0.16.0(@astrojs/starlight@0.34.3(astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3))):
+  starlight-links-validator@0.16.0(@astrojs/starlight@0.34.3(astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3)(yaml@2.8.0))):
     dependencies:
-      '@astrojs/starlight': 0.34.3(astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3))
+      '@astrojs/starlight': 0.34.3(astro@5.8.0(@netlify/blobs@8.2.0)(@types/node@20.17.50)(jiti@1.21.7)(rollup@4.40.1)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(typescript@5.8.3)(yaml@2.8.0))
       '@types/picomatch': 3.0.2
       github-slugger: 2.0.0
       hast-util-from-html: 2.0.3
@@ -11225,6 +11246,8 @@ snapshots:
 
   undici-types@6.19.6: {}
 
+  undici@6.21.3: {}
+
   unicode-properties@1.4.1:
     dependencies:
       base64-js: 1.5.1
@@ -11425,18 +11448,18 @@ snapshots:
       '@types/unist': 3.0.2
       vfile-message: 4.0.2
 
-  vite-plugin-svgr@4.3.0(rollup@4.40.1)(typescript@5.8.3)(vite@6.3.5(@types/node@20.17.50)(jiti@1.21.7)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))):
+  vite-plugin-svgr@4.3.0(rollup@4.40.1)(typescript@5.8.3)(vite@6.3.5(@types/node@20.17.50)(jiti@1.21.7)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(yaml@2.8.0)):
     dependencies:
       '@rollup/pluginutils': 5.1.3(rollup@4.40.1)
       '@svgr/core': 8.1.0(typescript@5.8.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.8.3))
-      vite: 6.3.5(@types/node@20.17.50)(jiti@1.21.7)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))
+      vite: 6.3.5(@types/node@20.17.50)(jiti@1.21.7)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(yaml@2.8.0)
     transitivePeerDependencies:
       - rollup
       - supports-color
       - typescript
 
-  vite@6.3.5(@types/node@20.17.50)(jiti@1.21.7)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3)):
+  vite@6.3.5(@types/node@20.17.50)(jiti@1.21.7)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(yaml@2.8.0):
     dependencies:
       esbuild: 0.25.0
       fdir: 6.4.4(picomatch@4.0.2)
@@ -11450,10 +11473,11 @@ snapshots:
       jiti: 1.21.7
       sass: 1.77.8
       sugarss: 4.0.1(postcss@8.5.3)
+      yaml: 2.8.0
 
-  vitefu@1.0.6(vite@6.3.5(@types/node@20.17.50)(jiti@1.21.7)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))):
+  vitefu@1.0.6(vite@6.3.5(@types/node@20.17.50)(jiti@1.21.7)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(yaml@2.8.0)):
     optionalDependencies:
-      vite: 6.3.5(@types/node@20.17.50)(jiti@1.21.7)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))
+      vite: 6.3.5(@types/node@20.17.50)(jiti@1.21.7)(sass@1.77.8)(sugarss@4.0.1(postcss@8.5.3))(yaml@2.8.0)
 
   vscode-languageserver-types@3.17.5: {}
 
@@ -11540,6 +11564,8 @@ snapshots:
   yallist@4.0.0: {}
 
   yallist@5.0.0: {}
+
+  yaml@2.8.0: {}
 
   yargs-parser@21.1.1: {}
 

--- a/src/pages/api/versions.ts
+++ b/src/pages/api/versions.ts
@@ -1,6 +1,8 @@
 import { getAllVersions } from "@biomejs/version-utils";
 import type { APIRoute } from "astro";
 
+export const prerender = false;
+
 export const GET: APIRoute = async ({ request }) => {
 	const url = new URL(request.url);
 

--- a/src/pages/api/versions.ts
+++ b/src/pages/api/versions.ts
@@ -1,0 +1,24 @@
+import { getAllVersions } from "@biomejs/version-utils";
+import type { APIRoute } from "astro";
+
+export const GET: APIRoute = async ({ request }) => {
+	const url = new URL(request.url);
+
+	const includePrereleases = url.searchParams.get("prereleases") === "true";
+	const wantedFormat = request.headers.get("Accept") || "application/json";
+	const versions = (await getAllVersions(includePrereleases)) ?? [];
+
+	if (wantedFormat === "text/plain") {
+		return new Response(versions.join("\n"), {
+			headers: {
+				"Content-Type": "text/plain",
+			},
+		});
+	}
+
+	return new Response(JSON.stringify(versions), {
+		headers: {
+			"Content-Type": "application/json",
+		},
+	});
+};

--- a/src/pages/api/versions/latest.ts
+++ b/src/pages/api/versions/latest.ts
@@ -1,0 +1,24 @@
+import { getLatestVersion } from "@biomejs/version-utils";
+import type { APIRoute } from "astro";
+
+export const GET: APIRoute = async ({ request }) => {
+	const url = new URL(request.url);
+
+	const prerelease = url.searchParams.get("prerelease") === "true";
+	const wantedFormat = request.headers.get("Accept") || "application/json";
+	const version = await getLatestVersion(prerelease ? "nightly" : "stable");
+
+	if (wantedFormat === "text/plain") {
+		return new Response(version, {
+			headers: {
+				"Content-Type": "text/plain",
+			},
+		});
+	}
+
+	return new Response(JSON.stringify({ version: version }), {
+		headers: {
+			"Content-Type": "application/json",
+		},
+	});
+};

--- a/src/pages/api/versions/latest.ts
+++ b/src/pages/api/versions/latest.ts
@@ -1,6 +1,8 @@
 import { getLatestVersion } from "@biomejs/version-utils";
 import type { APIRoute } from "astro";
 
+export const prerender = false;
+
 export const GET: APIRoute = async ({ request }) => {
 	const url = new URL(request.url);
 


### PR DESCRIPTION
## Summary

This PR introduces two new API endpoints for retrieving both the list of all Biome versions and the latest version. The purpose of these endpoints is to make it easier for first-party tooling to list and find those versions.

Both endpoints support content negotiation to serve either JSON (default) or plain text, depending on whether the `Accept` header is set to `text/plain` or `application/json`.

### Retrieving all versions

The `/api/versions` endpoint returns the list of all Biome versions, sorted in descending order (latest first). By default it only includes stable versions, but pre-release versions can be included with `?prereleases=true`

```sh
# Get all stable versions as JSON
curl https://biomejs.dev/api/versions

# Get all stable versions as plain text
curl -H 'Accept: text/plain' https://biomejs.dev/api/versions

# Get all stable + prereleases as JSON
curl https://biomejs.dev/api/versions?prereleases=true

# Get all stable + prereleases as plain text
curl -H 'Accept: text/plain' https://biomejs.dev/api/versions?prereleases=true
```


### Retrieving the latest version

The `/api/versions/latest` endpoint returns the latest version of Biome. By default, the latest stable version is returned, but the latest prerelease can be returned as well with `?prerelease=true`.


```sh
# Get the latest stable as JSON
curl https://biomejs.dev/api/versions/latest

# Get the latest stable as plain text
curl -H 'Accept: text/plain' https://biomejs.dev/api/versions/latest
```
