### PR TITLE
docs: add zh-CN  for `reporters.mdx`

### DIFF
--- a/src/content/docs/zh-CN/reference/reporters.mdx
+++ b/src/content/docs/zh-CN/reference/reporters.mdx
@@ -1,0 +1,98 @@
+---
+title: Reporters
+description: 使用 reporters 控制 Biome 的输出
+---
+
+从 **v1.8.0** 版本开始，Biome 的 CLI 接受一个 `--reporter` 参数，该参数允许更改诊断和摘要在终端中的打印方式。
+
+## Summary
+
+```shell
+biome check --reporter=summary
+```
+
+```
+Formatter ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+The following files needs to be formatted:
+main.ts
+index.ts
+
+Organize Imports ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+The following files needs to have their imports sorted:
+main.ts
+index.ts
+
+Analyzer ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Some analyzer rules were triggered
+
+Rule Name                                               Diagnostics
+lint/suspicious/noImplicitAnyLet                        12 (12 error(s), 0 warning(s), 0 info(s))
+lint/suspicious/noDoubleEquals                          8 (8 error(s), 0 warning(s), 0 info(s))
+lint/suspicious/noRedeclare                             12 (12 error(s), 0 warning(s), 0 info(s))
+lint/suspicious/noDebugger                              20 (20 error(s), 0 warning(s), 0 info(s))
+```
+
+## JSON
+
+:::caution
+此 reporter 是实验性的，可能会在补丁版本中发生变化。
+:::
+
+以 JSON 格式发出摘要和诊断信息。
+
+```shell
+biome ci --reporter=json
+```
+
+## JSON pretty
+
+:::caution
+此 reporter 是实验性的，可能会在补丁版本中发生变化。
+:::
+
+与 `--reporter=json` 相同，它以 JSON 格式发出摘要和诊断信息，并且输出使用当前的 JSON 格式化选项（配置文件或默认值）进行格式化。
+
+```shell
+biome ci --reporter=json-pretty
+```
+
+## GitHub
+
+在 GitHub 工作流中使用此 reporter。在 PR 工作流中正确配置后，GitHub 将为发出的每个 info/warning/error 打印一条消息。
+
+```shell
+biome ci --reporter=github
+```
+
+```
+::error title=lint/suspicious/noDoubleEquals,file=main.ts,line=4,endLine=4,col=3,endColumn=5::Use === instead of ==
+::error title=lint/suspicious/noDebugger,file=main.ts,line=6,endLine=6,col=1,endColumn=9::This is an unexpected use of the debugger statement.
+::error title=lint/nursery/noEvolvingAny,file=main.ts,line=8,endLine=8,col=5,endColumn=6::This variable's type is not allowed to evolve implicitly, leading to potential any types.
+```
+
+## JUnit
+
+```shell
+biome check --reporter=junit
+```
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<testsuites name="Biome" tests="16" failures="16" errors="20" time="<TIME>">
+  <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
+      <testcase name="org.biome.lint.suspicious.noDoubleEquals" line="4" column="3">
+          <failure message="Use === instead of ==. == is only allowed when comparing against `null`">line 3, col 2, Use === instead of ==. == is only allowed when comparing against `null`</failure>
+      </testcase>
+  </testsuite>
+  <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
+      <testcase name="org.biome.lint.suspicious.noDebugger" line="6" column="1">
+          <failure message="This is an unexpected use of the debugger statement.">line 5, col 0, This is an unexpected use of the debugger statement.</failure>
+      </testcase>
+  </testsuite>
+  <testsuite name="main.ts" tests="1" disabled="0" errors="0" failures="1" package="org.biome">
+      <testcase name="org.biome.lint.nursery.noEvolvingAny" line="8" column="5">
+          <failure message="This variable's type is not allowed to evolve implicitly, leading to potential any types.">line 7, col 4, This variable's type is not allowed to evolve implicitly, leading to potential any types.</failure>
+      </testcase>
+  </testsuite>
+</testsuites>
+```

--- a/src/content/docs/zh-CN/reference/reporters.mdx
+++ b/src/content/docs/zh-CN/reference/reporters.mdx
@@ -58,7 +58,7 @@ biome ci --reporter=json-pretty
 
 ## GitHub
 
-在 GitHub 工作流中使用此 reporter。在 PR 工作流中正确配置后，GitHub 将为发出的每个 info/warning/error 打印一条消息。
+在 GitHub 工作流中使用此 reporter。在 PR 工作流中正确配置后，GitHub 将为发出的每个 `info/warning/error` 打印一条消息。
 
 ```shell
 biome ci --reporter=github


### PR DESCRIPTION
## Summary

This PR adds the Chinese (Simplified) translation for the `reporters.mdx` documentation page to improve accessibility for Chinese-speaking users.