### PR TITLE
docs(es): fix typos

### DIFF
--- a/src/content/docs/es/guides/big-projects.mdx
+++ b/src/content/docs/es/guides/big-projects.mdx
@@ -1,5 +1,5 @@
 ---
-title: Utiliza Biome en proyectos grandess
+title: Utiliza Biome en proyectos grandes
 description: Una pequeña guía sobre cómo configurar Biome en proyectos grandes
 ---
 
@@ -33,9 +33,9 @@ Es posible utilizar la opción de configuración [`extends`](/es/guides/configur
 Supongamos que tenemos estos requisitos:
 
 - El proyecto `legacy-app` tiene que formatear utilizando espacios;
-- Los proyectos`backend` y `new-app` tienen que formatear usando tabs;
-- todos los proyectos deben formatear con un ancho de línea de 120;
-- El proyecto`backend` necesita hacer algunas verificaciones adicionales;
+- Los proyectos `backend` y `new-app` tienen que formatear usando tabs;
+- Todos los proyectos deben formatear con un ancho de línea de 120;
+- El proyecto `backend` necesita hacer algunas verificaciones adicionales;
 
 Comenzamos creando un nuevo archivo de configuración en `app/biome.json`, y ponemos allí las opciones compartidas:
 


### PR DESCRIPTION
## Summary

Fixed some typos in the Spanish translation.