### PR TITLE
feat(components): implement localization support for SiteTitle.astro 

### DIFF
--- a/src/components/starlight/SiteTitle.astro
+++ b/src/components/starlight/SiteTitle.astro
@@ -2,9 +2,9 @@
 import AstrolightSiteTitle from "@astrojs/starlight/components/SiteTitle.astro";
 
 const menuItems = [
-	{ name: "Docs", href: "/guides/getting-started" },
-	{ name: "Enterprise", href: "/enterprise" },
-	{ name: "Playground", href: "/playground" },
+	{ name: Astro.locals.t("title.docs"), href: "/guides/getting-started" },
+	{ name: Astro.locals.t("title.enterprise"), href: "/enterprise" },
+	{ name: Astro.locals.t("title.playground"), href: "/playground" },
 ];
 
 function pathsMatch(pathA: string, pathB: string): boolean {

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,6 +1,6 @@
 import { defineCollection, z } from "astro:content";
-import { docsLoader } from "@astrojs/starlight/loaders";
-import { docsSchema } from "@astrojs/starlight/schema";
+import { docsLoader, i18nLoader } from "@astrojs/starlight/loaders";
+import { docsSchema, i18nSchema } from "@astrojs/starlight/schema";
 import { file } from "astro/loaders";
 import { blogSchema } from "starlight-blog/schema";
 
@@ -19,4 +19,14 @@ export const collections = {
 			}),
 		loader: file("src/content/team.json"),
 	}),
+	i18n: defineCollection({
+		loader: i18nLoader(),
+		schema: i18nSchema({
+			extend: z.object({
+				"title.docs": z.string().optional(),
+				"title.enterprise": z.string().optional(),
+				"title.playground": z.string().optional(),
+			})
+		}),
+	})
 };

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -26,7 +26,7 @@ export const collections = {
 				"title.docs": z.string().optional(),
 				"title.enterprise": z.string().optional(),
 				"title.playground": z.string().optional(),
-			})
+			}),
 		}),
-	})
+	}),
 };

--- a/src/content/i18n/en.json
+++ b/src/content/i18n/en.json
@@ -1,0 +1,5 @@
+{
+    "title.docs": "Docs",
+    "title.enterprise": "Enterprise",
+    "title.playground": "Playground"
+}

--- a/src/content/i18n/en.json
+++ b/src/content/i18n/en.json
@@ -1,5 +1,5 @@
 {
-    "title.docs": "Docs",
-    "title.enterprise": "Enterprise",
-    "title.playground": "Playground"
+  "title.docs": "Docs",
+  "title.enterprise": "Enterprise",
+  "title.playground": "Playground"
 }

--- a/src/content/i18n/ru.json
+++ b/src/content/i18n/ru.json
@@ -1,0 +1,5 @@
+{
+    "title.docs": "Документация",
+    "title.enterprise": "Организациям",
+    "title.playground": "Песочница"
+}

--- a/src/content/i18n/ru.json
+++ b/src/content/i18n/ru.json
@@ -1,5 +1,5 @@
 {
-    "title.docs": "Документация",
-    "title.enterprise": "Организациям",
-    "title.playground": "Песочница"
+  "title.docs": "Документация",
+  "title.enterprise": "Организациям",
+  "title.playground": "Песочница"
 }


### PR DESCRIPTION
## Summary
### 💡Motivation
- Currently, components such as SiteTitle.astro cannot be localized.
### 🛠️ Changes
- Add definitions for the used locale keys to `content.config.ts`
- Add locale files: `en.json` and `ru.json`
### 💾 Affected Files
- `src/content.config.ts`
- `src/components/starlight/SiteTitle.astro`
- `src/content/i18n/en.json`
- `src/content/i18n/ru.json`
### 📝 Notes
- In this pull request, SiteTitle.astro is used as an _example implementation of this feature_, so I can make any changes needed to improve it. Any feedback is welcome.