### PR TITLE
ci: fix the schema sync workflow

### DIFF
--- a/.github/workflows/schema.yml
+++ b/.github/workflows/schema.yml
@@ -34,26 +34,13 @@ concurrency:
 jobs:
   synchronize:
     runs-on: depot-ubuntu-24.04-arm-16
+    env:
+      COMMIT_ID: ${{ github.event.inputs.sha || github.event.client_payload.sha }}
+      TAG: ${{ github.event.inputs.tag || github.event.client_payload.tag }}
+      BIOME_VERSION: ${{ github.event.inputs.version || github.event.client_payload.version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Set commit ID
-        if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch' }}
-        run: echo "COMMIT_ID=${{ github.event.inputs.sha }}" >> "$GITHUB_ENV"
-
-      # As for now, we don't use it, but it may be used in the future
-      - name: Set tag
-        if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch' }}
-        run: echo "TAG=${{ github.event.inputs.tag }}" >> $GITHUB_ENV
-
-      - name: Set version
-        if: ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'repository_dispatch' }}
-        run: echo "BIOME_VERSION=${{ github.event.inputs.version }}" >> "$GITHUB_ENV"
-
-
-      - name: Free Disk Space
-        uses: ./.github/actions/free-disk-space
 
       - name: Install pnpm
         run: |


### PR DESCRIPTION
## Summary

The payload of `repository_dispatch` can't be accessed by `github.event.inputs.*`, we need to use `github.event.client_payload.*` instead.