### PR TITLE
docs: winget install instructions

### DIFF
--- a/src/content/docs/es/guides/manual-installation.mdx
+++ b/src/content/docs/es/guides/manual-installation.mdx
@@ -36,6 +36,14 @@ Biome está disponible como [fórmula Homebrew](https://formulae.brew.sh/formula
 brew install biome
 ```
 
+## Winget
+
+Biome está disponible como [paquete winget](https://winget.run/pkg/BiomeJs/Biome) para usuarios de Windows.
+
+```shell
+winget install BiomeJs.Biome
+```
+
 ## Docker
 
 Biome publica [imágenes Docker oficiales](https://github.com/biomejs/docker/pkgs/container/biome) compatibles

--- a/src/content/docs/fr/guides/manual-installation.mdx
+++ b/src/content/docs/fr/guides/manual-installation.mdx
@@ -35,6 +35,14 @@ Biome est disponible sous forme de [formule Homebrew](https://formulae.brew.sh/f
 brew install biome
 ```
 
+## Winget
+
+Biome est disponible comme [paquet winget](https://winget.run/pkg/BiomeJs/Biome) pour les utilisateurs Windows.
+
+```shell
+winget install BiomeJs.Biome
+```
+
 ## Utiliser un binaire publié
 
 Pour installer Biome, prenez l’exécutable pour votre plateforme de la [dernière version de l’interface en ligne de commande](https://github.com/biomejs/biome/releases) sur GitHub et donnez-lui des permissions d’exécution.

--- a/src/content/docs/guides/manual-installation.mdx
+++ b/src/content/docs/guides/manual-installation.mdx
@@ -36,6 +36,14 @@ Biome is available as a [Homebrew formula](https://formulae.brew.sh/formula/biom
 brew install biome
 ```
 
+## Winget
+
+Biome is available as a [winget package](https://winget.run/pkg/BiomeJs/Biome) for Windows users.
+
+```shell
+winget install BiomeJs.Biome
+```
+
 ## Docker
 
 Biome publishes [official Docker images](https://github.com/biomejs/docker/pkgs/container/biome) that support

--- a/src/content/docs/ja/guides/manual-installation.mdx
+++ b/src/content/docs/ja/guides/manual-installation.mdx
@@ -36,6 +36,14 @@ BiomeはmacOSとLinuxユーザー向けに [Homebrew formula](https://formulae.b
 brew install biome
 ```
 
+## Winget
+
+BiomeはWindows向けに [wingetパッケージ](https://winget.run/pkg/BiomeJs/Biome) として利用可能です。
+
+```shell
+winget install BiomeJs.Biome
+```
+
 ## Docker
 
 Biomeはバージョン `v1.7.0` 移行の各バージョンについて **amd64** および **arm64** アーキテクチャをサポートした

--- a/src/content/docs/pt-BR/guides/manual-installation.mdx
+++ b/src/content/docs/pt-BR/guides/manual-installation.mdx
@@ -36,6 +36,14 @@ O Biome está disponível no [Homebrew](https://formulae.brew.sh/formula/biome) 
 brew install biome
 ```
 
+## Winget
+
+O Biome está disponível como [pacote winget](https://winget.run/pkg/BiomeJs/Biome) para usuários Windows.
+
+```shell
+winget install BiomeJs.Biome
+```
+
 ## Instalando o Biome
 
 Para instalar o Biome, baixe o [executável mais recente](https://github.com/biomejs/biome/releases) para a sua arquitetura no GitHub e conceda permissão de execução a ele.

--- a/src/content/docs/zh-CN/guides/manual-installation.mdx
+++ b/src/content/docs/zh-CN/guides/manual-installation.mdx
@@ -34,6 +34,14 @@ Biome可以作为[Homebrew formula](https://formulae.brew.sh/formula/biome)提�
 brew install biome
 ```
 
+## Winget
+
+Biome可以作为[winget包](https://winget.run/pkg/BiomeJs/Biome)提供给Windows用户。
+
+```shell
+winget install BiomeJs.Biome
+```
+
 ## 安装Biome
 
 要安装Biome，请从GitHub的[最新CLI版本](https://github.com/biomejs/biome/releases)中获取适用于您平台的可执行文件，并给它执行权限。


### PR DESCRIPTION
## Summary

This PR adds winget installation instructions to all language versions of the manual installation documentation, complementing the winget support recently introduced in [PR #6841](https://github.com/biomejs/biome/pull/6841).

## Changes Made

- **Added winget installation section** to all `manual-installation.mdx` files across supported languages
- **Positioned consistently** after the Homebrew section in each file
- **Included proper formatting** with links to the winget package page
- **Used localized descriptions** for each language version

## Files Updated

- ✅ `src/content/docs/guides/manual-installation.mdx` (English)
- ✅ `src/content/docs/fr/guides/manual-installation.mdx` (French)
- ✅ `src/content/docs/ja/guides/manual-installation.mdx` (Japanese)
- ✅ `src/content/docs/es/guides/manual-installation.mdx` (Spanish)
- ✅ `src/content/docs/pt-BR/guides/manual-installation.mdx` (Portuguese)
- ✅ `src/content/docs/zh-CN/guides/manual-installation.mdx` (Chinese)

## What's Added

Each language version now includes:

````markdown
## Winget

Biome is available as a [winget package](https://winget.run/pkg/BiomeJs/Biome) for Windows users.

```shell
winget install BiomeJs.Biome
```
````

## Translation Notes

⚠️ **AI-Generated Translations**: The translations for non-English versions were generated using AI assistance. Native speakers are welcome to review and improve the translations if needed.

## Motivation

Winget support [PR #6841](https://github.com/biomejs/biome/pull/6841)

## Testing

- [x] Verified markdown syntax in all files
- [x] Confirmed consistent positioning and formatting
- [x] Validated links to winget package page
- [x] Ensured proper shell code block formatting 