### PR TITLE
Extend scanner documentation

### DIFF
--- a/codegen/src/domains.rs
+++ b/codegen/src/domains.rs
@@ -98,7 +98,7 @@ impl DocDomains {
                     writeln!(buffer, "## {name}")?;
                     writeln!(
                         buffer,
-                        "This domain contains rules that perform project-level analysis. This includes our module graph for dependency resolution, as well as type information. When enabling rules that belong to this domain, Biome will scan the entire project. The scanning phase will have a performance impact on the linting process. See the reference for the [`files.includes`](/reference/configuration/#note-on-biomes-scanner) configuration on how you can influence the scanner behaviour with regards to generated code."
+                        "This domain contains rules that perform project-level analysis. This includes our module graph for dependency resolution, as well as type information. When enabling rules that belong to this domain, Biome will scan the entire project. The scanning phase will have a performance impact on the linting process. See the documentation on our [scanner](/internals/architecture/#scanner) to learn more about how you can influence the scanner behaviour."
                     )?;
                 }
                 #[allow(unreachable_patterns)]

--- a/src/content/docs/guides/big-projects.mdx
+++ b/src/content/docs/guides/big-projects.mdx
@@ -144,7 +144,7 @@ Sometimes, Biome may find a nested configuration file that doesn't have a
 correct `"root": false` setting. This can happen if you have another project
 that uses Biome in a vendored folder or Git submodule, for instance. In such a
 case, we suggest ignoring the nested project entirely using
-[the `files.includes` field](/reference/configuration#filesincludes).
+[the `files.includes` field](/reference/configuration/#filesincludes).
 :::
 
 ## Other ways to share a configuration file

--- a/src/content/docs/guides/big-projects.mdx
+++ b/src/content/docs/guides/big-projects.mdx
@@ -5,19 +5,22 @@ description: A small guide how to set Biome in big projects
 
 import {FileTree, Steps} from '@astrojs/starlight/components';
 
-Biome can provide some tools that can help you to use it properly in big projects, such as monorepo or workspaces that contain multiple projects.
-
+Biome can provide some tools that can help you to use it properly in big
+projects, such as monorepo or workspaces that contain multiple projects.
 
 ## Use multiple configuration files
 
-When you use Biome's features - either with the CLI or LSP - the tool looks for the nearest configuration file using the current working directory.
+When you use Biome's features - either with the CLI or LSP - the tool looks for
+the nearest configuration file using the current working directory.
 
-If Biome doesn't find the configuration file there, it **starts walking upwards** the directories of the file system, until it finds one.
+If Biome doesn't find the configuration file there, it **starts traversing
+upwards** the directories of the file system, until it finds one.
 
-You can leverage this feature to apply different settings based on the project/folder.
+You can leverage this feature to apply different settings based on the
+project/folder.
 
-Let's suppose we have a project that contains a backend app and new frontend app.
-
+Let's suppose we have a project that contains a backend app and a frontend
+app.
 
 <FileTree>
   - app
@@ -32,78 +35,23 @@ Let's suppose we have a project that contains a backend app and new frontend app
         - package.json
 </FileTree>
 
-This means that when you run a script from the file `app/backend/package.json`, Biome will use the configuration file `app/backend/biome.json`.
-
-When you run a script from `app/frontend/legacy-app/package.json` or `app/frontend/new-app/package.json`, Biome will use the configuration file `app/frontend/biome.json`.
-
-## Share the configuration
-
-It's possible to use the [`extends`](/guides/configure-biome/#share-a-configuration-file) configuration option to breakdown options across files.
-
-Let's assume that we have these requirements:
-- `legacy-app` have to format using spaces;
-- `backend` and `new-app` have to format using tabs;
-- all apps have to format using line width 120;
-- `backend` app needs some extra linting;
-
-We start by creating a new configuration file at `app/biome.json`, and put there the shared options:
-
-
-```json title="app/biome.json"
-{
-  "formatter": {
-    "enabled": true,
-    "lineWidth": 120
-  }
-}
-```
-
-Now let's **move** `app/frontend/biome.json` to `app/frontend/legacy-app/`, because that's where we need to use a different formatting.
-
-
-```json title="app/frontend/legacy-app/biome.json"
-{
-  "formatter": {
-    "indentStyle": "space"
-  }
-}
-```
-
-Then, we tell Biome to inherit all the options from the main `app/biome.json` file, using the `extends` property:
-
-```json title="app/frontend/legacy-app/biome.json" ins={2}
-{
-   "extends": ["../../biome.json"],
-   "formatter": {
-     "indentStyle": "space"
-   }
-}
-```
-
-Let's jump to `app/backend/biome.json`, where we need to enable the linting:
-
-
-```json title="app/backend/biome.json"
-{
-  "extends": ["../biome.json"],
-  "linter": {
-    "enabled": true,
-    "rules": {
-      "recommended": true
-    }
-  }
-}
-```
+This means that when you run Biome inside `app/backend`, Biome will use the
+configuration file `app/backend/biome.json`. And when you run from
+`app/frontend/legacy-app` or `app/frontend/new-app`, Biome will use the
+configuration file `app/frontend/biome.json`.
 
 ## Monorepo
 
-Monorepos are particular repositories where multiple libraries are stored and maintained in one big repository. Each library represents a self-contained package, which can contain different configurations.
+Monorepos are particular repositories where multiple packages are stored and
+maintained in one big repository. Each package can contain its own
+configuration.
 
-Since v2, Biome supports monorepos out of the box, and you'll need to set up the project in the following way.
+Since v2, Biome supports monorepos out of the box, and you'll need to set up the
+project in the following way.
 
 <Steps>
-1. Create a `biome.json` file at the root of the monorepo. We will use the recommended rules, and customise the formatter
-    options.:
+1. Create a `biome.json` file at the root of the monorepo. We will use the
+    recommended rules, and customise the formatter options:
 
     ```json title="biome.json"
     {
@@ -120,18 +68,22 @@ Since v2, Biome supports monorepos out of the box, and you'll need to set up the
         }
     }
     ```
-    This file is called **root configuration** and it sets the base options inside the project. However, nested
-    configurations can decide to adhere to these options or not. Let's see how.
+    This file is called the **root configuration** and it sets the base options
+    inside the project. However, nested configurations can decide to adhere to
+    these options or not. Let's see how.
 
-2. Create nested configuration files, one in each package, where is needed. These nested configuration files must have the
-    field `"root"` set to `false`. Failing to do so will result into an error. Also, we want these packages the follow
-    the formatting standards set up in the root configuration. In order to so, we will use a **new microsyntax**
-    available in Biome v2, which is `"extends": "//"`. This syntax tells Biome to extends from the **root configuration**,
-    regardless of where the nested configuration is.
+2. Create nested configuration files, one in each package where it is needed.
+    These nested configuration files must have the field `"root"` set to
+    `false`. Also, we want these packages to follow the formatting standards
+    set up in the root configuration. In order to so, we will use a **new
+    microsyntax** available in Biome v2, which is `"extends": "//"`. This syntax
+    tells Biome to extend from the **root configuration**, regardless of where
+    the nested configuration is.
 
-    Let's create two configuration files,
-    one inside `packages/logger` and one inside `packages/generate`. In the former we will disable `noConsole`, and in
-    `packages/generate` we will disable the formatter because those are files that are code-generated:
+    Let's create two configuration files, one inside `packages/logger` and one
+    inside `packages/generate`. In the former we will disable `noConsole`, and
+    in `packages/generate` we will disable the formatter because those are files
+    that are code-generated:
 
     ```json title="packages/logger/biome.json"
     {
@@ -156,8 +108,9 @@ Since v2, Biome supports monorepos out of the box, and you'll need to set up the
         }
     }
     ```
-    However, when you use the microsyntax `extends: "//"`, you can **omit**  `"root": false`, because it implies that this configuration isn't a
-    a root configuration, and it wants extends from the root configuration:
+    For convenience, when you use the microsyntax `extends: "//"`, you can
+    **omit** `"root": false`, because it is already implied that this
+    configuration isn't a root configuration:
 
     ```diff title="packages/generate/biome.json"
     {
@@ -167,8 +120,11 @@ Since v2, Biome supports monorepos out of the box, and you'll need to set up the
         "enabled": false
     }
     ```
-3. Now, let's suppose we have a new package in `packages/analytics`, maintained by another team that has different different coding standards.
-    To change these options, you just need to omit `"extends": "//"` from the configuration file, and change the formatting options:
+3. Now, let's suppose we have a new package in `packages/analytics` that is
+    maintained by a different team. This team follows entirely different coding
+    standards, so they _don't_ want to inherit options from the root
+    configuration. For them, they just need to omit `"extends": "//"` from the
+    configuration file, and change the formatting options:
     ```json title="packages/analytics/biome.json"
     {
         "root": false,
@@ -178,15 +134,145 @@ Since v2, Biome supports monorepos out of the box, and you'll need to set up the
     }
 
     ```
-4. Now that everything is set up, you have few options. You can run `biome` commands from the root of the project, or from the single packages.
-    Biome will respect all settings!
+4. Now that everything is set up, you have a few options. You can run `biome`
+    commands from the root of the project, or from the single packages. Biome
+    will respect all settings!
 </Steps>
 
-### Limitations and constraints
+:::tip
+Sometimes, Biome may find a nested configuration file that doesn't have a
+correct `"root": false` setting. This can happen if you have another project
+that uses Biome in a vendored folder or Git submodule, for instance. In such a
+case, we suggest ignoring the nested project entirely using
+[the `files.includes` field](/reference/configuration#filesincludes).
+:::
 
-To keep Biome as fast as possible, the nested configurations are discovered and loaded when at least one of these conditions is met:
-- the VCS integration is enabled
-- the CLI is run from the same folder where a root configuration file is present
-- when running the command `biome search`, or the command `biome migrate`
-- at least one project rule is enabled
-- you open a project in the IDE (using our LSP integration)
+## Other ways to share a configuration file
+
+As we saw above, the `extends` field allows you to split your configuration
+across multiple files. This way, you can share common settings across different
+projects or folders. The `"extends": "//"` syntax is a convenient shortcut when
+you want nested configurations to extend from the root configuration, but
+sometimes you may want to use an even more customised setup.
+
+Apart from `"//"`, the `extends` setting accept array values as well. In this
+case, every value in the array must be a path to another config to extend.
+
+For example, here is how you might set up your configuration to extend a
+`common.json` configuration file:
+
+```json title="biome.json"
+{
+  "extends": ["./common.json"]
+}
+```
+
+The entries defined in `extends` are resolved from the path where the
+`biome.json` file is defined. They are processed in the order they are listed,
+with settings in later files overriding earlier ones.
+
+Files that you `extend` from cannot `extend` other files in turn.
+
+Note that paths in a configuration file are always resolved from the folder in
+which the `biome.json`/`biome.jsonc` file resides. When using the `extends`
+field, this means that paths in a shared configuration are interpreted from the
+location of the configuration that is extending it, and not from the folder
+of the file being extended.
+
+For example, let's assume a project that contains two directories `backend/` and
+`frontend/`, each having their own `biome.json` that both extend a `common.json`
+configuration in the root folder:
+
+<FileTree>
+- backend/
+  - src/
+    - ...
+  - test/
+    - ...
+  - biome.json
+- frontend/
+  - src/
+    - ...
+  - test/
+    - ...
+  - biome.json
+- common.json
+</FileTree>
+
+```json title="common.json"
+{
+  "files": {
+    "includes": ["src/**/*.js", "test/**/*.js"],
+  },
+  "linter": {
+    "includes": ["**", "!test/**"]
+  }
+}
+```
+
+```json title="frontend/biome.json"
+{
+  "extends": ["../common.json"]
+}
+```
+
+* When running Biome from the `frontend/` folder, it will be configured to
+  format and lint all JavaScript files in the `frontend/src/` and
+  `frontend/test/` folders, and only format the files in the `frontend/src/`
+  folder. This works because the paths specified in `common.json` are
+  interpreted from the `frontend/` folder, because that's where the `biome.json`
+  file resides.
+* Assuming `backend/biome.json` looks the same as `frontend/biome.json`, it will
+  have the same behaviour, except the paths will be interpreted from the
+  `backend/` folder.
+
+Note that in this setup, both `frontend/biome.json` and `backend/biome.json` are
+considered root configurations. You won't be able to run Biome from the root of
+the repository, unless you use the `--config-path` CLI option and point it at
+one of the configurations.
+
+### Exporting a Biome configuration from an NPM package
+
+Biome is also able to resolve configuration files from the `node_modules/`
+folder. So you can export your configuration file from a package, and import it
+in multiple projects.
+
+In order to do so, the first thing to do is to set up your "shared" Biome
+configuration in a certain way. Let's suppose that you want to share a
+configuration from a package called `@org/shared-configs`, using the specifier
+`@org/shared-configs/biome`. You have to create an `exports` entry in the
+`package.json` of this package:
+
+```json title="package.json" ins={5,3}
+{
+  "name": "@org/shared-configs",
+  "type": "module",
+  "exports": {
+    "./biome": "./biome.json"
+  }
+}
+```
+
+Make sure that `@org/shared-configs` is correctly installed in your project, and
+update the `biome.json` file to look like the following snippet:
+
+```json title="biome.json"
+{
+  "extends": ["@org/shared-configs/biome"]
+}
+```
+
+Biome will attempt to resolve your library `@org/shared-configs/` from your
+working directory. The working directory is:
+
+- when using the CLI, the folder where you execute your scripts from.
+  Usually it matches the location of your `package.json` file;
+- when using the LSP, the root folder of your project.
+
+:::caution
+Paths starting with a dot `.` or ending with `.json` or `.jsonc` are always
+treated as relative paths, so they won't be resolved from `node_modules/`.
+:::
+
+For more information about the resolution algorithm, refer to the
+[Node.js documentation](https://nodejs.org/api/esm.html#resolution-and-loading-algorithm).

--- a/src/content/docs/guides/configure-biome.mdx
+++ b/src/content/docs/guides/configure-biome.mdx
@@ -273,6 +273,8 @@ The following files are parsed as `JSON` files with the options `json.parser.all
 - `jsconfig.json`
 - `jsr.json`
 - `language-configuration.json`
+- `nx.json`
+- `project.json`
 - `tsconfig.json`
 - `typedoc.json`
 - `typescript.json`

--- a/src/content/docs/guides/configure-biome.mdx
+++ b/src/content/docs/guides/configure-biome.mdx
@@ -141,14 +141,14 @@ Some shells don't support the recursive glob `**`.
 
 The Biome configuration file can be used to refine which files are processed.
 You can explicitly list the files to be processed using
-[the `files.includes` field](/reference/configuration#filesincludes).
+[the `files.includes` field](/reference/configuration/#filesincludes).
 `files.includes` accepts
-[glob patterns](/reference/configuration#glob-syntax-reference) such as
+[glob patterns](/reference/configuration/#glob-syntax-reference) such as
 `src/**/*.js`. Negated patterns starting with `!` can be used to exclude files.
 
 Paths and globs inside Biome's configuration file are resolved relative to the
 folder the configuration file is in. An exception to this is when a
-configuration file is [extended](/reference/configuration#extends) by another.
+configuration file is [extended](/reference/configuration/#extends) by another.
 
 `files.includes` applies to all of Biome's tools, meaning the files specified
 here are processed by the linter, the formatter and the assist, unless specified

--- a/src/content/docs/guides/configure-biome.mdx
+++ b/src/content/docs/guides/configure-biome.mdx
@@ -141,13 +141,14 @@ Some shells don't support the recursive glob `**`.
 
 The Biome configuration file can be used to refine which files are processed.
 You can explicitly list the files to be processed using
-[the `files.includes` field](/reference/configuration). `files.includes` accepts
+[the `files.includes` field](/reference/configuration#filesincludes).
+`files.includes` accepts
 [glob patterns](/reference/configuration#glob-syntax-reference) such as
 `src/**/*.js`. Negated patterns starting with `!` can be used to exclude files.
 
 Paths and globs inside Biome's configuration file are resolved relative to the
 folder the configuration file is in. An exception to this is when a
-configuration file is [extended](#sharing-a-configuration-file) by another.
+configuration file is [extended](/reference/configuration#extends) by another.
 
 `files.includes` applies to all of Biome's tools, meaning the files specified
 here are processed by the linter, the formatter and the assist, unless specified
@@ -224,7 +225,6 @@ In the following example, we tell Biome to include files, excluded the `dist` di
 
 You can [ignore files ignored by your VCS](/guides/integrate-in-vcs#use-the-ignore-file).
 
-
 ## Well-known files
 
 Here are some well-known files that we specifically treat based on their file names, rather than their extensions.
@@ -278,124 +278,3 @@ The following files are parsed as `JSON` files with the options `json.parser.all
 - `tsconfig.json`
 - `typedoc.json`
 - `typescript.json`
-
-
-## Sharing a configuration file
-
-The `extends` field allows you to split your configuration across multiple
-files. This way, you can share common settings across different projects or
-folders.
-
-Here's an example of how you might set up your configuration to extend a
-`common.json` configuration file:
-
-```json title="biome.json"
-{
-  "extends": ["./common.json"]
-}
-```
-
-The entries defined in `extends` are resolved from the path where the
-`biome.json` file is defined. They are processed in the order they are listed,
-with settings in later files overriding earlier ones.
-
-Files that you `extend` from cannot `extend` other files in turn.
-
-Note that paths in a configuration file are always resolved from the folder in
-which the `biome.json`/`biome.jsonc` file resides. When using the `extends`
-field, this means that paths in a shared configuration are interpreted from the
-location of the configuration that is extending it, and not from the folder
-of the file being extended.
-
-For example, let's assume a project that contains two directories `backend/` and
-`frontend/`, each having their own `biome.json` that both extend a `common.json`
-configuration in the root folder:
-
-<FileTree>
-- backend/
-  - src/
-    - ...
-  - test/
-    - ...
-  - biome.json
-- frontend/
-  - src/
-    - ...
-  - test/
-    - ...
-  - biome.json
-- common.json
-</FileTree>
-
-```json title="common.json"
-{
-  "files": {
-    "includes": ["src/**/*.js", "test/**/*.js"],
-  },
-  "linter": {
-    "includes": ["**", "!test/**"]
-  }
-}
-```
-
-```json title="frontend/biome.json"
-{
-  "extends": ["../common.json"]
-}
-```
-
-* When running Biome from the `frontend/` folder, it will be configured to
-  format and lint all JavaScript files in the `frontend/src/` and
-  `frontend/test/` folders, and only format the files in the `frontend/src/`
-  folder. This works because the paths specified in `common.json` are
-  interpreted from the `frontend/` folder, because that's where the `biome.json`
-  file resides.
-* Assuming `backend/biome.json` looks the same as `frontend/biome.json`, it will
-  have the same behaviour, except the paths will be interpreted from the
-  `backend/` folder.
-
-### Exporting a Biome configuration from an NPM package
-
-Biome is able to resolve configuration files from the `node_modules/` folder.
-So you can export your configuration file from a package, and import it in
-multiple projects.
-
-In order to do so, the first thing to do is to set up your "shared" Biome
-configuration in a certain way. Let's suppose that you want to share a
-configuration from a package called `@org/shared-configs`, using the specifier
-`@org/shared-configs/biome`. You have to create an `exports` entry in the
-`package.json` of this package:
-
-```json title="package.json" ins={5,3}
-{
-  "name": "@org/shared-configs",
-  "type": "module",
-  "exports": {
-    "./biome": "./biome.json"
-  }
-}
-```
-
-Make sure that `@org/shared-configs` is correctly installed in your project, and
-update the `biome.json` file to look like the following snippet:
-
-```json title="biome.json"
-{
-  "extends": ["@org/shared-configs/biome"]
-}
-```
-
-Biome will attempt to resolve your library `@org/shared-configs/` from your
-working directory. The working directory is:
-
-- when using the CLI, the folder where you execute your scripts from.
-  Usually it matches the location of your `package.json` file;
-- when using the LSP, the root folder of your project.
-
-:::caution
-Paths starting with a dot `.` or ending with `.json` or `.jsonc` are always
-treated as relative paths, so they won't be resolved from `node_modules/`.
-:::
-
-For more information about the resolution algorithm, refer to the
-[Node.js documentation](https://nodejs.org/api/esm.html#resolution-and-loading-algorithm).

--- a/src/content/docs/internals/architecture.mdx
+++ b/src/content/docs/internals/architecture.mdx
@@ -5,6 +5,69 @@ description: How Biome works under the hood.
 
 This document covers some of the internals of Biome, and how they are used inside the project.
 
+## Scanner
+
+Biome has a scanner that is responsible for crawling the file system to extract
+important metadata about projects. Specifically, there are three ways in which
+the scanner is used:
+
+- To discover nested `biome.json`/`biome.jsonc` files in monorepos.
+- To discover `.gitignore` files if the
+  [`vcs.useIgnoreFile`](/reference/configuration/#vcsuseignorefile) setting is
+  enabled.
+- To index all JavaScript/TypeScript files in a project if any rules from the
+  [project domain](/linter/domains/#project) are enabled.
+
+### Scanner targeting
+
+If project rules are not enabled, the scanner automatically targets only the
+folders that are relevant for a given session.
+
+This means that if you have a large monorepo, and you run `biome check` from
+inside the `packages/foo/` folder, that folder will be "targeted". This means
+the following folders get scanned for configuration files and/or `.gitignore`:
+
+- The root folder of the repository.
+- The `packages/` folder.
+- The `packages/foo/` folder.
+- Any folders that exist under `packages/foo/`, except `node_modules/` or
+  those that are excluded by your configuration (see
+  [below](#configuringthescanner)).
+
+Other folders that may be adjacent to either `packages/` or `packages/foo/` will
+be automatically skipped.
+
+Similarly, if you run `biome format packages/bar/src/index.ts` from the root
+of the repository, the scanner will target the `packages/bar/src/` folder.
+
+If project rules are enabled, these optimisations don't apply.
+
+### Configuring the scanner
+
+The scanner mostly respects the
+[`files.includes`](/reference/configuration/#filesincludes) setting, but there
+are some exceptions to be aware of:
+
+* If the project domain or one of its rules is enabled, `.d.ts` files and
+  `package.json` manifests inside `node_modules` are still read, even if they're
+  ignored in `files.includes`. This is because they may be a valuable source of
+  type information.
+* The scanner will not ignore individual files if they are in a non-ignored
+  directory. This is because files that are co-located with regular
+  (non-ignored) files are likely to be a valuable source of type information,
+  and they are also more likely to form import cycles with other files.
+
+This means that if you use `files.includes` to ignore folders with generated
+code, type information from such folders is inaccessible to the scanner. If you
+do wish to have such type information available, we advise to _not_ ignore these
+folders through `files.includes` and instead ignore them using tool-specific
+settings such as `linter.includes` and `formatter.includes` only.
+
+Finally, if you really insist on preventing the scanner from accessing a given
+file or folder, you can use the
+[`files.experimentalScannerIgnores`](`/reference/configuration/#filesexperimentalscannerignores`)
+setting for that.
+
 ## Parser and CST
 
 The architecture of the parser is bumped by an internal fork of [rowan], a library

--- a/src/content/docs/internals/architecture.mdx
+++ b/src/content/docs/internals/architecture.mdx
@@ -65,7 +65,7 @@ settings such as `linter.includes` and `formatter.includes` only.
 
 Finally, if you really insist on preventing the scanner from accessing a given
 file or folder, you can use the
-[`files.experimentalScannerIgnores`](`/reference/configuration#filesexperimentalscannerignores`)
+[`files.experimentalScannerIgnores`](`/reference/configuration/#filesexperimentalscannerignores`)
 setting for that.
 
 ## Parser and CST

--- a/src/content/docs/internals/architecture.mdx
+++ b/src/content/docs/internals/architecture.mdx
@@ -65,7 +65,7 @@ settings such as `linter.includes` and `formatter.includes` only.
 
 Finally, if you really insist on preventing the scanner from accessing a given
 file or folder, you can use the
-[`files.experimentalScannerIgnores`](`/reference/configuration/#filesexperimentalscannerignores`)
+[`files.experimentalScannerIgnores`](`/reference/configuration#filesexperimentalscannerignores`)
 setting for that.
 
 ## Parser and CST

--- a/src/content/docs/linter/domains.mdx
+++ b/src/content/docs/linter/domains.mdx
@@ -51,7 +51,7 @@ Rules that belong to the domain:
 - [noDocumentImportInPage](/linter/rules/no-document-import-in-page) (recommended)
 - [noHeadImportInDocument](/linter/rules/no-head-import-in-document) (recommended)
 ## Project
-This domain contains rules that perform project-level analysis. This includes our module graph for dependency resolution, as well as type information. When enabling rules that belong to this domain, Biome will scan the entire project. The scanning phase will have a performance impact on the linting process. See the reference for the [`files.includes`](/reference/configuration/#note-on-biomes-scanner) configuration on how you can influence the scanner behaviour with regards to generated code.
+This domain contains rules that perform project-level analysis. This includes our module graph for dependency resolution, as well as type information. When enabling rules that belong to this domain, Biome will scan the entire project. The scanning phase will have a performance impact on the linting process. See the documentation on our [scanner](/internals/architecture/#scanner) to learn more about how you can influence the scanner behaviour.
 ### Project activation
 Enabled the **recommended** rules of the domain:
 ```json title="biome.json" ins={3-5}

--- a/src/content/docs/linter/index.mdx
+++ b/src/content/docs/linter/index.mdx
@@ -442,7 +442,7 @@ It's also worth mentioning that **we're aware** of this impact on performance, a
 
 If you notice some abnormal numbers in terms of memory or time, please file an issue with a link to the repository, so we can help.
 
-To mitigate possible slow-downs, you can use the option [`files.experimentalScannerIgnores`](/reference/configuration#filesexperimentalscannerignores)
+To mitigate possible slow-downs, you can use the option [`files.experimentalScannerIgnores`](/reference/configuration/#filesexperimentalscannerignores)
 
 ### Why is Biome using so much memory?
 

--- a/src/content/docs/reference/configuration.mdx
+++ b/src/content/docs/reference/configuration.mdx
@@ -115,21 +115,9 @@ Biome has a scanner that is responsible for discovering `.gitignore` files as
 well as indexing projects if any of the rules from the project domain are
 enabled.
 
-The scanner respects `files.includes`, with two exceptions:
-
-* If the project domain or one of its rules is enabled, dependencies in
-  `node_modules` are still read, even if they're ignored in `files.includes`.
-  This is because they may be a valuable source of type information.
-* The scanner will not ignore individual files if they are in a non-ignored
-  directory. This is because files that are co-located with regular
-  (non-ignored) files are likely to be a valuable source of type information,
-  and they are also more likely to form import cycles with other files.
-
-This means that if you use `files.includes` to ignore folders with generated
-code, type information from such folders is inaccessible to the scanner. If you
-do wish to have such type information available, we advise to _not_ ignore these
-folders through `files.includes` and instead ignore them using tool-specific
-settings such as `linter.includes` and `formatter.includes` only.
+The scanner mostly respects the `files.includes` setting, but there are some
+exceptions. See the [scanner documentation](/internals/architecture/#scanner)
+for more information.
 
 ### `files.ignoreUnknown`
 
@@ -155,16 +143,15 @@ this limit will be ignored for performance reasons.
 
 ### `files.experimentalScannerIgnores`
 
-An array of literal paths that the scanner should ignore during the crawling. The ignored files
-won't be indexed, which means that Biome won't be part of the module graph, and types won't be inferred.
+An array of literal paths that the scanner should ignore during the crawling. The ignored files won't be indexed, which means that these files won't be part of the module graph, and types won't be inferred from them.
 
-In the following example, the folders `node_modules/lodash` and `dist` and the file `RedisCommander.d.ts` will be ignored:
+In the following example, the folders `lodash` and `dist` and the file `RedisCommander.d.ts` will be ignored:
 
 ```json title="biome.json"
 {
   "files" : {
     "experimentalScannerIgnores": [
-      "node_modules/lodash",
+      "lodash",
       "dist",
       "RedisCommander.d.ts"
     ]
@@ -172,8 +159,9 @@ In the following example, the folders `node_modules/lodash` and `dist` and the f
 }
 ```
 
-You should use this option only as a last resort in cases Biome takes a lot of time to lint/check your project. Glob paths
-aren't supported.
+You should use this option only as a last resort in cases Biome takes a lot of time to lint/check your project. (Glob) paths aren't supported, and only basenames are matched.
+
+See the [scanner documentation](/internals/architecture/#scanner) for more information.
 
 :::caution
 As an experimental option, its usage is subject to change. The goal is to make Biome as fast as possible and eventually remove the option.


### PR DESCRIPTION
## Summary

This reorganises and extends the scanner documentation, including the new "targeted" scanner behaviour.

Also added `nx.json` and `project.json` to the list of known files.