### PR TITLE
docs: update `files.includes` doc

### DIFF
--- a/src/content/docs/reference/configuration.mdx
+++ b/src/content/docs/reference/configuration.mdx
@@ -102,6 +102,10 @@ This example specifies that:
 4. ... _except_ when it occurs in the folder named `test`, because _no_ files
    inside that folder are processed.
 
+:::caution
+Using `!test` to completely exclude a directory is only supported in `files.includes`. In other places where `includes` is used (`linter.includes`, `formatter.includes`, etc.), you need to use `!/test/**` to exclude the directory.
+:::
+
 This means that:
 
 * `src/app.js` **is** processed.

--- a/src/content/docs/reference/configuration.mdx
+++ b/src/content/docs/reference/configuration.mdx
@@ -102,7 +102,7 @@ This example specifies that:
 4. ... _except_ when it occurs in the folder named `test`, because _no_ files
    inside that folder are processed.
 
-:::caution
+:::note
 Using `!test` to completely exclude a directory is only supported in `files.includes`. In other places where `includes` is used (`linter.includes`, `formatter.includes`, etc.), you need to use `!/test/**` to exclude the directory.
 :::
 


### PR DESCRIPTION
## Summary

Add a caution block regarding the usage of `!` to exclude directories in `files.includes`. The intent is to emphasize that using `!test` will work in `files.includes` and will exclude completely the `test` directory, but will not have that effect in other places where `includes` exists (like `linter`, `formatter`, etc.)

I'm suggesting this update because of https://github.com/biomejs/biome/issues/7262
<!-- 
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->
