### PR TITLE
Fix:  linktext in "docs/ja/linter/index.mdx"

### DIFF
--- a/src/content/docs/ja/linter/index.mdx
+++ b/src/content/docs/ja/linter/index.mdx
@@ -7,7 +7,7 @@ import NumberOfRules from "@/components/generated/linter/NumberOfRules.astro";
 import PackageManagerBiomeCommand from "@/components/PackageManagerBiomeCommand.astro";
 
 Biomeのリンタはあなたのコードを静的に分析し、典型的なエラーを検出して、より自然なコードを書く手助けをします。
-[複数の言語](/internals/language-support)をサポートし、全部で**<NumberOfRules/> 個のルール**を提供しています。
+[複数の言語](/internals/language-support)をサポートし、全部で[**<NumberOfRules/> 個のルール**](/linter/rules-sources)を提供しています。
 
 ## CLI
 

--- a/src/content/docs/ja/linter/index.mdx
+++ b/src/content/docs/ja/linter/index.mdx
@@ -7,7 +7,7 @@ import NumberOfRules from "@/components/generated/linter/NumberOfRules.astro";
 import PackageManagerBiomeCommand from "@/components/PackageManagerBiomeCommand.astro";
 
 Biomeのリンタはあなたのコードを静的に分析し、典型的なエラーを検出して、より自然なコードを書く手助けをします。
-[複数の言語](/internals/language-support)をサポートし、全部で[**<NumberOfRules/> 個のルール**](/linter/rules/)を提供しています。
+[複数の言語](/internals/language-support)をサポートし、全部で**<NumberOfRules/> 個のルール**を提供しています。
 
 ## CLI
 


### PR DESCRIPTION
## Summary

When I read Biome doc, I found non-existent link in linter doc. So, I fix textlink. 
Now english doc don't have link to linter rules page. If it is better to delete textlink than fix textlink, I will delete textlink. What do you all think?