### PR TITLE
fix: Correct nursery links in rules

### DIFF
--- a/codegen/src/lintdoc.rs
+++ b/codegen/src/lintdoc.rs
@@ -542,7 +542,7 @@ struct GenRule<'a> {
 fn generate_rule(
     payload: GenRule,
     path_prefix: &str,
-    middle_path: &str,
+    _middle_path: &str,
     rule_category: RuleCategory,
 ) -> Result<()> {
     let mut content = Vec::new();
@@ -779,7 +779,7 @@ fn generate_rule_content(rule_content: RuleContent) -> Result<(Vec<u8>, String, 
         writeln!(content, ":::caution")?;
         writeln!(
             content,
-            "This rule is part of the [nursery](/{path_prefix}/{middle_path}/#nursery) group. This means that it is experimental and the behavior can change at any time."
+            "This rule is part of the [nursery](/{path_prefix}/#nursery) group. This means that it is experimental and the behavior can change at any time."
         )?;
         writeln!(content, ":::")?;
     }

--- a/src/content/docs/linter/rules/no-await-in-loop.mdx
+++ b/src/content/docs/linter/rules/no-await-in-loop.mdx
@@ -18,7 +18,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   - Same as [`no-await-in-loop`](https://eslint.org/docs/latest/rules/no-await-in-loop)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Disallow `await` inside loops.

--- a/src/content/docs/linter/rules/no-bitwise-operators.mdx
+++ b/src/content/docs/linter/rules/no-bitwise-operators.mdx
@@ -18,7 +18,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   - Same as [`no-bitwise`](https://eslint.org/docs/latest/rules/no-bitwise)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Disallow bitwise operators.

--- a/src/content/docs/linter/rules/no-constant-binary-expression.mdx
+++ b/src/content/docs/linter/rules/no-constant-binary-expression.mdx
@@ -18,7 +18,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   - Same as [`no-constant-binary-expression`](https://eslint.org/docs/latest/rules/no-constant-binary-expression)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Disallow expressions where the operation doesn't affect the value

--- a/src/content/docs/linter/rules/no-destructured-props.mdx
+++ b/src/content/docs/linter/rules/no-destructured-props.mdx
@@ -20,7 +20,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   - Inspired from [`solidjs/no-destructure`](https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/no-destructure.md)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Disallow destructuring props inside JSX components in Solid projects.

--- a/src/content/docs/linter/rules/no-excessive-lines-per-function.mdx
+++ b/src/content/docs/linter/rules/no-excessive-lines-per-function.mdx
@@ -18,7 +18,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   - Inspired from [`max-lines-per-function`](https://eslint.org/docs/latest/rules/max-lines-per-function)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Restrict the number of lines of code in a function.

--- a/src/content/docs/linter/rules/no-floating-promises.mdx
+++ b/src/content/docs/linter/rules/no-floating-promises.mdx
@@ -20,7 +20,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   - Same as [`@typescript-eslint/no-floating-promises`](https://typescript-eslint.io/rules/no-floating-promises)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Require Promise-like statements to be handled appropriately.

--- a/src/content/docs/linter/rules/no-global-dirname-filename.mdx
+++ b/src/content/docs/linter/rules/no-global-dirname-filename.mdx
@@ -18,7 +18,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   - Inspired from [`unicorn/prefer-module`](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-module.md)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Disallow the use of `__dirname` and `__filename` in the global scope.

--- a/src/content/docs/linter/rules/no-implicit-coercion.mdx
+++ b/src/content/docs/linter/rules/no-implicit-coercion.mdx
@@ -18,7 +18,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   - Same as [`no-implicit-coercion`](https://eslint.org/docs/latest/rules/no-implicit-coercion)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Disallow shorthand type conversions.

--- a/src/content/docs/linter/rules/no-import-cycles.mdx
+++ b/src/content/docs/linter/rules/no-import-cycles.mdx
@@ -20,7 +20,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   - Same as [`import/no-cycle`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-cycle.md)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Prevent import cycles.

--- a/src/content/docs/linter/rules/no-important-styles.mdx
+++ b/src/content/docs/linter/rules/no-important-styles.mdx
@@ -18,7 +18,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   - Same as [`stylelint/declaration-no-important`](https://github.com/stylelint/stylelint/blob/main/lib/rules/declaration-no-important/README.md)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Disallow the use of the `!important` style.

--- a/src/content/docs/linter/rules/no-magic-numbers.mdx
+++ b/src/content/docs/linter/rules/no-magic-numbers.mdx
@@ -18,7 +18,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   - Same as [`@typescript-eslint/no-magic-numbers`](https://typescript-eslint.io/rules/no-magic-numbers)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Reports usage of "magic numbers" — numbers used directly instead of being assigned to named constants.

--- a/src/content/docs/linter/rules/no-misused-promises.mdx
+++ b/src/content/docs/linter/rules/no-misused-promises.mdx
@@ -20,7 +20,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   - Same as [`@typescript-eslint/no-misused-promises`](https://typescript-eslint.io/rules/no-misused-promises)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Disallow Promises to be used in places where they are almost certainly a

--- a/src/content/docs/linter/rules/no-nested-component-definitions.mdx
+++ b/src/content/docs/linter/rules/no-nested-component-definitions.mdx
@@ -21,7 +21,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   - Same as [`@eslint-react/no-nested-component-definitions`](https://eslint-react.xyz/docs/rules/no-nested-component-definitions)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Disallows defining React components inside other components.

--- a/src/content/docs/linter/rules/no-noninteractive-element-interactions.mdx
+++ b/src/content/docs/linter/rules/no-noninteractive-element-interactions.mdx
@@ -18,7 +18,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   - Same as [`jsx-a11y/no-noninteractive-element-interactions`](https://github.com/jsx-eslint/eslint-plugin-jsx-a11y/blob/main/docs/rules/no-noninteractive-element-interactions.md)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Disallow use event handlers on non-interactive elements.

--- a/src/content/docs/linter/rules/no-process-global.mdx
+++ b/src/content/docs/linter/rules/no-process-global.mdx
@@ -18,7 +18,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   - Same as [`deno-lint/no-process-global`](https://lint.deno.land/rules/no-process-global)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Disallow the use of `process` global.

--- a/src/content/docs/linter/rules/no-quickfix-biome.mdx
+++ b/src/content/docs/linter/rules/no-quickfix-biome.mdx
@@ -15,7 +15,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 - This rule has a [**safe**](/linter/#safe-fixes) fix.
 - The default severity of this rule is [**information**](/reference/diagnostics#information).
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Disallow the use if `quickfix.biome` inside editor settings file.

--- a/src/content/docs/linter/rules/no-qwik-use-visible-task.mdx
+++ b/src/content/docs/linter/rules/no-qwik-use-visible-task.mdx
@@ -22,7 +22,7 @@ This rule is currently only available in the [2.0 beta release](/blog/biome-v2-0
   - Same as [`qwik/no-use-visible-task`](https://github.com/BuilderIO/eslint-plugin-qwik/blob/main/docs/rules/no-use-visible-task.md)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Disallow `useVisibleTask$()` functions in Qwik components.

--- a/src/content/docs/linter/rules/no-react-prop-assign.mdx
+++ b/src/content/docs/linter/rules/no-react-prop-assign.mdx
@@ -18,7 +18,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   - Same as [`react-hooks/react-compiler`](https://github.com/facebook/react/blob/main/packages/eslint-plugin-react-hooks/README.md)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Disallow assigning to React component props.

--- a/src/content/docs/linter/rules/no-restricted-elements.mdx
+++ b/src/content/docs/linter/rules/no-restricted-elements.mdx
@@ -18,7 +18,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   - Same as [`react/forbid-elements`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/forbid-elements.md)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Disallow the use of configured elements.

--- a/src/content/docs/linter/rules/no-secrets.mdx
+++ b/src/content/docs/linter/rules/no-secrets.mdx
@@ -18,7 +18,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   - Inspired from [`no-secrets/no-secrets`](https://github.com/nickdeis/eslint-plugin-no-secrets/blob/master/README.md)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Disallow usage of sensitive data such as API keys and tokens.

--- a/src/content/docs/linter/rules/no-shadow.mdx
+++ b/src/content/docs/linter/rules/no-shadow.mdx
@@ -18,7 +18,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   - Same as [`no-shadow`](https://eslint.org/docs/latest/rules/no-shadow)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Disallow variable declarations from shadowing variables declared in the outer scope.

--- a/src/content/docs/linter/rules/no-ts-ignore.mdx
+++ b/src/content/docs/linter/rules/no-ts-ignore.mdx
@@ -18,7 +18,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   - Inspired from [`@typescript-eslint/ban-ts-comment`](https://typescript-eslint.io/rules/ban-ts-comment)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Prevents the use of the TypeScript directive `@ts-ignore`.

--- a/src/content/docs/linter/rules/no-unassigned-variables.mdx
+++ b/src/content/docs/linter/rules/no-unassigned-variables.mdx
@@ -18,7 +18,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   - Same as [`no-unassigned-vars`](https://eslint.org/docs/latest/rules/no-unassigned-vars)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Disallow `let` or `var` variables that are read but never assigned.

--- a/src/content/docs/linter/rules/no-unknown-at-rule.mdx
+++ b/src/content/docs/linter/rules/no-unknown-at-rule.mdx
@@ -18,7 +18,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   - Same as [`stylelint/at-rule-no-unknown`](https://github.com/stylelint/stylelint/blob/main/lib/rules/at-rule-no-unknown/README.md)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Disallow unknown at-rules.

--- a/src/content/docs/linter/rules/no-unresolved-imports.mdx
+++ b/src/content/docs/linter/rules/no-unresolved-imports.mdx
@@ -20,7 +20,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   - Inspired from [`import/named`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/named.md)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Warn when importing non-existing exports.

--- a/src/content/docs/linter/rules/no-unwanted-polyfillio.mdx
+++ b/src/content/docs/linter/rules/no-unwanted-polyfillio.mdx
@@ -20,7 +20,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   - Same as [`@next/no-unwanted-polyfillio`](https://nextjs.org/docs/messages/no-unwanted-polyfillio)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Prevent duplicate polyfills from Polyfill.io.

--- a/src/content/docs/linter/rules/no-useless-backref-in-regex.mdx
+++ b/src/content/docs/linter/rules/no-useless-backref-in-regex.mdx
@@ -19,7 +19,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   - Same as [`regexp/no-useless-backreference`](https://ota-meshi.github.io/eslint-plugin-regexp/rules/no-useless-backreference.html)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Disallow useless backreferences in regular expression literals that always match an empty string.

--- a/src/content/docs/linter/rules/no-useless-escape-in-string.mdx
+++ b/src/content/docs/linter/rules/no-useless-escape-in-string.mdx
@@ -15,7 +15,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 - This rule has a [**safe**](/linter/#safe-fixes) fix.
 - The default severity of this rule is [**warning**](/reference/diagnostics#warning).
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Disallow unnecessary escapes in string literals.
@@ -84,7 +84,7 @@ a::after {
 - This rule has a [**safe**](/linter/#safe-fixes) fix.
 - The default severity of this rule is [**warning**](/reference/diagnostics#warning).
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Disallow unnecessary escapes in string literals.

--- a/src/content/docs/linter/rules/no-useless-undefined.mdx
+++ b/src/content/docs/linter/rules/no-useless-undefined.mdx
@@ -18,7 +18,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   - Same as [`unicorn/no-useless-undefined`](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/no-useless-undefined.md)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Disallow the use of useless `undefined`.

--- a/src/content/docs/linter/rules/no-vue-reserved-keys.mdx
+++ b/src/content/docs/linter/rules/no-vue-reserved-keys.mdx
@@ -20,7 +20,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   - Same as [`vue/no-reserved-keys`](https://eslint.vuejs.org/rules/no-reserved-keys)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Disallow reserved keys in Vue component data and computed properties.

--- a/src/content/docs/linter/rules/no-vue-reserved-props.mdx
+++ b/src/content/docs/linter/rules/no-vue-reserved-props.mdx
@@ -20,7 +20,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   - Same as [`vue/no-reserved-props`](https://eslint.vuejs.org/rules/no-reserved-props)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Disallow reserved names to be used as props.

--- a/src/content/docs/linter/rules/use-adjacent-getter-setter.mdx
+++ b/src/content/docs/linter/rules/use-adjacent-getter-setter.mdx
@@ -18,7 +18,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   - Same as [`grouped-accessor-pairs`](https://eslint.org/docs/latest/rules/grouped-accessor-pairs)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Enforce that getters and setters for the same property are adjacent in class and object definitions.

--- a/src/content/docs/linter/rules/use-anchor-href.mdx
+++ b/src/content/docs/linter/rules/use-anchor-href.mdx
@@ -22,7 +22,7 @@ This rule is currently only available in the [2.0 beta release](/blog/biome-v2-0
   - Same as [`qwik/jsx-a`](https://github.com/BuilderIO/eslint-plugin-qwik/blob/main/docs/rules/jsx-a.md)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Enforces `href` attribute for `<a>` elements.

--- a/src/content/docs/linter/rules/use-consistent-object-definition.mdx
+++ b/src/content/docs/linter/rules/use-consistent-object-definition.mdx
@@ -18,7 +18,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   - Inspired from [`object-shorthand`](https://eslint.org/docs/latest/rules/object-shorthand)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Require the consistent declaration of object literals. Defaults to explicit definitions.

--- a/src/content/docs/linter/rules/use-consistent-response.mdx
+++ b/src/content/docs/linter/rules/use-consistent-response.mdx
@@ -15,7 +15,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 - This rule has an [**unsafe**](/linter/#unsafe-fixes) fix.
 - The default severity of this rule is [**information**](/reference/diagnostics#information).
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Use static `Response` methods instead of `new Response()` constructor when possible.

--- a/src/content/docs/linter/rules/use-exhaustive-switch-cases.mdx
+++ b/src/content/docs/linter/rules/use-exhaustive-switch-cases.mdx
@@ -20,7 +20,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   - Same as [`@typescript-eslint/switch-exhaustiveness-check`](https://typescript-eslint.io/rules/switch-exhaustiveness-check)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Require switch-case statements to be exhaustive.

--- a/src/content/docs/linter/rules/use-explicit-type.mdx
+++ b/src/content/docs/linter/rules/use-explicit-type.mdx
@@ -19,7 +19,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   - Inspired from [`@typescript-eslint/explicit-module-boundary-types`](https://typescript-eslint.io/rules/explicit-module-boundary-types)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Enforce types in functions, methods, variables, and parameters.

--- a/src/content/docs/linter/rules/use-exports-last.mdx
+++ b/src/content/docs/linter/rules/use-exports-last.mdx
@@ -18,7 +18,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   - Same as [`import/exports-last`](https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/exports-last.md)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Require that all exports are declared after all non-export statements.

--- a/src/content/docs/linter/rules/use-for-component.mdx
+++ b/src/content/docs/linter/rules/use-for-component.mdx
@@ -20,7 +20,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   - Inspired from [`solidjs/prefer-for`](https://github.com/solidjs-community/eslint-plugin-solid/blob/main/packages/eslint-plugin-solid/docs/prefer-for.md)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Enforce using Solid's `<For />` component for mapping an array to JSX elements.

--- a/src/content/docs/linter/rules/use-google-font-preconnect.mdx
+++ b/src/content/docs/linter/rules/use-google-font-preconnect.mdx
@@ -20,7 +20,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   - Same as [`@next/google-font-preconnect`](https://nextjs.org/docs/messages/google-font-preconnect)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Ensure the `preconnect` attribute is used when using Google Fonts.

--- a/src/content/docs/linter/rules/use-image-size.mdx
+++ b/src/content/docs/linter/rules/use-image-size.mdx
@@ -22,7 +22,7 @@ This rule is currently only available in the [2.0 beta release](/blog/biome-v2-0
   - Same as [`qwik/jsx-img`](https://github.com/BuilderIO/eslint-plugin-qwik/blob/main/docs/rules/jsx-img.md)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Enforces that `<img>` elements have both width and height attributes.

--- a/src/content/docs/linter/rules/use-index-of.mdx
+++ b/src/content/docs/linter/rules/use-index-of.mdx
@@ -18,7 +18,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   - Same as [`unicorn/prefer-array-index-of`](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/main/docs/rules/prefer-array-index-of.md)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Prefer `Array#{indexOf,lastIndexOf}()` over `Array#{findIndex,findLastIndex}()` when looking for the index of an item.

--- a/src/content/docs/linter/rules/use-iterable-callback-return.mdx
+++ b/src/content/docs/linter/rules/use-iterable-callback-return.mdx
@@ -18,7 +18,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   - Same as [`array-callback-return`](https://eslint.org/docs/latest/rules/array-callback-return)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Enforce consistent return values in iterable callbacks.

--- a/src/content/docs/linter/rules/use-json-import-attribute.mdx
+++ b/src/content/docs/linter/rules/use-json-import-attribute.mdx
@@ -17,7 +17,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 - This rule belongs to the following domains:
   - [`project`](/linter/domains#project)
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Enforces the use of `with { type: "json" }` for JSON module imports.

--- a/src/content/docs/linter/rules/use-named-operation.mdx
+++ b/src/content/docs/linter/rules/use-named-operation.mdx
@@ -18,7 +18,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   - Same as [`graphql/no-anonymous-operations`](https://the-guild.dev/graphql/eslint/rules/no-anonymous-operations)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Enforce specifying the name of GraphQL operations.

--- a/src/content/docs/linter/rules/use-numeric-separators.mdx
+++ b/src/content/docs/linter/rules/use-numeric-separators.mdx
@@ -19,7 +19,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   - Same as [`unreadable_literal`](https://rust-lang.github.io/rust-clippy/master/#unreadable_literal)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Enforce the use of numeric separators in numeric literals.

--- a/src/content/docs/linter/rules/use-object-spread.mdx
+++ b/src/content/docs/linter/rules/use-object-spread.mdx
@@ -18,7 +18,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   - Same as [`prefer-object-spread`](https://eslint.org/docs/latest/rules/prefer-object-spread)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Prefer object spread over `Object.assign()` when constructing new objects.

--- a/src/content/docs/linter/rules/use-parse-int-radix.mdx
+++ b/src/content/docs/linter/rules/use-parse-int-radix.mdx
@@ -18,7 +18,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   - Same as [`radix`](https://eslint.org/docs/latest/rules/radix)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Enforce the consistent use of the radix argument when using `parseInt()`.

--- a/src/content/docs/linter/rules/use-qwik-classlist.mdx
+++ b/src/content/docs/linter/rules/use-qwik-classlist.mdx
@@ -22,7 +22,7 @@ This rule is currently only available in the [2.0 beta release](/blog/biome-v2-0
   - Same as [`qwik/prefer-classlist`](https://github.com/BuilderIO/eslint-plugin-qwik/blob/main/docs/rules/prefer-classlist.md)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Prefer using the `class` prop as a classlist over the `classnames` helper.

--- a/src/content/docs/linter/rules/use-react-function-components.mdx
+++ b/src/content/docs/linter/rules/use-react-function-components.mdx
@@ -20,7 +20,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   - Same as [`react-prefer-function-component/react-prefer-function-component`](https://github.com/tatethurston/eslint-plugin-react-prefer-function-component)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Enforce that components are defined as functions and never as classes.

--- a/src/content/docs/linter/rules/use-readonly-class-properties.mdx
+++ b/src/content/docs/linter/rules/use-readonly-class-properties.mdx
@@ -18,7 +18,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   - Same as [`@typescript-eslint/prefer-readonly`](https://typescript-eslint.io/rules/prefer-readonly)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Enforce marking members as `readonly` if they are never modified outside the constructor.

--- a/src/content/docs/linter/rules/use-single-js-doc-asterisk.mdx
+++ b/src/content/docs/linter/rules/use-single-js-doc-asterisk.mdx
@@ -18,7 +18,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   - Same as [`jsdoc/no-multi-asterisks`](https://github.com/gajus/eslint-plugin-jsdoc/blob/main/docs/rules/no-multi-asterisks.md)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Enforce JSDoc comment lines to start with a single asterisk, except for the first one.

--- a/src/content/docs/linter/rules/use-sorted-classes.mdx
+++ b/src/content/docs/linter/rules/use-sorted-classes.mdx
@@ -15,7 +15,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 - This rule has an [**unsafe**](/linter/#unsafe-fixes) fix.
 - The default severity of this rule is [**information**](/reference/diagnostics#information).
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Enforce the sorting of CSS utility classes.

--- a/src/content/docs/linter/rules/use-symbol-description.mdx
+++ b/src/content/docs/linter/rules/use-symbol-description.mdx
@@ -18,7 +18,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   - Same as [`symbol-description`](https://eslint.org/docs/latest/rules/symbol-description)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Require a description parameter for the `Symbol()`.

--- a/src/content/docs/linter/rules/use-unified-type-signature.mdx
+++ b/src/content/docs/linter/rules/use-unified-type-signature.mdx
@@ -18,7 +18,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
   - Same as [`@typescript-eslint/unified-signatures`](https://typescript-eslint.io/rules/unified-signatures)
 
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Disallow overload signatures that can be unified into a single signature.

--- a/src/content/docs/linter/rules/use-unique-element-ids.mdx
+++ b/src/content/docs/linter/rules/use-unique-element-ids.mdx
@@ -17,7 +17,7 @@ import { Tabs, TabItem } from '@astrojs/starlight/components';
 - This rule belongs to the following domains:
   - [`react`](/linter/domains#react)
 :::caution
-This rule is part of the [nursery](/linter/rules/#nursery) group. This means that it is experimental and the behavior can change at any time.
+This rule is part of the [nursery](/linter/#nursery) group. This means that it is experimental and the behavior can change at any time.
 :::
 ## Description
 Prevent the usage of static string literal `id` attribute on elements.


### PR DESCRIPTION
## Summary

Every nursery rule that says it is part of the group contains a dead link. Fixed the code generation to point to the correct link.