### PR TITLE
Fix: Remove duplicated organizeImports configuration example

### DIFF
--- a/src/content/docs/assist/actions/organize-imports.mdx
+++ b/src/content/docs/assist/actions/organize-imports.mdx
@@ -274,23 +274,6 @@ Given the following configuration...
 
 ```json title='biome.json'
 {
-    "assist": {
-        "actions": {
-            "source": {
-                "organizeImports": {
-                    "level": "on",
-                    "options": {
-                        "groups": [
-                            ":URL:",
-                            ":NODE:"
-                        ]
-                    }
-                }
-            }
-        }
-    }
-}
-{
 	"assist": {
 		"actions": {
 			"source": {


### PR DESCRIPTION
## Summary

https://biomejs.dev/assist/actions/organize-imports/#import-and-export-groups

The same content seemed to be repeated.

<img width="806" height="975" alt="image" src="https://github.com/user-attachments/assets/4390f811-0c54-410c-a2bf-98be8e192cd5" />
