### PR TITLE
fix(zh-cn): fix linter introduction

### DIFF
--- a/src/content/docs/zh-CN/linter/index.mdx
+++ b/src/content/docs/zh-CN/linter/index.mdx
@@ -8,7 +8,8 @@ import RecommendedRules from "@/components/generated/linter/RecommendedRules.ast
 
 Biome 的 linter 静态分析你的代码以捕获常见错误并帮助编写符合规范的代码。
 
-<NumberOfRules />
+它[支持多种语言](/internals/language-support)，并提供了总计 **<NumberOfRules/> 条规则**.
+
 
 ## 通过 CLI 使用 linter
 


### PR DESCRIPTION
中文界面存在问题，rules 数量在第二行单独显示


<img width="1522" height="896" alt="image" src="https://github.com/user-attachments/assets/4baec83e-4eb9-4bc2-8b63-44a8f8e6a13d" />

