### PR TITLE
docs: don't use `/**` to ignore folders

### DIFF
--- a/src/content/docs/guides/big-projects.mdx
+++ b/src/content/docs/guides/big-projects.mdx
@@ -205,7 +205,7 @@ configuration in the root folder:
     "includes": ["src/**/*.js", "test/**/*.js"],
   },
   "linter": {
-    "includes": ["**", "!test/**"]
+    "includes": ["**", "!test"]
   }
 }
 ```

--- a/src/content/docs/guides/configure-biome.mdx
+++ b/src/content/docs/guides/configure-biome.mdx
@@ -213,7 +213,7 @@ In the following example, we tell Biome to include files, excluded the `dist` di
   "files": {
     "includes": [
       "**",
-      "!**/dist/**",
+      "!**/dist",
       "!**/*.generated.js"
     ]
   }

--- a/src/content/docs/reference/configuration.mdx
+++ b/src/content/docs/reference/configuration.mdx
@@ -1325,10 +1325,18 @@ following syntax in globs:
 - If the entire glob starts with `!`, it is a so-called negated pattern. This
   glob only matches if the path _doesn't_ match the glob. Negated patterns
   cannot be used alone, they can only be used as _exception_ to a regular glob.
+- When determining whether a file is included or not, Biome considers the parent
+  folders too. This means that if you want to _include_ all files in a folder,
+  you need to use the `/**` suffix to match those files. But if you want to
+  _ignore_ all files in a folder, you may do so without the `/**` suffix. We
+  recommend ignoring folders without the trailing `/**`, to avoid needlessly
+  traversing it, as well as to avoid the risk of Biome loading a `biome.json` or
+  a `.gitignore` file from an ignored folder.
 
 Some examples:
 
 - `dist/**` matches the `dist/` folder and all files inside it.
+- `!dist` ignores the `dist/` folder and all files inside it.
 - `**/test/**` matches all files under any folder named `test`, regardless of
   where they are. E.g. `dist/test`, `src/test`.
 - `**/*.js` matches all files ending with the extension `.js` in all folders.


### PR DESCRIPTION
## Summary

This now works "properly" in 2.2.