### PR TITLE
fix: correct date in v2 blog post

### DIFF
--- a/src/content/docs/blog/biome-v2.mdx
+++ b/src/content/docs/blog/biome-v2.mdx
@@ -7,7 +7,7 @@ excerpt: |
 authors:
   - ema
   - team
-date: 2025-06-02
+date: 2025-06-17
 cover:
     light: "@/assets/blog/roadmap-2024/banner-light.png"
     dark: "@/assets/blog/roadmap-2024/banner-dark.png"


### PR DESCRIPTION
## Summary

<!-- 
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

"Jun 2, 2025" in blog post is not correct, because biome v2 released today on Jun 17.