### PR TITLE
docs: add note about external packages in conjunction with biome action

### DIFF
--- a/src/content/docs/recipes/continuous-integration.mdx
+++ b/src/content/docs/recipes/continuous-integration.mdx
@@ -31,6 +31,21 @@ jobs:
         run: biome ci .
 ```
 
+:::note
+If your Biome configuration has external dependencies (e.g., extends a config from a package), you'll need to setup Node.js and install dependencies using your preferred package manager before running Biome:
+
+```yaml
+- name: Setup Node.js
+  uses: actions/setup-node@v4
+  with:
+    node-version: 20 # or your preferred version
+    cache: "npm" # or 'yarn', 'pnpm'
+- name: Install dependencies
+  run: npm ci # or yarn install --frozen-lockfile, pnpm install --frozen-lockfile
+```
+
+:::
+
 ### Third-party actions
 
 These are actions maintained by other communities, that you use in your runner:

--- a/src/content/docs/recipes/continuous-integration.mdx
+++ b/src/content/docs/recipes/continuous-integration.mdx
@@ -31,7 +31,6 @@ jobs:
         run: biome ci .
 ```
 
-:::note
 If your Biome configuration has external dependencies (e.g., extends a config from a package), you'll need to setup Node.js and install dependencies using your preferred package manager before running Biome:
 
 ```yaml
@@ -43,8 +42,6 @@ If your Biome configuration has external dependencies (e.g., extends a config fr
 - name: Install dependencies
   run: npm ci # or yarn install --frozen-lockfile, pnpm install --frozen-lockfile
 ```
-
-:::
 
 ### Third-party actions
 


### PR DESCRIPTION
**Add documentation note for using external packages with Biome CI action**

This improves the CI recipe documentation by adding a note on handling Biome configs that rely on external dependencies/configs. It includes a snippet showing how to set up Node.js and install dependencies before running biome ci.









