### PR TITLE
Fix typo in zed docs

### DIFF
--- a/src/content/docs/reference/zed.mdx
+++ b/src/content/docs/reference/zed.mdx
@@ -99,6 +99,7 @@ See [Language Support](/internals/language-support) for more information.
         "source.organizeImports.biome": true
       }
     }
+  }
 }
 ```
 


### PR DESCRIPTION
## Summary
Fixed typo in docs for Zed editor extension.
