### PR TITLE
docs(formatter): more inline ignore examples

### DIFF
--- a/src/content/docs/formatter/index.mdx
+++ b/src/content/docs/formatter/index.mdx
@@ -92,6 +92,8 @@ See the [configuration reference](/reference/configuration#formatter) for more d
 
 ## Ignore Code
 
+### Ignore Line
+
 There are times when the formatted code isn't ideal.
 
 For these cases, you can use a format suppression comment:
@@ -125,5 +127,53 @@ const expr =
   ];
 ```
 
-Biome doesn't provide ignore comments that ignore an entire file.
-However, you can [ignore a file using the Biome configuration file](/guides/configure-biome/#ignore-files).
+### Ignore File
+
+When you want disable formatting for entire file without changing the config file.
+
+```js title="example.js"
+// biome-ignore-all format: <explanation>
+```
+
+Example:
+
+```js title="example.js"
+// biome-ignore-all format: silence biome for entire file
+
+const expr =
+  [
+    (2 * n) / (r - l), 0,
+    (r + l) / (r - l), 0,
+    0, (2 * n) / (t - b),
+    (t + b) / (t - b), 0,
+    0, 0,
+    -(f + n) / (f - n), -(2 * f * n) / (f - n),
+    0, 0,
+    -1, 0,
+  ];
+```
+
+### Ignore Parts of File
+
+When you want to disable formatting only for some parts of the file.
+
+```js title="example.js"
+// biome-ignore-start format: <explanation>
+...
+// biome-ignore-end format: <explanation>
+```
+
+Example:
+
+```js title="example.js"
+const expr =
+  // biome-ignore-start format: reviewer demanded this specific array formatted as ladder
+  [
+    (2 * n) / (r - l),
+    0, (r + l) / (r - l),
+    0, 0, (2 * n) / (t - b),
+    (t + b) / (t - b), 0, 0, 0,
+    -(f + n) / (f - n), -(2 * f * n) / (f - n), 0, 0, -1,
+  ];
+  // biome-ignore-start format: reviewer demanded this specific array formatted as ladder
+```


### PR DESCRIPTION
## Summary

I was reading [formatter introduction page](https://biomejs.dev/formatter/) and this line:
> Biome doesn’t provide ignore comments that ignore an entire file.

Made be remember that changelog for v2 said it's [possible to suppress an entire file inline](https://biomejs.dev/blog/biome-v2/#improved-suppressions) now.