### PR TITLE
fix(ja): use long date style for ja to avoid “/” in blog dates

### DIFF
--- a/src/content/i18n/ja.json
+++ b/src/content/i18n/ja.json
@@ -1,5 +1,6 @@
 {
   "title.docs": "ドキュメント",
   "title.enterprise": "エンタープライズ",
-  "title.playground": "プレイグラウンド"
+  "title.playground": "プレイグラウンド",
+  "starlightBlog.post.date": "{{date, datetime(dateStyle: long)}}"
 }


### PR DESCRIPTION
## Summary
**Fix JA blog dates showing HTML-escaped slashes.**

### What
- Override JA i18n for blog date
  - Update `ja.json`

### Why
- Default JA format uses “/”, which is rendered as &#x2F; and appears as mojibake.

### Scope/Impact
- Affects JA blog index and post pages only.
- Other locales remain unchanged.

## Screenshots
| Before | After |
|--------|--------|
| <img width="1552" height="987" alt="Screenshot 2025-08-10 at 2 31 48" src="https://github.com/user-attachments/assets/3b413618-9b90-4069-a45e-247efe1fd37b" /> | <img width="1552" height="987" alt="Screenshot 2025-08-10 at 2 44 26" src="https://github.com/user-attachments/assets/4a94fd71-a9ca-4f62-8aa0-cf41c92b877e" /> | 

Fixes https://github.com/biomejs/website/issues/2877