### PR TITLE
docs: Fix misleading typo + unclosed markdown tag for the v2 "Big Projects" page

### DIFF
--- a/src/content/docs/guides/big-projects.mdx
+++ b/src/content/docs/guides/big-projects.mdx
@@ -156,7 +156,7 @@ Since v2, Biome supports monorepos out of the box, and you'll need to set up the
         }
     }
     ```
-    However, when you use the microsyntax `extends: "//"`, you can **omit `"root": true`, because it implies that this configuration isn't a
+    However, when you use the microsyntax `extends: "//"`, you can **omit**  `"root": false`, because it implies that this configuration isn't a
     a root configuration, and it wants extends from the root configuration:
 
     ```diff title="packages/generate/biome.json"


### PR DESCRIPTION
## Summary

Hi Biome team,

I noticed what I think is a slightly misleading typo on the Biome v2 beta [Big Projects page](https://next.biomejs.dev/guides/big-projects/#:~:text=%2C%20you%20can-,**omit%20%22root%22%3A%20true,-%2C%20because%20it%20implies). The page currently states:


> However, when you use the microsyntax extends: "//", you can **omit "root": true, ...

The docs however state that monorepo packages should be using `"root": false` and the [code snippet that follows this line](https://next.biomejs.dev/guides/big-projects/#:~:text=the%20root%20configuration%3A-,packages/generate/biome.json,-1) on the docs also confirms the expected behavior:

```diff title="packages/generate/biome.json"
{
-    "root": false,
    "extends": "//",
    "formatter": {
    "enabled": false
}
```

There are also two asterisks preceding the word "omit" in the docs; I'm assuming omit was meant to be bolded but the closing \** tag was left off.

This PR fixes both issues. The bold tag is closed and the line now reads as

> However, when you use the microsyntax `extends: "//"`, you can **omit**  `"root": false` ...

Thanks! Our team is eagerly looking forward to v2.