### PR TITLE
Fix yarn check script (all files)

### DIFF
--- a/src/content/docs/guides/getting-started.mdx
+++ b/src/content/docs/guides/getting-started.mdx
@@ -148,7 +148,7 @@ yarn exec biome lint --write
 yarn exec biome lint --write <files>
 
 # Format, lint, and organize imports of all files
-yarn exec biome check --write <files>
+yarn exec biome check --write
 
 # Format, lint, and organize imports of specific files
 yarn exec biome check --write <files>


### PR DESCRIPTION
## Summary

Hey ! While setting up biome on my project I noticed that the yarn script on `# Format, lint, and organize imports of all files` mentions `<files>`  which should not be here.

The others tabs (npm, pnpm...) don't have this so this PR removes it 