### PR TITLE
feat: document scanner ignores option

### DIFF
--- a/src/content/docs/linter/index.mdx
+++ b/src/content/docs/linter/index.mdx
@@ -442,6 +442,8 @@ It's also worth mentioning that **we're aware** of this impact on performance, a
 
 If you notice some abnormal numbers in terms of memory or time, please file an issue with a link to the repository, so we can help.
 
+To mitigate possible slow-downs, you can use the option [`files.experimentalScannerIgnores`](/reference/configuration#filesexperimentalscannerignores)
+
 ### Why is Biome using so much memory?
 
 If you use an editor extension that uses Biome, you might notice that one of its processes could use a lot of memory.

--- a/src/content/docs/reference/configuration.mdx
+++ b/src/content/docs/reference/configuration.mdx
@@ -128,7 +128,7 @@ The scanner respects `files.includes`, with two exceptions:
 This means that if you use `files.includes` to ignore folders with generated
 code, type information from such folders is inaccessible to the scanner. If you
 do wish to have such type information available, we advise to _not_ ignore these
-folders through `files.includes` and instead ignore them using tool-specific 
+folders through `files.includes` and instead ignore them using tool-specific
 settings such as `linter.includes` and `formatter.includes` only.
 
 ### `files.ignoreUnknown`
@@ -152,6 +152,32 @@ The maximum allowed size for source code files in bytes. Files above
 this limit will be ignored for performance reasons.
 
 > Default: `1048576` (1024*1024, 1MB)
+
+### `files.experimentalScannerIgnores`
+
+An array of literal paths that the scanner should ignore during the crawling. The ignored files
+won't be indexed, which means that Biome won't be part of the module graph, and types won't be inferred.
+
+In the following example, the folders `node_modules/lodash` and `dist` and the file `RedisCommander.d.ts` will be ignored:
+
+```json title="biome.json"
+{
+  "files" : {
+    "experimentalScannerIgnores": [
+      "node_modules/lodash",
+      "dist",
+      "RedisCommander.d.ts"
+    ]
+  }
+}
+```
+
+You should use this option only as a last resort in cases Biome takes a lot of time to lint/check your project. Glob paths
+aren't supported.
+
+:::caution
+As an experimental option, its usage is subject to change. The goal is to make Biome as fast as possible and eventually remove the option.
+:::
 
 ## `vcs`
 
@@ -489,7 +515,7 @@ When formatting `package.json`, Biome will use `always` unless configured otherw
 
 ### `formatter.useEditorconfig`
 
-Whether Biome should use the `.editorconfig` file to determine the formatting options. 
+Whether Biome should use the `.editorconfig` file to determine the formatting options.
 
 The config files `.editorconfig` and `biome.json` will follow the follwing rules:
 


### PR DESCRIPTION
## Summary
This PR documents `files.experimentalScannerIgnores`