### PR TITLE
Remove references to Issue #2228 after closure

### DIFF
--- a/src/content/docs/es/guides/big-projects.mdx
+++ b/src/content/docs/es/guides/big-projects.mdx
@@ -87,8 +87,6 @@ Vamos a `app/backend/biome.json`, donde tenemos que activar el linting:
 
 Los monorrepositorios son repositorios particulares en los que se almacenan y mantienen múltiples bibliotecas en un gran repositorio. Cada biblioteca representa un proyecto autónomo, que puede contener diferentes configuraciones.
 
-Biome no soporta monorepos muy bien debido a algunas limitaciones en la resolución de archivos de configuración anidados, puedes [ayudar y seguir la discusión del fallo](https://github.com/biomejs/biome/issues/2228).
-
 Para tener la mejor experiencia de desarrollo a pesar de la limitación actual, se recomienda tener un `biome.json` en la raíz del monorepo, y utilizar la configuración [`overrides`](/reference/configuration/#overrides) para cambiar el comportamiento de Biome en determinados paquetes.
 
 En el siguiente ejemplo desactivamos la regla `suspicious/noConsoleLog` dentro del paquete `packages/logger`.

--- a/src/content/docs/es/guides/configure-biome.mdx
+++ b/src/content/docs/es/guides/configure-biome.mdx
@@ -90,10 +90,6 @@ A continuación, un ejemplo:
 - Comandos de Biome que se ejecutan en `app/frontend/legacy/package.json` y `app/frontend/new/package.json`
   utilizarán el archivo de configuración `app/frontend/biome.json`;
 
-:::caution
-Biome no soporta archivos `biome.json` anidados, ni en CLI ni en LSP. [ Sigue y ayuda al soporte en el tema relacionado](https://github.com/biomejs/biome/issues/2228)
-:::
-
 :::note
 Los comandos de Biome admiten el uso de la opción `--config-path` y la variable de entorno `BIOME_CONFIG_PATH`.
 Esto te permite especificar un archivo de configuración personalizado o un directorio donde Biome puede buscar un archivo `biome.json` o `biome.jsonc`.

--- a/src/content/docs/fr/guides/big-projects.mdx
+++ b/src/content/docs/fr/guides/big-projects.mdx
@@ -99,8 +99,6 @@ Passons à `app/backend/biome.json`, où nous avons besoin d’activer le lintin
 
 Les monorepos sont des dépôts particuliers où plusieurs libraries sont stockées et maintenues dans un seul gros dépôt. Chaque librairie représente un projet indépendant, qui peut contenir différentes configurations.
 
-Biome ne prend pas très bien en charge les monorepos en raison de certaines limites dans la résolution des fichiers de configuration imbriqués. Vous pouvez [aider en suivant le ticket correspondant](https://github.com/biomejs/biome/issues/2228).
-
 Pour une meilleure expérience développeur malgré les limites actuelles, il est conseillé d’avoir un `biome.json` à la racine du monorepo et d’utiliser la configuration [`overrides`](/fr/reference/configuration/#overrides) pour changer le comportement de Biome dans certains paquets.
 
 Dans l’exemple suivant, nous désactivons la règle `suspicious/noConsoleLog` dans le paquet `packages/logger`.

--- a/src/content/docs/fr/guides/configure-biome.mdx
+++ b/src/content/docs/fr/guides/configure-biome.mdx
@@ -99,10 +99,6 @@ Voici un exemple&nbsp;:
 - les commandes de Biome qui s’exécutent dans `app/frontend/legacy/package.json` et `app/frontend/new/package.json`
 utiliseront le fichier de configuration `app/frontend/biome.json`&nbsp;;
 
-:::caution
-Biome ne prend pas en charge les fichiers `biome.json` imbriqués, ni en ligne de commande ni en LSP. [Suivre et aider à la prise en charge dans le ticket correspondant](https://github.com/biomejs/biome/issues/2228)
-:::
-
 :::note
 Les commandes de Biome prennent en charge l’utilisation de l’option `--config-path` et de la variable d’environnement `BIOME_CONFIG_PATH`,
 ce qui vous permet de spécifier un fichier de configuration personnalisé ou un répertoire où Biome peut trouver un fichier `biome.json` ou `biome.jsonc`.

--- a/src/content/docs/guides/big-projects.mdx
+++ b/src/content/docs/guides/big-projects.mdx
@@ -99,8 +99,6 @@ Let's jump to `app/backend/biome.json`, where we need to enable the linting:
 
 Monorepos are particular repositories where multiple libraries are stored and maintained in one big repository. Each library represents a self-contained project, which can contain different configurations.
 
-Biome doesn't support monorepos very well due to some limitations in resolving nested configuration files, you [help and follow the relative issue](https://github.com/biomejs/biome/issues/2228).
-
 In order to have the best developer experience despite the current limitation, it's advised to have a `biome.json` at the root of the monorepo, and use the [`overrides`](/reference/configuration/#overrides) configuration to change the behaviour of Biome in certain packages.
 
 In the following example we disable the rule `suspicious/noConsoleLog` inside the package `packages/logger`.

--- a/src/content/docs/guides/configure-biome.mdx
+++ b/src/content/docs/guides/configure-biome.mdx
@@ -100,10 +100,6 @@ Here's an example:
 - Biome commands that run in `app/frontend/legacy/package.json` and `app/frontend/new/package.json`
 will use the configuration file `app/frontend/biome.json`;
 
-:::caution
-Biome doesn't support nested `biome.json` files, neither in CLI nor in LSP. [Follow and help the support in the related issue](https://github.com/biomejs/biome/issues/2228)
-:::
-
 :::note
 Biome commands support using the `--config-path` option and the `BIOME_CONFIG_PATH` environment variable.
 This allows you to specify a custom configuration file or a directory where Biome can look for a `biome.json` or `biome.jsonc` file.


### PR DESCRIPTION
[Monorepo support #2228
](https://github.com/biomejs/biome/issues/2228) has closed and is now supported. This removes references to it in documentation. 

<!-- 
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->