### PR TITLE
fix: nest ui/src properly in relative globs example

### DIFF
--- a/src/content/docs/guides/upgrade-to-biome-v2.mdx
+++ b/src/content/docs/guides/upgrade-to-biome-v2.mdx
@@ -92,9 +92,9 @@ In the following example, the configuration file is at root of the project, the 
         - deploy.js
     - ui/
         - package.json
-    - src/
-        - main.tsx
-        - utils.ts
+        - src/
+            - main.tsx
+            - utils.ts
 </FileTree>
 
 ```json title="ui/package.json"


### PR DESCRIPTION
In the example for "Paths and globs are now relative to the configuration file", both `src` directories are at the same level in the `FileTree`. This moves `ui/src` to nest correctly under `ui`

## Before
<img width="736" alt="Screenshot 2025-06-24 at 10 49 41 AM" src="https://github.com/user-attachments/assets/e235443d-8b28-4476-99af-792d5df73ddd" />

## After
<img width="811" alt="Screenshot 2025-06-24 at 11 03 29 AM" src="https://github.com/user-attachments/assets/fb81fdc8-565e-4098-be09-a8c10a84da33" />

## Note
Sorry about the inconsequential final line diff, I edited through github UI and that was performed automatically. If you would like me to remake without that I am happy to