### PR TITLE
fix: do not select `next` by default

### DIFF
--- a/src/components/starlight/LanguageSelect.astro
+++ b/src/components/starlight/LanguageSelect.astro
@@ -13,7 +13,7 @@ import Select from "@astrojs/starlight/components/Select.astro";
         options={[
             { label: "v1.x", value: "v1", selected: false },
             { label: "v2.x", value: "v2", selected: true },
-            { label: "next", value: "next", selected: true },
+            { label: "next", value: "next", selected: false },
         ]}
     />
 </version-select>


### PR DESCRIPTION
## Summary

This PR fixes the version selector so that it doesn't select `next` by default on the `main` branch.