### PR TITLE
docs: remove duplicate `html.formatter.enabled`

### DIFF
--- a/src/content/docs/reference/configuration.mdx
+++ b/src/content/docs/reference/configuration.mdx
@@ -1312,12 +1312,6 @@ Enables Biome's formatter for HTML files.
 
 > Default: `false`
 
-### `html.formatter.enabled`
-
-Whether this formatting option should be enabled.
-
-> Default: `true`
-
 ### `html.formatter.indentStyle`
 
 The style of the indentation for HTML files. It can be `"tab"` or `"space"`.


### PR DESCRIPTION
## Summary

I was just checking out the docs and noticed the duplicate. I removed the one saying that the default is `true` since the HTML formatter is still experimental and whose description did not match the format of the other `*.formatter.enabled` entries.

Feel free to close this if I missed something and the duplication is intentional.