### PR TITLE
Fix example to integrate biomejs with gitlab-ci

### DIFF
--- a/src/content/docs/recipes/continuous-integration.mdx
+++ b/src/content/docs/recipes/continuous-integration.mdx
@@ -86,8 +86,9 @@ lint:
         - biome ci --reporter=gitlab --colors=off > /tmp/code-quality.json 
         - cp /tmp/code-quality.json code-quality.json
     artifacts:
-        paths:
-            - code-quality.json    # Collect the code quality report as an artifact
+      reports:
+        codequality:
+          - code-quality.json    # Collect the code quality report artifact
     rules:
         - if: $CI_COMMIT_BRANCH    # Run job for commits on branches
         - if: $CI_MERGE_REQUEST_ID # Run job for merge requests

--- a/src/content/docs/recipes/continuous-integration.mdx
+++ b/src/content/docs/recipes/continuous-integration.mdx
@@ -92,7 +92,3 @@ lint:
         - if: $CI_COMMIT_BRANCH    # Run job for commits on branches
         - if: $CI_MERGE_REQUEST_ID # Run job for merge requests
 ```
-
-:::note
-If your project's source code is located in another directory, replace `src` with that directory's path in the command.
-:::


### PR DESCRIPTION
## Summary

The example of how to integrate biome with gitlab-ci was outdated, this fixes the example code

- the **code-quality.json** needs to be passed as `artifacts.reports.codequality`
- the note about the `src` directory seems to be outdated as there is no reference to a `src` directory in the example-code