### PR TITLE
ci: sync `next` branch from the main repo

### DIFF
--- a/.github/workflows/synchronize.yaml
+++ b/.github/workflows/synchronize.yaml
@@ -24,6 +24,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          ref: ${{ github.event.client_payload.event.ref || github.ref }}
 
       - name: Get commit ID (workflow dispatch, empty)
         if: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.commit-id == '' }}


### PR DESCRIPTION
## Summary

The synchronize workflow will use the ref provided in the repository_dispatch payload. If the `next` branch is updated in the biomejs/biome repository, this workflow will sync it to the `next` branch in this repository.