### PR TITLE
style: remove hero grid

### DIFF
--- a/src/components/starlight/Hero.astro
+++ b/src/components/starlight/Hero.astro
@@ -5,34 +5,12 @@ import Default from "@astrojs/starlight/components/Hero.astro";
 <Default {...Astro.props}>
   <slot />
 </Default>
-<div aria-hidden="true" class="grid"></div>
 
 <script>
   import "@/frontend-scripts/hover.ts";
 </script>
 
 <style>
-  .grid {
-    z-index: -1;
-    position: absolute;
-    content: "";
-    inset: 0;
-    background-image: linear-gradient(
-        to right,
-        var(--sl-color-gray-6) 0.06rem,
-        transparent 0.06rem
-      ),
-      linear-gradient(
-        to bottom,
-        var(--sl-color-gray-6) 0.06rem,
-        transparent 0.06rem
-      );
-    background-position: top center;
-    background-size: 1.3rem 1.3rem;
-    -webkit-mask-image: radial-gradient(circle at 100%, white, transparent 80%);
-    mask-image: radial-gradient(circle at 100%, white, transparent 80%);
-  }
-
   :global([data-has-hero] .page) {
     background:
       radial-gradient(var(--sl-color-accent-low), transparent 50%) no-repeat -60vw -50vh /

--- a/src/content/docs/es/index.mdx
+++ b/src/content/docs/es/index.mdx
@@ -48,7 +48,6 @@ import NumberOfRules from "@/components/generated/linter/NumberOfRules.astro";
 import AwardBanner from "@/components/AwardBanner.astro";
 
 <div class="gradient"></div>
-<div class="grid"></div>
 
 <div class="hero-code">
     <h2 class="head">Formatear el código como Prettier y ahorra tiempo</h2>

--- a/src/content/docs/fr/index.mdx
+++ b/src/content/docs/fr/index.mdx
@@ -44,7 +44,6 @@ import NumberOfRules from "@/components/generated/linter/NumberOfRules.astro";
 import AwardBanner from "@/components/AwardBanner.astro"
 
 <div class="gradient"></div>
-<div class="grid"></div>
 
 
 <div class="hero-code">

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -48,8 +48,6 @@ import NumberOfRules from "@/components/generated/linter/NumberOfRules.astro";
 import AwardBanner from "@/components/AwardBanner.astro"
 
 <div class="gradient"></div>
-<div class="grid"></div>
-
 
 <div class="hero-code">
     <h2 class="head">Format code like Prettier, save time</h2>

--- a/src/content/docs/ja/index.mdx
+++ b/src/content/docs/ja/index.mdx
@@ -43,7 +43,6 @@ import LinterExample from "@/components/linter/example.md";
 import AwardBanner from "@/components/AwardBanner.astro"
 
 <div class="gradient"></div>
-<div class="grid"></div>
 
 
 <div class="hero-code">

--- a/src/content/docs/pt-BR/index.mdx
+++ b/src/content/docs/pt-BR/index.mdx
@@ -43,7 +43,6 @@ import LinterExample from "@/components/linter/example.md";
 import AwardBanner from "@/components/AwardBanner.astro"
 
 <div class="gradient"></div>
-<div class="grid"></div>
 
 <div class="hero-code">
     <h2 class="head">Formata código como o Prettier e economiza tempo</h2>

--- a/src/content/docs/uk/index.mdx
+++ b/src/content/docs/uk/index.mdx
@@ -44,7 +44,6 @@ import NumberOfRules from "@/components/generated/linter/NumberOfRules.astro";
 import AwardBanner from "@/components/AwardBanner.astro";
 
 <div class="gradient"></div>
-<div class="grid"></div>
 
 <div class="hero-code">
   <h2 class="head">Форматуй код як Prettier, заощаджуй час</h2>

--- a/src/content/docs/zh-CN/index.mdx
+++ b/src/content/docs/zh-CN/index.mdx
@@ -43,7 +43,6 @@ import LinterExample from "@/components/linter/example.md";
 import AwardBanner from "@/components/AwardBanner.astro"
 
 <div class="gradient"></div>
-<div class="grid"></div>
 
 <div class="hero-code">
     <h2 class="head">像 Prettier 一样格式化代码，但是更省时</h2>


### PR DESCRIPTION
## Summary

This removes the background grid from the hero on the landing page.

## Why

I removed the background grid from the hero section because it made the overall design feel too busy and visually overwhelming.

By simplifying the background, the hero section now feels more focused and clean, allowing the headline and call-to-action to stand out more effectively.

## Before / after

### Before

![before](https://github.com/user-attachments/assets/33983992-7eb4-4eb4-a987-555e10126394)

### After

![after](https://github.com/user-attachments/assets/2205bd3f-5107-4ad5-bdd1-b9daf90a83d1)

