### PR TITLE
chore: bump the pre-commit version of biomejs that the docs recommend

### DIFF
--- a/src/content/docs/es/recipes/git-hooks.mdx
+++ b/src/content/docs/es/recipes/git-hooks.mdx
@@ -148,10 +148,10 @@ si deseas utilizar el hook `biome-check`, añade la siguiente configuración pre
 ```yaml title=".pre-commit-config.yaml"
 repos:
   - repo: https://github.com/biomejs/pre-commit
-    rev: "v0.1.0" # Utiliza el sha / tag al que quieras apuntar
+    rev: "v2.0.6" # Utiliza el sha / tag al que quieras apuntar
     hooks:
       - id: biome-check
-        additional_dependencies: ["@biomejs/biome@1.4.1"]
+        additional_dependencies: ["@biomejs/biome@2.1.1"]
 ```
 
 Esto ejecutará `biome check --write` cuando ejecutes `git commit`.

--- a/src/content/docs/fr/recipes/git-hooks.mdx
+++ b/src/content/docs/fr/recipes/git-hooks.mdx
@@ -152,10 +152,10 @@ Si vous voulez utiliser le hook `biome-check`, ajoutez la configuration pre-comm
 ```yaml title=".pre-commit-config.yaml"
 repos:
 -   repo: https://github.com/biomejs/pre-commit
-    rev: "v0.1.0"  # Utilisez le sha / tag que vous voulez cibler
+    rev: "v2.0.6"  # Utilisez le sha / tag que vous voulez cibler
     hooks:
     -   id: biome-check
-        additional_dependencies: ["@biomejs/biome@1.4.1"]
+        additional_dependencies: ["@biomejs/biome@2.1.1"]
 ```
 
 Ce qui exécutera `biome check --write` quand vous exécuterez `git commit`.

--- a/src/content/docs/ja/recipes/git-hooks.mdx
+++ b/src/content/docs/ja/recipes/git-hooks.mdx
@@ -152,10 +152,10 @@ Biomeは [biomejs/pre-commit](https://github.com/biomejs/pre-commit) リポジ�
 ```yaml title=".pre-commit-config.yaml"
 repos:
 -   repo: https://github.com/biomejs/pre-commit
-    rev: "v0.1.0"  # タグやハッシュ値を指定してください
+    rev: "v2.0.6"  # タグやハッシュ値を指定してください
     hooks:
     -   id: biome-check
-        additional_dependencies: ["@biomejs/biome@1.4.1"]
+        additional_dependencies: ["@biomejs/biome@2.1.1"]
 ```
 
 これで`git commit`を実行したときに `biome check --write` が実行されるようになりました。

--- a/src/content/docs/pt-BR/recipes/git-hooks.mdx
+++ b/src/content/docs/pt-BR/recipes/git-hooks.mdx
@@ -153,10 +153,10 @@ Se você quiser usar o hook `biome-check`, adicione a seguinte configuração na
 ```yaml title=".pre-commit-config.yaml"
 repos:
 -   repo: https://github.com/biomejs/pre-commit
-    rev: "v0.1.0"  # Use the sha / tag you want to point at
+    rev: "v2.0.6"  # Use the sha / tag you want to point at
     hooks:
     -   id: biome-check
-        additional_dependencies: ["@biomejs/biome@1.4.1"]
+        additional_dependencies: ["@biomejs/biome@2.1.1"]
 ```
 
 Isso vai rodar o comando `biome check --write` quando você executar `git commit`.

--- a/src/content/docs/recipes/git-hooks.mdx
+++ b/src/content/docs/recipes/git-hooks.mdx
@@ -152,10 +152,10 @@ if you want to use the `biome-check` hook, add the following pre-commit configur
 ```yaml title=".pre-commit-config.yaml"
 repos:
 -   repo: https://github.com/biomejs/pre-commit
-    rev: "v0.1.0"  # Use the sha / tag you want to point at
+    rev: "v2.0.6"  # Use the sha / tag you want to point at
     hooks:
     -   id: biome-check
-        additional_dependencies: ["@biomejs/biome@1.4.1"]
+        additional_dependencies: ["@biomejs/biome@2.1.1"]
 ```
 
 This will run `biome check --write` when you run `git commit`.

--- a/src/content/docs/zh-CN/recipes/git-hooks.mdx
+++ b/src/content/docs/zh-CN/recipes/git-hooks.mdx
@@ -152,10 +152,10 @@ Biome 通过 [biomejs/pre-commit](https://github.com/biomejs/pre-commit) 仓库�
 ```yaml title=".pre-commit-config.yaml"
 repos:
 -   repo: https://github.com/biomejs/pre-commit
-    rev: "v0.1.0"  # Use the sha / tag you want to point at
+    rev: "v2.0.6"  # Use the sha / tag you want to point at
     hooks:
     -   id: biome-check
-        additional_dependencies: ["@biomejs/biome@1.4.1"]
+        additional_dependencies: ["@biomejs/biome@2.1.1"]
 ```
 
 这将会在你运行 `git commit` 命令时候，执行 `biome check --write`。


### PR DESCRIPTION
## Summary

<!-- 
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

Currently, if one blinly copies the pre-commit config, it does not work. Bumping the versions makes it work.

Obviously, changing the version based on the version of the docs one looks at would be better, but I did not find such functionality in other parts of the codebase (maybe I looked in the wrong place) and before I reverse-engineer the whole system, just bumping the version seems simpler.