### PR TITLE
Correctly close bold text

### DIFF
--- a/src/content/docs/reference/configuration.mdx
+++ b/src/content/docs/reference/configuration.mdx
@@ -106,8 +106,8 @@ This means that:
 
 * `src/app.js` **is** processed.
 * `src/app.test.js` **is not** processed.
-* `src/special.test.js` **is* processed.
-* `test/special.test.js` **is not* processed.
+* `src/special.test.js` **is** processed.
+* `test/special.test.js` **is not** processed.
 
 #### Note on Biome's scanner
 


### PR DESCRIPTION
## Summary

This change adds asterisks to properly close the bold text that currently renders *\*like this*.