### PR TITLE
docs: tweak the text that warns the user a rule is in nursery

### DIFF
--- a/codegen/src/lintdoc.rs
+++ b/codegen/src/lintdoc.rs
@@ -779,7 +779,7 @@ fn generate_rule_content(rule_content: RuleContent) -> Result<(Vec<u8>, String, 
         writeln!(content, ":::caution")?;
         writeln!(
             content,
-            "This rule is part of the [nursery](/{path_prefix}/{middle_path}/#nursery) group."
+            "This rule is part of the [nursery](/{path_prefix}/{middle_path}/#nursery) group. This means that it is experimental and the behavior can change at any time."
         )?;
         writeln!(content, ":::")?;
     }


### PR DESCRIPTION
## Summary

<!-- 
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

A small change to make it more immediately clear what nursery means.
