### PR TITLE
chore: merge contrib across repos

### DIFF
--- a/src/components/generated/Community.astro
+++ b/src/components/generated/Community.astro
@@ -27,11 +27,20 @@ import { Image } from "astro:assets";
   />
   <Image
     class="contributor-avatar"
+    src="https://avatars.githubusercontent.com/u/649677?v=4"
+    alt="User nhedger"
+    width="84"
+    height="84"
+  />
+  <Image
+    class="contributor-avatar"
     src="https://avatars.githubusercontent.com/u/1203881?v=4"
     alt="User MichaReiser"
     width="84"
     height="84"
   />
+</div>
+<div class="contributor-row">
   <Image
     class="contributor-avatar"
     src="https://avatars.githubusercontent.com/u/533294?v=4"
@@ -39,8 +48,6 @@ import { Image } from "astro:assets";
     width="84"
     height="84"
   />
-</div>
-<div class="contributor-row">
   <Image
     class="contributor-avatar"
     src="https://avatars.githubusercontent.com/u/1895119?v=4"
@@ -57,13 +64,6 @@ import { Image } from "astro:assets";
   />
   <Image
     class="contributor-avatar"
-    src="https://avatars.githubusercontent.com/u/1808807?v=4"
-    alt="User dyc3"
-    width="84"
-    height="84"
-  />
-  <Image
-    class="contributor-avatar"
     src="https://avatars.githubusercontent.com/u/12772118?v=4"
     alt="User siketyan"
     width="84"
@@ -73,8 +73,8 @@ import { Image } from "astro:assets";
 <div class="contributor-row">
   <Image
     class="contributor-avatar"
-    src="https://avatars.githubusercontent.com/u/83425?v=4"
-    alt="User xunilrj"
+    src="https://avatars.githubusercontent.com/u/1808807?v=4"
+    alt="User dyc3"
     width="84"
     height="84"
   />
@@ -87,8 +87,8 @@ import { Image } from "astro:assets";
   />
   <Image
     class="contributor-avatar"
-    src="https://avatars.githubusercontent.com/u/7271639?v=4"
-    alt="User yassere"
+    src="https://avatars.githubusercontent.com/u/83425?v=4"
+    alt="User xunilrj"
     width="84"
     height="84"
   />
@@ -101,15 +101,15 @@ import { Image } from "astro:assets";
   />
   <Image
     class="contributor-avatar"
-    src="https://avatars.githubusercontent.com/u/17974631?v=4"
-    alt="User IWANABETHATGUY"
+    src="https://avatars.githubusercontent.com/u/7271639?v=4"
+    alt="User yassere"
     width="84"
     height="84"
   />
   <Image
     class="contributor-avatar"
-    src="https://avatars.githubusercontent.com/u/5262527?v=4"
-    alt="User diokey"
+    src="https://avatars.githubusercontent.com/u/17974631?v=4"
+    alt="User IWANABETHATGUY"
     width="84"
     height="84"
   />
@@ -117,8 +117,22 @@ import { Image } from "astro:assets";
 <div class="contributor-row">
   <Image
     class="contributor-avatar"
+    src="https://avatars.githubusercontent.com/u/5262527?v=4"
+    alt="User diokey"
+    width="84"
+    height="84"
+  />
+  <Image
+    class="contributor-avatar"
     src="https://avatars.githubusercontent.com/u/41323220?v=4"
     alt="User yeonjuan"
+    width="84"
+    height="84"
+  />
+  <Image
+    class="contributor-avatar"
+    src="https://avatars.githubusercontent.com/u/17228098?v=4"
+    alt="User nissy-dev"
     width="84"
     height="84"
   />
@@ -136,6 +150,8 @@ import { Image } from "astro:assets";
     width="84"
     height="84"
   />
+</div>
+<div class="contributor-row">
   <Image
     class="contributor-avatar"
     src="https://avatars.githubusercontent.com/u/783733?v=4"
@@ -143,15 +159,6 @@ import { Image } from "astro:assets";
     width="84"
     height="84"
   />
-  <Image
-    class="contributor-avatar"
-    src="https://avatars.githubusercontent.com/u/17228098?v=4"
-    alt="User nissy-dev"
-    width="84"
-    height="84"
-  />
-</div>
-<div class="contributor-row">
   <Image
     class="contributor-avatar"
     src="https://avatars.githubusercontent.com/u/33844379?v=4"
@@ -166,6 +173,8 @@ import { Image } from "astro:assets";
     width="84"
     height="84"
   />
+</div>
+<div class="contributor-row">
   <Image
     class="contributor-avatar"
     src="https://avatars.githubusercontent.com/u/62130798?v=4"
@@ -173,12 +182,10 @@ import { Image } from "astro:assets";
     width="84"
     height="84"
   />
-</div>
-<div class="contributor-row">
   <Image
     class="contributor-avatar"
-    src="https://avatars.githubusercontent.com/u/649677?v=4"
-    alt="User nhedger"
+    src="https://avatars.githubusercontent.com/u/78874691?v=4"
+    alt="User victor-teles"
     width="84"
     height="84"
   />
@@ -191,13 +198,6 @@ import { Image } from "astro:assets";
   />
   <Image
     class="contributor-avatar"
-    src="https://avatars.githubusercontent.com/u/20097860?v=4"
-    alt="User macovedj"
-    width="84"
-    height="84"
-  />
-  <Image
-    class="contributor-avatar"
     src="https://avatars.githubusercontent.com/u/32598811?v=4"
     alt="User fireairforce"
     width="84"
@@ -205,13 +205,20 @@ import { Image } from "astro:assets";
   />
   <Image
     class="contributor-avatar"
-    src="https://avatars.githubusercontent.com/u/23608309?v=4"
-    alt="User ah-yu"
+    src="https://avatars.githubusercontent.com/u/20097860?v=4"
+    alt="User macovedj"
     width="84"
     height="84"
   />
 </div>
 <div class="contributor-row">
+  <Image
+    class="contributor-avatar"
+    src="https://avatars.githubusercontent.com/u/23608309?v=4"
+    alt="User ah-yu"
+    width="84"
+    height="84"
+  />
   <Image
     class="contributor-avatar"
     src="https://avatars.githubusercontent.com/u/8914032?v=4"
@@ -221,22 +228,15 @@ import { Image } from "astro:assets";
   />
   <Image
     class="contributor-avatar"
-    src="https://avatars.githubusercontent.com/u/85363195?v=4"
-    alt="User vasucp1207"
+    src="https://avatars.githubusercontent.com/u/11046907?v=4"
+    alt="User kaioduarte"
     width="84"
     height="84"
   />
   <Image
     class="contributor-avatar"
-    src="https://avatars.githubusercontent.com/u/501052?v=4"
-    alt="User chansuke"
-    width="84"
-    height="84"
-  />
-  <Image
-    class="contributor-avatar"
-    src="https://avatars.githubusercontent.com/u/78874691?v=4"
-    alt="User victor-teles"
+    src="https://avatars.githubusercontent.com/u/76632500?v=4"
+    alt="User webdevbynight"
     width="84"
     height="84"
   />

--- a/src/components/generated/Contributors.astro
+++ b/src/components/generated/Contributors.astro
@@ -36,6 +36,16 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
+    <a href="https://github.com/biomejs/biome/commits?author=nhedger">
+      <Image
+        src="https://avatars.githubusercontent.com/u/649677?v=4"
+        alt="User nhedger"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
     <a href="https://github.com/biomejs/biome/commits?author=MichaReiser">
       <Image
         src="https://avatars.githubusercontent.com/u/1203881?v=4"
@@ -76,16 +86,6 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=dyc3">
-      <Image
-        src="https://avatars.githubusercontent.com/u/1808807?v=4"
-        alt="User dyc3"
-        width="57"
-        height="57"
-      />
-    </a>
-  </li>
-  <li>
     <a href="https://github.com/biomejs/biome/commits?author=siketyan">
       <Image
         src="https://avatars.githubusercontent.com/u/12772118?v=4"
@@ -96,10 +96,10 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=xunilrj">
+    <a href="https://github.com/biomejs/biome/commits?author=dyc3">
       <Image
-        src="https://avatars.githubusercontent.com/u/83425?v=4"
-        alt="User xunilrj"
+        src="https://avatars.githubusercontent.com/u/1808807?v=4"
+        alt="User dyc3"
         width="57"
         height="57"
       />
@@ -116,10 +116,10 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=yassere">
+    <a href="https://github.com/biomejs/biome/commits?author=xunilrj">
       <Image
-        src="https://avatars.githubusercontent.com/u/7271639?v=4"
-        alt="User yassere"
+        src="https://avatars.githubusercontent.com/u/83425?v=4"
+        alt="User xunilrj"
         width="57"
         height="57"
       />
@@ -130,6 +130,16 @@ import { Image } from "astro:assets";
       <Image
         src="https://avatars.githubusercontent.com/u/38400669?v=4"
         alt="User unvalley"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=yassere">
+      <Image
+        src="https://avatars.githubusercontent.com/u/7271639?v=4"
+        alt="User yassere"
         width="57"
         height="57"
       />
@@ -166,6 +176,16 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
+    <a href="https://github.com/biomejs/biome/commits?author=nissy-dev">
+      <Image
+        src="https://avatars.githubusercontent.com/u/17228098?v=4"
+        alt="User nissy-dev"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
     <a href="https://github.com/biomejs/biome/commits?author=EduardoLopes">
       <Image
         src="https://avatars.githubusercontent.com/u/1084297?v=4"
@@ -190,16 +210,6 @@ import { Image } from "astro:assets";
       <Image
         src="https://avatars.githubusercontent.com/u/783733?v=4"
         alt="User faultyserver"
-        width="57"
-        height="57"
-      />
-    </a>
-  </li>
-  <li>
-    <a href="https://github.com/biomejs/biome/commits?author=nissy-dev">
-      <Image
-        src="https://avatars.githubusercontent.com/u/17228098?v=4"
-        alt="User nissy-dev"
         width="57"
         height="57"
       />
@@ -236,10 +246,10 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=nhedger">
+    <a href="https://github.com/biomejs/biome/commits?author=victor-teles">
       <Image
-        src="https://avatars.githubusercontent.com/u/649677?v=4"
-        alt="User nhedger"
+        src="https://avatars.githubusercontent.com/u/78874691?v=4"
+        alt="User victor-teles"
         width="57"
         height="57"
       />
@@ -256,20 +266,20 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=macovedj">
+    <a href="https://github.com/biomejs/biome/commits?author=fireairforce">
       <Image
-        src="https://avatars.githubusercontent.com/u/20097860?v=4"
-        alt="User macovedj"
+        src="https://avatars.githubusercontent.com/u/32598811?v=4"
+        alt="User fireairforce"
         width="57"
         height="57"
       />
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=fireairforce">
+    <a href="https://github.com/biomejs/biome/commits?author=macovedj">
       <Image
-        src="https://avatars.githubusercontent.com/u/32598811?v=4"
-        alt="User fireairforce"
+        src="https://avatars.githubusercontent.com/u/20097860?v=4"
+        alt="User macovedj"
         width="57"
         height="57"
       />
@@ -296,6 +306,26 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
+    <a href="https://github.com/biomejs/biome/commits?author=kaioduarte">
+      <Image
+        src="https://avatars.githubusercontent.com/u/11046907?v=4"
+        alt="User kaioduarte"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=webdevbynight">
+      <Image
+        src="https://avatars.githubusercontent.com/u/76632500?v=4"
+        alt="User webdevbynight"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
     <a href="https://github.com/biomejs/biome/commits?author=vasucp1207">
       <Image
         src="https://avatars.githubusercontent.com/u/85363195?v=4"
@@ -310,16 +340,6 @@ import { Image } from "astro:assets";
       <Image
         src="https://avatars.githubusercontent.com/u/501052?v=4"
         alt="User chansuke"
-        width="57"
-        height="57"
-      />
-    </a>
-  </li>
-  <li>
-    <a href="https://github.com/biomejs/biome/commits?author=victor-teles">
-      <Image
-        src="https://avatars.githubusercontent.com/u/78874691?v=4"
-        alt="User victor-teles"
         width="57"
         height="57"
       />
@@ -346,6 +366,16 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
+    <a href="https://github.com/biomejs/biome/commits?author=luckydye">
+      <Image
+        src="https://avatars.githubusercontent.com/u/10381895?v=4"
+        alt="User luckydye"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
     <a href="https://github.com/biomejs/biome/commits?author=Kelbie">
       <Image
         src="https://avatars.githubusercontent.com/u/19197564?v=4"
@@ -356,10 +386,20 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=kaioduarte">
+    <a href="https://github.com/biomejs/biome/commits?author=SuperchupuDev">
       <Image
-        src="https://avatars.githubusercontent.com/u/11046907?v=4"
-        alt="User kaioduarte"
+        src="https://avatars.githubusercontent.com/u/53496941?v=4"
+        alt="User SuperchupuDev"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=lucasweng">
+      <Image
+        src="https://avatars.githubusercontent.com/u/30640930?v=4"
+        alt="User lucasweng"
         width="57"
         height="57"
       />
@@ -370,16 +410,6 @@ import { Image } from "astro:assets";
       <Image
         src="https://avatars.githubusercontent.com/u/8802980?v=4"
         alt="User mattcompiles"
-        width="57"
-        height="57"
-      />
-    </a>
-  </li>
-  <li>
-    <a href="https://github.com/biomejs/biome/commits?author=SuperchupuDev">
-      <Image
-        src="https://avatars.githubusercontent.com/u/53496941?v=4"
-        alt="User SuperchupuDev"
         width="57"
         height="57"
       />
@@ -406,20 +436,10 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=lucasweng">
+    <a href="https://github.com/biomejs/biome/commits?author=95th">
       <Image
-        src="https://avatars.githubusercontent.com/u/30640930?v=4"
-        alt="User lucasweng"
-        width="57"
-        height="57"
-      />
-    </a>
-  </li>
-  <li>
-    <a href="https://github.com/biomejs/biome/commits?author=jamiebuilds">
-      <Image
-        src="https://avatars.githubusercontent.com/u/952783?v=4"
-        alt="User jamiebuilds"
+        src="https://avatars.githubusercontent.com/u/22871609?v=4"
+        alt="User 95th"
         width="57"
         height="57"
       />
@@ -430,6 +450,16 @@ import { Image } from "astro:assets";
       <Image
         src="https://avatars.githubusercontent.com/u/176898?v=4"
         alt="User mdevils"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=jamiebuilds">
+      <Image
+        src="https://avatars.githubusercontent.com/u/952783?v=4"
+        alt="User jamiebuilds"
         width="57"
         height="57"
       />
@@ -456,6 +486,16 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
+    <a href="https://github.com/biomejs/biome/commits?author=Jayllyz">
+      <Image
+        src="https://avatars.githubusercontent.com/u/16305216?v=4"
+        alt="User Jayllyz"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
     <a href="https://github.com/biomejs/biome/commits?author=kaykdm">
       <Image
         src="https://avatars.githubusercontent.com/u/34934746?v=4"
@@ -470,16 +510,6 @@ import { Image } from "astro:assets";
       <Image
         src="https://avatars.githubusercontent.com/u/41065217?v=4"
         alt="User TaKO8Ki"
-        width="57"
-        height="57"
-      />
-    </a>
-  </li>
-  <li>
-    <a href="https://github.com/biomejs/biome/commits?author=Jayllyz">
-      <Image
-        src="https://avatars.githubusercontent.com/u/16305216?v=4"
-        alt="User Jayllyz"
         width="57"
         height="57"
       />
@@ -516,10 +546,10 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=95th">
+    <a href="https://github.com/biomejs/biome/commits?author=Netail">
       <Image
-        src="https://avatars.githubusercontent.com/u/22871609?v=4"
-        alt="User 95th"
+        src="https://avatars.githubusercontent.com/u/11695769?v=4"
+        alt="User Netail"
         width="57"
         height="57"
       />
@@ -556,6 +586,16 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
+    <a href="https://github.com/biomejs/biome/commits?author=SzymCode">
+      <Image
+        src="https://avatars.githubusercontent.com/u/107359025?v=4"
+        alt="User SzymCode"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
     <a href="https://github.com/biomejs/biome/commits?author=kalleep">
       <Image
         src="https://avatars.githubusercontent.com/u/23356117?v=4"
@@ -566,30 +606,20 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=wgardiner">
-      <Image
-        src="https://avatars.githubusercontent.com/u/4764564?v=4"
-        alt="User wgardiner"
-        width="57"
-        height="57"
-      />
-    </a>
-  </li>
-  <li>
-    <a href="https://github.com/biomejs/biome/commits?author=anthonyshew">
-      <Image
-        src="https://avatars.githubusercontent.com/u/35677084?v=4"
-        alt="User anthonyshew"
-        width="57"
-        height="57"
-      />
-    </a>
-  </li>
-  <li>
     <a href="https://github.com/biomejs/biome/commits?author=ktfth">
       <Image
         src="https://avatars.githubusercontent.com/u/44123854?v=4"
         alt="User ktfth"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=ernieMrtnz">
+      <Image
+        src="https://avatars.githubusercontent.com/u/1855668?v=4"
+        alt="User ernieMrtnz"
         width="57"
         height="57"
       />
@@ -616,20 +646,50 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=jonahsnider">
+    <a href="https://github.com/biomejs/biome/commits?author=wgardiner">
       <Image
-        src="https://avatars.githubusercontent.com/u/7608555?v=4"
-        alt="User jonahsnider"
+        src="https://avatars.githubusercontent.com/u/4764564?v=4"
+        alt="User wgardiner"
         width="57"
         height="57"
       />
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=Netail">
+    <a href="https://github.com/biomejs/biome/commits?author=anthonyshew">
       <Image
-        src="https://avatars.githubusercontent.com/u/11695769?v=4"
-        alt="User Netail"
+        src="https://avatars.githubusercontent.com/u/35677084?v=4"
+        alt="User anthonyshew"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=daivinhtran">
+      <Image
+        src="https://avatars.githubusercontent.com/u/13268391?v=4"
+        alt="User daivinhtran"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=cr7pt0gr4ph7">
+      <Image
+        src="https://avatars.githubusercontent.com/u/3719586?v=4"
+        alt="User cr7pt0gr4ph7"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=jonahsnider">
+      <Image
+        src="https://avatars.githubusercontent.com/u/7608555?v=4"
+        alt="User jonahsnider"
         width="57"
         height="57"
       />
@@ -646,10 +706,30 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
+    <a href="https://github.com/biomejs/biome/commits?author=bc-m">
+      <Image
+        src="https://avatars.githubusercontent.com/u/40334865?v=4"
+        alt="User bc-m"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
     <a href="https://github.com/biomejs/biome/commits?author=ImBIOS">
       <Image
         src="https://avatars.githubusercontent.com/u/41441643?v=4"
         alt="User ImBIOS"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=mrkldshv">
+      <Image
+        src="https://avatars.githubusercontent.com/u/47859603?v=4"
+        alt="User mrkldshv"
         width="57"
         height="57"
       />
@@ -676,10 +756,50 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
+    <a href="https://github.com/biomejs/biome/commits?author=mehm8128">
+      <Image
+        src="https://avatars.githubusercontent.com/u/83744975?v=4"
+        alt="User mehm8128"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
     <a href="https://github.com/biomejs/biome/commits?author=DerTimonius">
       <Image
         src="https://avatars.githubusercontent.com/u/103483059?v=4"
         alt="User DerTimonius"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=Marukome0743">
+      <Image
+        src="https://avatars.githubusercontent.com/u/146040408?v=4"
+        alt="User Marukome0743"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=cpojer">
+      <Image
+        src="https://avatars.githubusercontent.com/u/13352?v=4"
+        alt="User cpojer"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=anonrig">
+      <Image
+        src="https://avatars.githubusercontent.com/u/1935246?v=4"
+        alt="User anonrig"
         width="57"
         height="57"
       />
@@ -716,6 +836,36 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
+    <a href="https://github.com/biomejs/biome/commits?author=magic-akari">
+      <Image
+        src="https://avatars.githubusercontent.com/u/7829098?v=4"
+        alt="User magic-akari"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=morinokami">
+      <Image
+        src="https://avatars.githubusercontent.com/u/7889778?v=4"
+        alt="User morinokami"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=Vivalldi">
+      <Image
+        src="https://avatars.githubusercontent.com/u/8962537?v=4"
+        alt="User Vivalldi"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
     <a href="https://github.com/biomejs/biome/commits?author=matvp91">
       <Image
         src="https://avatars.githubusercontent.com/u/12699796?v=4"
@@ -726,10 +876,10 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=daivinhtran">
+    <a href="https://github.com/biomejs/biome/commits?author=hamirmahal">
       <Image
-        src="https://avatars.githubusercontent.com/u/13268391?v=4"
-        alt="User daivinhtran"
+        src="https://avatars.githubusercontent.com/u/43425812?v=4"
+        alt="User hamirmahal"
         width="57"
         height="57"
       />
@@ -746,16 +896,6 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=cpojer">
-      <Image
-        src="https://avatars.githubusercontent.com/u/13352?v=4"
-        alt="User cpojer"
-        width="57"
-        height="57"
-      />
-    </a>
-  </li>
-  <li>
     <a href="https://github.com/biomejs/biome/commits?author=strager">
       <Image
         src="https://avatars.githubusercontent.com/u/48666?v=4"
@@ -766,10 +906,10 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=anonrig">
+    <a href="https://github.com/biomejs/biome/commits?author=printfn">
       <Image
-        src="https://avatars.githubusercontent.com/u/1935246?v=4"
-        alt="User anonrig"
+        src="https://avatars.githubusercontent.com/u/1643883?v=4"
+        alt="User printfn"
         width="57"
         height="57"
       />
@@ -796,40 +936,10 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=cr7pt0gr4ph7">
-      <Image
-        src="https://avatars.githubusercontent.com/u/3719586?v=4"
-        alt="User cr7pt0gr4ph7"
-        width="57"
-        height="57"
-      />
-    </a>
-  </li>
-  <li>
-    <a href="https://github.com/biomejs/biome/commits?author=morinokami">
-      <Image
-        src="https://avatars.githubusercontent.com/u/7889778?v=4"
-        alt="User morinokami"
-        width="57"
-        height="57"
-      />
-    </a>
-  </li>
-  <li>
     <a href="https://github.com/biomejs/biome/commits?author=jloleysens">
       <Image
         src="https://avatars.githubusercontent.com/u/8155004?v=4"
         alt="User jloleysens"
-        width="57"
-        height="57"
-      />
-    </a>
-  </li>
-  <li>
-    <a href="https://github.com/biomejs/biome/commits?author=Vivalldi">
-      <Image
-        src="https://avatars.githubusercontent.com/u/8962537?v=4"
-        alt="User Vivalldi"
         width="57"
         height="57"
       />
@@ -866,10 +976,40 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=mrkldshv">
+    <a href="https://github.com/biomejs/biome/commits?author=bhbs">
       <Image
-        src="https://avatars.githubusercontent.com/u/47859603?v=4"
-        alt="User mrkldshv"
+        src="https://avatars.githubusercontent.com/u/22282293?v=4"
+        alt="User bhbs"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=ryan-m-walker">
+      <Image
+        src="https://avatars.githubusercontent.com/u/26845525?v=4"
+        alt="User ryan-m-walker"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=uncenter">
+      <Image
+        src="https://avatars.githubusercontent.com/u/47499684?v=4"
+        alt="User uncenter"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=Malix-Labs">
+      <Image
+        src="https://avatars.githubusercontent.com/u/76160668?v=4"
+        alt="User Malix-Labs"
         width="57"
         height="57"
       />
@@ -886,20 +1026,30 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=daniel-macovei-kr">
+    <a href="https://github.com/biomejs/biome/commits?author=matvasenin">
       <Image
-        src="https://avatars.githubusercontent.com/u/81317209?v=4"
-        alt="User daniel-macovei-kr"
+        src="https://avatars.githubusercontent.com/u/80706941?v=4"
+        alt="User matvasenin"
         width="57"
         height="57"
       />
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=mehm8128">
+    <a href="https://github.com/biomejs/biome/commits?author=okineadev">
       <Image
-        src="https://avatars.githubusercontent.com/u/83744975?v=4"
-        alt="User mehm8128"
+        src="https://avatars.githubusercontent.com/u/81070564?v=4"
+        alt="User okineadev"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=daniel-macovei-kr">
+      <Image
+        src="https://avatars.githubusercontent.com/u/81317209?v=4"
+        alt="User daniel-macovei-kr"
         width="57"
         height="57"
       />
@@ -946,16 +1096,6 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=printfn">
-      <Image
-        src="https://avatars.githubusercontent.com/u/1643883?v=4"
-        alt="User printfn"
-        width="57"
-        height="57"
-      />
-    </a>
-  </li>
-  <li>
     <a href="https://github.com/biomejs/biome/commits?author=CodyCahoon">
       <Image
         src="https://avatars.githubusercontent.com/u/5962054?v=4"
@@ -986,10 +1126,10 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=magic-akari">
+    <a href="https://github.com/biomejs/biome/commits?author=mzbac">
       <Image
-        src="https://avatars.githubusercontent.com/u/7829098?v=4"
-        alt="User magic-akari"
+        src="https://avatars.githubusercontent.com/u/7523197?v=4"
+        alt="User mzbac"
         width="57"
         height="57"
       />
@@ -1016,10 +1156,40 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
+    <a href="https://github.com/biomejs/biome/commits?author=notmd">
+      <Image
+        src="https://avatars.githubusercontent.com/u/33456881?v=4"
+        alt="User notmd"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=JohannesIBK">
+      <Image
+        src="https://avatars.githubusercontent.com/u/50352679?v=4"
+        alt="User JohannesIBK"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
     <a href="https://github.com/biomejs/biome/commits?author=seitarof">
       <Image
         src="https://avatars.githubusercontent.com/u/51070449?v=4"
         alt="User seitarof"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=diegofribeiro">
+      <Image
+        src="https://avatars.githubusercontent.com/u/87657958?v=4"
+        alt="User diegofribeiro"
         width="57"
         height="57"
       />
@@ -1056,6 +1226,36 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
+    <a href="https://github.com/biomejs/biome/commits?author=malobre">
+      <Image
+        src="https://avatars.githubusercontent.com/u/1368457?v=4"
+        alt="User malobre"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=Joshuabaker2">
+      <Image
+        src="https://avatars.githubusercontent.com/u/3316640?v=4"
+        alt="User Joshuabaker2"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=wojtekmaj">
+      <Image
+        src="https://avatars.githubusercontent.com/u/5426427?v=4"
+        alt="User wojtekmaj"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
     <a href="https://github.com/biomejs/biome/commits?author=ryota-murakami">
       <Image
         src="https://avatars.githubusercontent.com/u/5501268?v=4"
@@ -1066,10 +1266,10 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=mzbac">
+    <a href="https://github.com/biomejs/biome/commits?author=jk-gan">
       <Image
-        src="https://avatars.githubusercontent.com/u/7523197?v=4"
-        alt="User mzbac"
+        src="https://avatars.githubusercontent.com/u/7545747?v=4"
+        alt="User jk-gan"
         width="57"
         height="57"
       />
@@ -1146,16 +1346,6 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=bhbs">
-      <Image
-        src="https://avatars.githubusercontent.com/u/22282293?v=4"
-        alt="User bhbs"
-        width="57"
-        height="57"
-      />
-    </a>
-  </li>
-  <li>
     <a href="https://github.com/biomejs/biome/commits?author=oki07">
       <Image
         src="https://avatars.githubusercontent.com/u/22608727?v=4"
@@ -1166,10 +1356,10 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=ryan-m-walker">
+    <a href="https://github.com/biomejs/biome/commits?author=rriski">
       <Image
-        src="https://avatars.githubusercontent.com/u/26845525?v=4"
-        alt="User ryan-m-walker"
+        src="https://avatars.githubusercontent.com/u/25483483?v=4"
+        alt="User rriski"
         width="57"
         height="57"
       />
@@ -1180,16 +1370,6 @@ import { Image } from "astro:assets";
       <Image
         src="https://avatars.githubusercontent.com/u/34422996?v=4"
         alt="User hknsh"
-        width="57"
-        height="57"
-      />
-    </a>
-  </li>
-  <li>
-    <a href="https://github.com/biomejs/biome/commits?author=uncenter">
-      <Image
-        src="https://avatars.githubusercontent.com/u/47499684?v=4"
-        alt="User uncenter"
         width="57"
         height="57"
       />
@@ -1216,6 +1396,16 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
+    <a href="https://github.com/biomejs/biome/commits?author=mrazauskas">
+      <Image
+        src="https://avatars.githubusercontent.com/u/72159681?v=4"
+        alt="User mrazauskas"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
     <a href="https://github.com/biomejs/biome/commits?author=realtimetodie">
       <Image
         src="https://avatars.githubusercontent.com/u/72995223?v=4"
@@ -1236,20 +1426,30 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=Marukome0743">
+    <a href="https://github.com/biomejs/biome/commits?author=qraqras">
       <Image
-        src="https://avatars.githubusercontent.com/u/146040408?v=4"
-        alt="User Marukome0743"
+        src="https://avatars.githubusercontent.com/u/209121567?v=4"
+        alt="User qraqras"
         width="57"
         height="57"
       />
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=qraqras">
+    <a href="https://github.com/biomejs/biome/commits?author=Bryasxin">
       <Image
-        src="https://avatars.githubusercontent.com/u/209121567?v=4"
-        alt="User qraqras"
+        src="https://avatars.githubusercontent.com/u/218210238?v=4"
+        alt="User Bryasxin"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=ptkagori">
+      <Image
+        src="https://avatars.githubusercontent.com/u/220782652?v=4"
+        alt="User ptkagori"
         width="57"
         height="57"
       />
@@ -1266,10 +1466,20 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=malobre">
+    <a href="https://github.com/biomejs/biome/commits?author=lanker">
       <Image
-        src="https://avatars.githubusercontent.com/u/1368457?v=4"
-        alt="User malobre"
+        src="https://avatars.githubusercontent.com/u/356553?v=4"
+        alt="User lanker"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=u1aryz">
+      <Image
+        src="https://avatars.githubusercontent.com/u/644368?v=4"
+        alt="User u1aryz"
         width="57"
         height="57"
       />
@@ -1280,16 +1490,6 @@ import { Image } from "astro:assets";
       <Image
         src="https://avatars.githubusercontent.com/u/5240571?v=4"
         alt="User s-mark-holmes-ii"
-        width="57"
-        height="57"
-      />
-    </a>
-  </li>
-  <li>
-    <a href="https://github.com/biomejs/biome/commits?author=wojtekmaj">
-      <Image
-        src="https://avatars.githubusercontent.com/u/5426427?v=4"
-        alt="User wojtekmaj"
         width="57"
         height="57"
       />
@@ -1346,6 +1546,16 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
+    <a href="https://github.com/biomejs/biome/commits?author=jeysal">
+      <Image
+        src="https://avatars.githubusercontent.com/u/16069751?v=4"
+        alt="User jeysal"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
     <a href="https://github.com/biomejs/biome/commits?author=yukukotani">
       <Image
         src="https://avatars.githubusercontent.com/u/16265411?v=4"
@@ -1360,6 +1570,16 @@ import { Image } from "astro:assets";
       <Image
         src="https://avatars.githubusercontent.com/u/18071040?v=4"
         alt="User e965"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=ianzone">
+      <Image
+        src="https://avatars.githubusercontent.com/u/20043230?v=4"
+        alt="User ianzone"
         width="57"
         height="57"
       />
@@ -1406,16 +1626,6 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=rriski">
-      <Image
-        src="https://avatars.githubusercontent.com/u/25483483?v=4"
-        alt="User rriski"
-        width="57"
-        height="57"
-      />
-    </a>
-  </li>
-  <li>
     <a href="https://github.com/biomejs/biome/commits?author=stefanuros">
       <Image
         src="https://avatars.githubusercontent.com/u/25876628?v=4"
@@ -1446,10 +1656,10 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=notmd">
+    <a href="https://github.com/biomejs/biome/commits?author=nemuvski">
       <Image
-        src="https://avatars.githubusercontent.com/u/33456881?v=4"
-        alt="User notmd"
+        src="https://avatars.githubusercontent.com/u/32708603?v=4"
+        alt="User nemuvski"
         width="57"
         height="57"
       />
@@ -1460,6 +1670,16 @@ import { Image } from "astro:assets";
       <Image
         src="https://avatars.githubusercontent.com/u/35226412?v=4"
         alt="User jianzhoujz"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=n-gude">
+      <Image
+        src="https://avatars.githubusercontent.com/u/47453778?v=4"
+        alt="User n-gude"
         width="57"
         height="57"
       />
@@ -1496,6 +1716,16 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
+    <a href="https://github.com/biomejs/biome/commits?author=GiveMe-A-Name">
+      <Image
+        src="https://avatars.githubusercontent.com/u/58852732?v=4"
+        alt="User GiveMe-A-Name"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
     <a href="https://github.com/biomejs/biome/commits?author=MaxtuneLee">
       <Image
         src="https://avatars.githubusercontent.com/u/60775796?v=4"
@@ -1520,16 +1750,6 @@ import { Image } from "astro:assets";
       <Image
         src="https://avatars.githubusercontent.com/u/68492618?v=4"
         alt="User isnakode"
-        width="57"
-        height="57"
-      />
-    </a>
-  </li>
-  <li>
-    <a href="https://github.com/biomejs/biome/commits?author=mrazauskas">
-      <Image
-        src="https://avatars.githubusercontent.com/u/72159681?v=4"
-        alt="User mrazauskas"
         width="57"
         height="57"
       />
@@ -1566,10 +1786,10 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=ptkagori">
+    <a href="https://github.com/biomejs/biome/commits?author=noritaka1166">
       <Image
-        src="https://avatars.githubusercontent.com/u/220782652?v=4"
-        alt="User ptkagori"
+        src="https://avatars.githubusercontent.com/u/189505037?v=4"
+        alt="User noritaka1166"
         width="57"
         height="57"
       />
@@ -1580,6 +1800,16 @@ import { Image } from "astro:assets";
       <Image
         src="https://avatars.githubusercontent.com/u/131824?v=4"
         alt="User hytromo"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=notpeter">
+      <Image
+        src="https://avatars.githubusercontent.com/u/145113?v=4"
+        alt="User notpeter"
         width="57"
         height="57"
       />
@@ -1616,10 +1846,20 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=lanker">
+    <a href="https://github.com/biomejs/biome/commits?author=setchy">
       <Image
-        src="https://avatars.githubusercontent.com/u/356553?v=4"
-        alt="User lanker"
+        src="https://avatars.githubusercontent.com/u/386277?v=4"
+        alt="User setchy"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=Pascalmh">
+      <Image
+        src="https://avatars.githubusercontent.com/u/498197?v=4"
+        alt="User Pascalmh"
         width="57"
         height="57"
       />
@@ -1656,6 +1896,16 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
+    <a href="https://github.com/biomejs/biome/commits?author=JaCoB1123">
+      <Image
+        src="https://avatars.githubusercontent.com/u/642504?v=4"
+        alt="User JaCoB1123"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
     <a href="https://github.com/biomejs/biome/commits?author=simon04">
       <Image
         src="https://avatars.githubusercontent.com/u/782446?v=4"
@@ -1676,10 +1926,40 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
+    <a href="https://github.com/biomejs/biome/commits?author=iwollmann">
+      <Image
+        src="https://avatars.githubusercontent.com/u/997343?v=4"
+        alt="User iwollmann"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=MacFJA">
+      <Image
+        src="https://avatars.githubusercontent.com/u/1475671?v=4"
+        alt="User MacFJA"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
     <a href="https://github.com/biomejs/biome/commits?author=gie3d">
       <Image
         src="https://avatars.githubusercontent.com/u/1977772?v=4"
         alt="User gie3d"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=edvardchen">
+      <Image
+        src="https://avatars.githubusercontent.com/u/1981743?v=4"
+        alt="User edvardchen"
         width="57"
         height="57"
       />
@@ -1696,10 +1976,10 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=Joshuabaker2">
+    <a href="https://github.com/biomejs/biome/commits?author=kenrick95">
       <Image
-        src="https://avatars.githubusercontent.com/u/3316640?v=4"
-        alt="User Joshuabaker2"
+        src="https://avatars.githubusercontent.com/u/3090380?v=4"
+        alt="User kenrick95"
         width="57"
         height="57"
       />
@@ -1726,6 +2006,16 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
+    <a href="https://github.com/biomejs/biome/commits?author=tylerlaprade">
+      <Image
+        src="https://avatars.githubusercontent.com/u/5475199?v=4"
+        alt="User tylerlaprade"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
     <a href="https://github.com/biomejs/biome/commits?author=Th3S4mur41">
       <Image
         src="https://avatars.githubusercontent.com/u/5543595?v=4"
@@ -1746,10 +2036,10 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=jk-gan">
+    <a href="https://github.com/biomejs/biome/commits?author=walkerdb">
       <Image
-        src="https://avatars.githubusercontent.com/u/7545747?v=4"
-        alt="User jk-gan"
+        src="https://avatars.githubusercontent.com/u/7026330?v=4"
+        alt="User walkerdb"
         width="57"
         height="57"
       />
@@ -1846,20 +2136,20 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=keita-hino">
+    <a href="https://github.com/biomejs/biome/commits?author=chungweileong94">
       <Image
-        src="https://avatars.githubusercontent.com/u/15973671?v=4"
-        alt="User keita-hino"
+        src="https://avatars.githubusercontent.com/u/15154097?v=4"
+        alt="User chungweileong94"
         width="57"
         height="57"
       />
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=jeysal">
+    <a href="https://github.com/biomejs/biome/commits?author=keita-hino">
       <Image
-        src="https://avatars.githubusercontent.com/u/16069751?v=4"
-        alt="User jeysal"
+        src="https://avatars.githubusercontent.com/u/15973671?v=4"
+        alt="User keita-hino"
         width="57"
         height="57"
       />
@@ -1886,6 +2176,16 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
+    <a href="https://github.com/biomejs/biome/commits?author=coderfee">
+      <Image
+        src="https://avatars.githubusercontent.com/u/18255987?v=4"
+        alt="User coderfee"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
     <a href="https://github.com/biomejs/biome/commits?author=zuisong">
       <Image
         src="https://avatars.githubusercontent.com/u/19145952?v=4"
@@ -1900,16 +2200,6 @@ import { Image } from "astro:assets";
       <Image
         src="https://avatars.githubusercontent.com/u/19623160?v=4"
         alt="User hangaoke1"
-        width="57"
-        height="57"
-      />
-    </a>
-  </li>
-  <li>
-    <a href="https://github.com/biomejs/biome/commits?author=ianzone">
-      <Image
-        src="https://avatars.githubusercontent.com/u/20043230?v=4"
-        alt="User ianzone"
         width="57"
         height="57"
       />
@@ -1936,10 +2226,30 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
+    <a href="https://github.com/biomejs/biome/commits?author=luislobo9b">
+      <Image
+        src="https://avatars.githubusercontent.com/u/23505581?v=4"
+        alt="User luislobo9b"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
     <a href="https://github.com/biomejs/biome/commits?author=botoxparty">
       <Image
         src="https://avatars.githubusercontent.com/u/24580068?v=4"
         alt="User botoxparty"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=CommanderStorm">
+      <Image
+        src="https://avatars.githubusercontent.com/u/26258709?v=4"
+        alt="User CommanderStorm"
         width="57"
         height="57"
       />
@@ -1976,10 +2286,30 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
+    <a href="https://github.com/biomejs/biome/commits?author=noftaly">
+      <Image
+        src="https://avatars.githubusercontent.com/u/34779161?v=4"
+        alt="User noftaly"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
     <a href="https://github.com/biomejs/biome/commits?author=kerolloz">
       <Image
         src="https://avatars.githubusercontent.com/u/36763164?v=4"
         alt="User kerolloz"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=jsparkdev">
+      <Image
+        src="https://avatars.githubusercontent.com/u/39112954?v=4"
+        alt="User jsparkdev"
         width="57"
         height="57"
       />
@@ -2006,16 +2336,6 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=hamirmahal">
-      <Image
-        src="https://avatars.githubusercontent.com/u/43425812?v=4"
-        alt="User hamirmahal"
-        width="57"
-        height="57"
-      />
-    </a>
-  </li>
-  <li>
     <a href="https://github.com/biomejs/biome/commits?author=thunfisch987">
       <Image
         src="https://avatars.githubusercontent.com/u/43795814?v=4"
@@ -2036,10 +2356,10 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=n-gude">
+    <a href="https://github.com/biomejs/biome/commits?author=stathis-alexander">
       <Image
-        src="https://avatars.githubusercontent.com/u/47453778?v=4"
-        alt="User n-gude"
+        src="https://avatars.githubusercontent.com/u/45887494?v=4"
+        alt="User stathis-alexander"
         width="57"
         height="57"
       />
@@ -2050,6 +2370,16 @@ import { Image } from "astro:assets";
       <Image
         src="https://avatars.githubusercontent.com/u/47887646?v=4"
         alt="User yuya-okuse"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=kortin99">
+      <Image
+        src="https://avatars.githubusercontent.com/u/50259158?v=4"
+        alt="User kortin99"
         width="57"
         height="57"
       />
@@ -2070,6 +2400,16 @@ import { Image } from "astro:assets";
       <Image
         src="https://avatars.githubusercontent.com/u/52933714?v=4"
         alt="User rmehri01"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=You-saku">
+      <Image
+        src="https://avatars.githubusercontent.com/u/53119949?v=4"
+        alt="User You-saku"
         width="57"
         height="57"
       />
@@ -2106,10 +2446,10 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=GiveMe-A-Name">
+    <a href="https://github.com/biomejs/biome/commits?author=toririm">
       <Image
-        src="https://avatars.githubusercontent.com/u/58852732?v=4"
-        alt="User GiveMe-A-Name"
+        src="https://avatars.githubusercontent.com/u/59079411?v=4"
+        alt="User toririm"
         width="57"
         height="57"
       />
@@ -2186,6 +2526,26 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
+    <a href="https://github.com/biomejs/biome/commits?author=phibkro">
+      <Image
+        src="https://avatars.githubusercontent.com/u/71797726?v=4"
+        alt="User phibkro"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=gggchaseggg">
+      <Image
+        src="https://avatars.githubusercontent.com/u/72274595?v=4"
+        alt="User gggchaseggg"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
     <a href="https://github.com/biomejs/biome/commits?author=Kenzo-Wada">
       <Image
         src="https://avatars.githubusercontent.com/u/79452224?v=4"
@@ -2196,10 +2556,10 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=okineadev">
+    <a href="https://github.com/biomejs/biome/commits?author=ddanielsantos">
       <Image
-        src="https://avatars.githubusercontent.com/u/81070564?v=4"
-        alt="User okineadev"
+        src="https://avatars.githubusercontent.com/u/80872981?v=4"
+        alt="User ddanielsantos"
         width="57"
         height="57"
       />
@@ -2256,20 +2616,20 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=noritaka1166">
+    <a href="https://github.com/biomejs/biome/commits?author=davidbgk">
       <Image
-        src="https://avatars.githubusercontent.com/u/189505037?v=4"
-        alt="User noritaka1166"
+        src="https://avatars.githubusercontent.com/u/3556?v=4"
+        alt="User davidbgk"
         width="57"
         height="57"
       />
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=davidbgk">
+    <a href="https://github.com/biomejs/biome/commits?author=monmon">
       <Image
-        src="https://avatars.githubusercontent.com/u/3556?v=4"
-        alt="User davidbgk"
+        src="https://avatars.githubusercontent.com/u/10237?v=4"
+        alt="User monmon"
         width="57"
         height="57"
       />
@@ -2286,10 +2646,60 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
+    <a href="https://github.com/biomejs/biome/commits?author=mountainash">
+      <Image
+        src="https://avatars.githubusercontent.com/u/27637?v=4"
+        alt="User mountainash"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
     <a href="https://github.com/biomejs/biome/commits?author=bugeats">
       <Image
         src="https://avatars.githubusercontent.com/u/33055?v=4"
         alt="User bugeats"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=dandv">
+      <Image
+        src="https://avatars.githubusercontent.com/u/33569?v=4"
+        alt="User dandv"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=johnlindquist">
+      <Image
+        src="https://avatars.githubusercontent.com/u/36073?v=4"
+        alt="User johnlindquist"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=roblillack">
+      <Image
+        src="https://avatars.githubusercontent.com/u/37167?v=4"
+        alt="User roblillack"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=frodeaa">
+      <Image
+        src="https://avatars.githubusercontent.com/u/45172?v=4"
+        alt="User frodeaa"
         width="57"
         height="57"
       />
@@ -2366,6 +2776,16 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
+    <a href="https://github.com/biomejs/biome/commits?author=OzzyCzech">
+      <Image
+        src="https://avatars.githubusercontent.com/u/105520?v=4"
+        alt="User OzzyCzech"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
     <a href="https://github.com/biomejs/biome/commits?author=cristianl">
       <Image
         src="https://avatars.githubusercontent.com/u/109261?v=4"
@@ -2406,6 +2826,26 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
+    <a href="https://github.com/biomejs/biome/commits?author=BoltsJ">
+      <Image
+        src="https://avatars.githubusercontent.com/u/182554?v=4"
+        alt="User BoltsJ"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=nikosalonen">
+      <Image
+        src="https://avatars.githubusercontent.com/u/185737?v=4"
+        alt="User nikosalonen"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
     <a href="https://github.com/biomejs/biome/commits?author=lgarron">
       <Image
         src="https://avatars.githubusercontent.com/u/248078?v=4"
@@ -2420,6 +2860,16 @@ import { Image } from "astro:assets";
       <Image
         src="https://avatars.githubusercontent.com/u/307712?v=4"
         alt="User cheshrkat"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=Angelfire">
+      <Image
+        src="https://avatars.githubusercontent.com/u/315504?v=4"
+        alt="User Angelfire"
         width="57"
         height="57"
       />
@@ -2516,10 +2966,10 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=Pascalmh">
+    <a href="https://github.com/biomejs/biome/commits?author=afc163">
       <Image
-        src="https://avatars.githubusercontent.com/u/498197?v=4"
-        alt="User Pascalmh"
+        src="https://avatars.githubusercontent.com/u/507615?v=4"
+        alt="User afc163"
         width="57"
         height="57"
       />
@@ -2586,6 +3036,16 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
+    <a href="https://github.com/biomejs/biome/commits?author=PowerSupply">
+      <Image
+        src="https://avatars.githubusercontent.com/u/622851?v=4"
+        alt="User PowerSupply"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
     <a href="https://github.com/biomejs/biome/commits?author=ghiscoding">
       <Image
         src="https://avatars.githubusercontent.com/u/643976?v=4"
@@ -2646,10 +3106,40 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
+    <a href="https://github.com/biomejs/biome/commits?author=Wroud">
+      <Image
+        src="https://avatars.githubusercontent.com/u/811729?v=4"
+        alt="User Wroud"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=jsejcksn">
+      <Image
+        src="https://avatars.githubusercontent.com/u/868251?v=4"
+        alt="User jsejcksn"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
     <a href="https://github.com/biomejs/biome/commits?author=dikaio">
       <Image
         src="https://avatars.githubusercontent.com/u/869535?v=4"
         alt="User dikaio"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=OliverJAsh">
+      <Image
+        src="https://avatars.githubusercontent.com/u/921609?v=4"
+        alt="User OliverJAsh"
         width="57"
         height="57"
       />
@@ -2676,10 +3166,10 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=iwollmann">
+    <a href="https://github.com/biomejs/biome/commits?author=autarc">
       <Image
-        src="https://avatars.githubusercontent.com/u/997343?v=4"
-        alt="User iwollmann"
+        src="https://avatars.githubusercontent.com/u/1060490?v=4"
+        alt="User autarc"
         width="57"
         height="57"
       />
@@ -2706,6 +3196,16 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
+    <a href="https://github.com/biomejs/biome/commits?author=mrnugget">
+      <Image
+        src="https://avatars.githubusercontent.com/u/1185253?v=4"
+        alt="User mrnugget"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
     <a href="https://github.com/biomejs/biome/commits?author=lmauromb">
       <Image
         src="https://avatars.githubusercontent.com/u/1216941?v=4"
@@ -2720,6 +3220,26 @@ import { Image } from "astro:assets";
       <Image
         src="https://avatars.githubusercontent.com/u/1313693?v=4"
         alt="User drdaemos"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=benfrain">
+      <Image
+        src="https://avatars.githubusercontent.com/u/1318466?v=4"
+        alt="User benfrain"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=Kesin11">
+      <Image
+        src="https://avatars.githubusercontent.com/u/1324862?v=4"
+        alt="User Kesin11"
         width="57"
         height="57"
       />
@@ -2746,10 +3266,10 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=MacFJA">
+    <a href="https://github.com/biomejs/biome/commits?author=maxdeviant">
       <Image
-        src="https://avatars.githubusercontent.com/u/1475671?v=4"
-        alt="User MacFJA"
+        src="https://avatars.githubusercontent.com/u/1486634?v=4"
+        alt="User maxdeviant"
         width="57"
         height="57"
       />
@@ -2776,6 +3296,16 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
+    <a href="https://github.com/biomejs/biome/commits?author=liuzhaowei55">
+      <Image
+        src="https://avatars.githubusercontent.com/u/1835787?v=4"
+        alt="User liuzhaowei55"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
     <a href="https://github.com/biomejs/biome/commits?author=gsimone">
       <Image
         src="https://avatars.githubusercontent.com/u/1862172?v=4"
@@ -2786,10 +3316,10 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=edvardchen">
+    <a href="https://github.com/biomejs/biome/commits?author=vitallium">
       <Image
-        src="https://avatars.githubusercontent.com/u/1981743?v=4"
-        alt="User edvardchen"
+        src="https://avatars.githubusercontent.com/u/1894248?v=4"
+        alt="User vitallium"
         width="57"
         height="57"
       />
@@ -2846,6 +3376,26 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
+    <a href="https://github.com/biomejs/biome/commits?author=michalvankodev">
+      <Image
+        src="https://avatars.githubusercontent.com/u/2760618?v=4"
+        alt="User michalvankodev"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=ffMathy">
+      <Image
+        src="https://avatars.githubusercontent.com/u/2824010?v=4"
+        alt="User ffMathy"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
     <a href="https://github.com/biomejs/biome/commits?author=iamakulov">
       <Image
         src="https://avatars.githubusercontent.com/u/2953267?v=4"
@@ -2860,6 +3410,16 @@ import { Image } from "astro:assets";
       <Image
         src="https://avatars.githubusercontent.com/u/3019731?v=4"
         alt="User Princesseuh"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=xnuk">
+      <Image
+        src="https://avatars.githubusercontent.com/u/3071003?v=4"
+        alt="User xnuk"
         width="57"
         height="57"
       />
@@ -2890,6 +3450,16 @@ import { Image } from "astro:assets";
       <Image
         src="https://avatars.githubusercontent.com/u/3243191?v=4"
         alt="User andasan"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=polyzen">
+      <Image
+        src="https://avatars.githubusercontent.com/u/3533182?v=4"
+        alt="User polyzen"
         width="57"
         height="57"
       />
@@ -2946,10 +3516,40 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
+    <a href="https://github.com/biomejs/biome/commits?author=besya">
+      <Image
+        src="https://avatars.githubusercontent.com/u/4789696?v=4"
+        alt="User besya"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
     <a href="https://github.com/biomejs/biome/commits?author=jharrell">
       <Image
         src="https://avatars.githubusercontent.com/u/4829245?v=4"
         alt="User jharrell"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=YangYongAn">
+      <Image
+        src="https://avatars.githubusercontent.com/u/4987317?v=4"
+        alt="User YangYongAn"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=damianfrizzi">
+      <Image
+        src="https://avatars.githubusercontent.com/u/5004390?v=4"
+        alt="User damianfrizzi"
         width="57"
         height="57"
       />
@@ -2990,6 +3590,16 @@ import { Image } from "astro:assets";
       <Image
         src="https://avatars.githubusercontent.com/u/5417662?v=4"
         alt="User ftonato"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=yor-so">
+      <Image
+        src="https://avatars.githubusercontent.com/u/5457965?v=4"
+        alt="User yor-so"
         width="57"
         height="57"
       />
@@ -3066,10 +3676,30 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
+    <a href="https://github.com/biomejs/biome/commits?author=roadsidev">
+      <Image
+        src="https://avatars.githubusercontent.com/u/6503047?v=4"
+        alt="User roadsidev"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
     <a href="https://github.com/biomejs/biome/commits?author=Geenzo">
       <Image
         src="https://avatars.githubusercontent.com/u/6834228?v=4"
         alt="User Geenzo"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=ChiefORZ">
+      <Image
+        src="https://avatars.githubusercontent.com/u/6916518?v=4"
+        alt="User ChiefORZ"
         width="57"
         height="57"
       />
@@ -3100,6 +3730,26 @@ import { Image } from "astro:assets";
       <Image
         src="https://avatars.githubusercontent.com/u/7902626?v=4"
         alt="User matejkrajcovic"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=richardtorres314">
+      <Image
+        src="https://avatars.githubusercontent.com/u/7980806?v=4"
+        alt="User richardtorres314"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=jeremyhon">
+      <Image
+        src="https://avatars.githubusercontent.com/u/8131750?v=4"
+        alt="User jeremyhon"
         width="57"
         height="57"
       />
@@ -3216,6 +3866,16 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
+    <a href="https://github.com/biomejs/biome/commits?author=Zaczero">
+      <Image
+        src="https://avatars.githubusercontent.com/u/10835147?v=4"
+        alt="User Zaczero"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
     <a href="https://github.com/biomejs/biome/commits?author=JoostKersjes">
       <Image
         src="https://avatars.githubusercontent.com/u/10849207?v=4"
@@ -3276,6 +3936,36 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
+    <a href="https://github.com/biomejs/biome/commits?author=karima-xyz">
+      <Image
+        src="https://avatars.githubusercontent.com/u/11689450?v=4"
+        alt="User karima-xyz"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=quanru">
+      <Image
+        src="https://avatars.githubusercontent.com/u/11739753?v=4"
+        alt="User quanru"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=MakakWasTaken">
+      <Image
+        src="https://avatars.githubusercontent.com/u/11789635?v=4"
+        alt="User MakakWasTaken"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
     <a href="https://github.com/biomejs/biome/commits?author=octoshikari">
       <Image
         src="https://avatars.githubusercontent.com/u/11928813?v=4"
@@ -3290,6 +3980,26 @@ import { Image } from "astro:assets";
       <Image
         src="https://avatars.githubusercontent.com/u/11944718?v=4"
         alt="User m-nakamura145"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=tyleralbee">
+      <Image
+        src="https://avatars.githubusercontent.com/u/12023274?v=4"
+        alt="User tyleralbee"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=konojunya">
+      <Image
+        src="https://avatars.githubusercontent.com/u/12035578?v=4"
+        alt="User konojunya"
         width="57"
         height="57"
       />
@@ -3436,6 +4146,26 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
+    <a href="https://github.com/biomejs/biome/commits?author=APshenkin">
+      <Image
+        src="https://avatars.githubusercontent.com/u/14344430?v=4"
+        alt="User APshenkin"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=illright">
+      <Image
+        src="https://avatars.githubusercontent.com/u/15035286?v=4"
+        alt="User illright"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
     <a href="https://github.com/biomejs/biome/commits?author=LucianBuzzo">
       <Image
         src="https://avatars.githubusercontent.com/u/15064535?v=4"
@@ -3546,10 +4276,50 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
+    <a href="https://github.com/biomejs/biome/commits?author=Sayakie">
+      <Image
+        src="https://avatars.githubusercontent.com/u/18323202?v=4"
+        alt="User Sayakie"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=rfberaldo">
+      <Image
+        src="https://avatars.githubusercontent.com/u/18370605?v=4"
+        alt="User rfberaldo"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=xeho91">
+      <Image
+        src="https://avatars.githubusercontent.com/u/18627568?v=4"
+        alt="User xeho91"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
     <a href="https://github.com/biomejs/biome/commits?author=DavisVaughan">
       <Image
         src="https://avatars.githubusercontent.com/u/19150088?v=4"
         alt="User DavisVaughan"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=coka-stefan">
+      <Image
+        src="https://avatars.githubusercontent.com/u/19175357?v=4"
+        alt="User coka-stefan"
         width="57"
         height="57"
       />
@@ -3566,10 +4336,30 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
+    <a href="https://github.com/biomejs/biome/commits?author=bioleyl">
+      <Image
+        src="https://avatars.githubusercontent.com/u/19560772?v=4"
+        alt="User bioleyl"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
     <a href="https://github.com/biomejs/biome/commits?author=DeJayDev">
       <Image
         src="https://avatars.githubusercontent.com/u/19671604?v=4"
         alt="User DeJayDev"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=ahaoboy">
+      <Image
+        src="https://avatars.githubusercontent.com/u/19884146?v=4"
+        alt="User ahaoboy"
         width="57"
         height="57"
       />
@@ -3636,6 +4426,16 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
+    <a href="https://github.com/biomejs/biome/commits?author=bohdanbirdie">
+      <Image
+        src="https://avatars.githubusercontent.com/u/23266928?v=4"
+        alt="User bohdanbirdie"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
     <a href="https://github.com/biomejs/biome/commits?author=jorgebodega">
       <Image
         src="https://avatars.githubusercontent.com/u/23708828?v=4"
@@ -3696,6 +4496,26 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
+    <a href="https://github.com/biomejs/biome/commits?author=FalkZ">
+      <Image
+        src="https://avatars.githubusercontent.com/u/24669719?v=4"
+        alt="User FalkZ"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=mpeterdev">
+      <Image
+        src="https://avatars.githubusercontent.com/u/24904709?v=4"
+        alt="User mpeterdev"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
     <a href="https://github.com/biomejs/biome/commits?author=marcalexiei">
       <Image
         src="https://avatars.githubusercontent.com/u/24919330?v=4"
@@ -3726,10 +4546,10 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=CommanderStorm">
+    <a href="https://github.com/biomejs/biome/commits?author=halil-pan">
       <Image
-        src="https://avatars.githubusercontent.com/u/26258709?v=4"
-        alt="User CommanderStorm"
+        src="https://avatars.githubusercontent.com/u/26265451?v=4"
+        alt="User halil-pan"
         width="57"
         height="57"
       />
@@ -3786,6 +4606,16 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
+    <a href="https://github.com/biomejs/biome/commits?author=Arctomachine">
+      <Image
+        src="https://avatars.githubusercontent.com/u/29041820?v=4"
+        alt="User Arctomachine"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
     <a href="https://github.com/biomejs/biome/commits?author=hanseltime">
       <Image
         src="https://avatars.githubusercontent.com/u/30543808?v=4"
@@ -3816,6 +4646,26 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
+    <a href="https://github.com/biomejs/biome/commits?author=bastiendmt">
+      <Image
+        src="https://avatars.githubusercontent.com/u/32489032?v=4"
+        alt="User bastiendmt"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=Jiralite">
+      <Image
+        src="https://avatars.githubusercontent.com/u/33201955?v=4"
+        alt="User Jiralite"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
     <a href="https://github.com/biomejs/biome/commits?author=marvin-j97">
       <Image
         src="https://avatars.githubusercontent.com/u/33938500?v=4"
@@ -3826,10 +4676,20 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=noftaly">
+    <a href="https://github.com/biomejs/biome/commits?author=HonkingGoose">
       <Image
-        src="https://avatars.githubusercontent.com/u/34779161?v=4"
-        alt="User noftaly"
+        src="https://avatars.githubusercontent.com/u/34918129?v=4"
+        alt="User HonkingGoose"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=BennyHinrichs">
+      <Image
+        src="https://avatars.githubusercontent.com/u/35133653?v=4"
+        alt="User BennyHinrichs"
         width="57"
         height="57"
       />
@@ -3856,20 +4716,40 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=yz4230">
+    <a href="https://github.com/biomejs/biome/commits?author=maxchang3">
       <Image
-        src="https://avatars.githubusercontent.com/u/38999742?v=4"
-        alt="User yz4230"
+        src="https://avatars.githubusercontent.com/u/36927158?v=4"
+        alt="User maxchang3"
         width="57"
         height="57"
       />
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=jsparkdev">
+    <a href="https://github.com/biomejs/biome/commits?author=9romise">
       <Image
-        src="https://avatars.githubusercontent.com/u/39112954?v=4"
-        alt="User jsparkdev"
+        src="https://avatars.githubusercontent.com/u/38204901?v=4"
+        alt="User 9romise"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=nopeless">
+      <Image
+        src="https://avatars.githubusercontent.com/u/38830903?v=4"
+        alt="User nopeless"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=yz4230">
+      <Image
+        src="https://avatars.githubusercontent.com/u/38999742?v=4"
+        alt="User yz4230"
         width="57"
         height="57"
       />
@@ -3926,6 +4806,16 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
+    <a href="https://github.com/biomejs/biome/commits?author=troyizzle">
+      <Image
+        src="https://avatars.githubusercontent.com/u/43835286?v=4"
+        alt="User troyizzle"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
     <a href="https://github.com/biomejs/biome/commits?author=ajkachnic">
       <Image
         src="https://avatars.githubusercontent.com/u/44317699?v=4"
@@ -3936,10 +4826,50 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
+    <a href="https://github.com/biomejs/biome/commits?author=jackTabsCode">
+      <Image
+        src="https://avatars.githubusercontent.com/u/44332148?v=4"
+        alt="User jackTabsCode"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=ManuPerezDev">
+      <Image
+        src="https://avatars.githubusercontent.com/u/44470187?v=4"
+        alt="User ManuPerezDev"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=thilllon">
+      <Image
+        src="https://avatars.githubusercontent.com/u/44559468?v=4"
+        alt="User thilllon"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
     <a href="https://github.com/biomejs/biome/commits?author=Omochice">
       <Image
         src="https://avatars.githubusercontent.com/u/44566328?v=4"
         alt="User Omochice"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=mochi-sann">
+      <Image
+        src="https://avatars.githubusercontent.com/u/44772513?v=4"
+        alt="User mochi-sann"
         width="57"
         height="57"
       />
@@ -3966,10 +4896,10 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=stathis-alexander">
+    <a href="https://github.com/biomejs/biome/commits?author=shulandmimi">
       <Image
-        src="https://avatars.githubusercontent.com/u/45887494?v=4"
-        alt="User stathis-alexander"
+        src="https://avatars.githubusercontent.com/u/45983040?v=4"
+        alt="User shulandmimi"
         width="57"
         height="57"
       />
@@ -3980,6 +4910,26 @@ import { Image } from "astro:assets";
       <Image
         src="https://avatars.githubusercontent.com/u/47110179?v=4"
         alt="User avshalomt2"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=rnkln">
+      <Image
+        src="https://avatars.githubusercontent.com/u/47398070?v=4"
+        alt="User rnkln"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=ryoheinan">
+      <Image
+        src="https://avatars.githubusercontent.com/u/49315610?v=4"
+        alt="User ryoheinan"
         width="57"
         height="57"
       />
@@ -4006,10 +4956,10 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=You-saku">
+    <a href="https://github.com/biomejs/biome/commits?author=jamesliu4c">
       <Image
-        src="https://avatars.githubusercontent.com/u/53119949?v=4"
-        alt="User You-saku"
+        src="https://avatars.githubusercontent.com/u/52677895?v=4"
+        alt="User jamesliu4c"
         width="57"
         height="57"
       />
@@ -4036,10 +4986,40 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
+    <a href="https://github.com/biomejs/biome/commits?author=light-planck">
+      <Image
+        src="https://avatars.githubusercontent.com/u/55218925?v=4"
+        alt="User light-planck"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=arch-fan">
+      <Image
+        src="https://avatars.githubusercontent.com/u/55891793?v=4"
+        alt="User arch-fan"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
     <a href="https://github.com/biomejs/biome/commits?author=matteosacchetto">
       <Image
         src="https://avatars.githubusercontent.com/u/56300116?v=4"
         alt="User matteosacchetto"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=ZCY-G">
+      <Image
+        src="https://avatars.githubusercontent.com/u/59002875?v=4"
+        alt="User ZCY-G"
         width="57"
         height="57"
       />
@@ -4076,6 +5056,26 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
+    <a href="https://github.com/biomejs/biome/commits?author=Makonede">
+      <Image
+        src="https://avatars.githubusercontent.com/u/61922615?v=4"
+        alt="User Makonede"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=Insik-Han">
+      <Image
+        src="https://avatars.githubusercontent.com/u/63291908?v=4"
+        alt="User Insik-Han"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
     <a href="https://github.com/biomejs/biome/commits?author=4strodev">
       <Image
         src="https://avatars.githubusercontent.com/u/63979138?v=4"
@@ -4096,10 +5096,40 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
+    <a href="https://github.com/biomejs/biome/commits?author=mcecode">
+      <Image
+        src="https://avatars.githubusercontent.com/u/65783406?v=4"
+        alt="User mcecode"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
     <a href="https://github.com/biomejs/biome/commits?author=Procrustes5">
       <Image
         src="https://avatars.githubusercontent.com/u/66271155?v=4"
         alt="User Procrustes5"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=Willem-Jaap">
+      <Image
+        src="https://avatars.githubusercontent.com/u/67187467?v=4"
+        alt="User Willem-Jaap"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=mezotv">
+      <Image
+        src="https://avatars.githubusercontent.com/u/68947960?v=4"
+        alt="User mezotv"
         width="57"
         height="57"
       />
@@ -4126,6 +5156,36 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
+    <a href="https://github.com/biomejs/biome/commits?author=ivanesmantovich">
+      <Image
+        src="https://avatars.githubusercontent.com/u/70603816?v=4"
+        alt="User ivanesmantovich"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=jake8655">
+      <Image
+        src="https://avatars.githubusercontent.com/u/70668395?v=4"
+        alt="User jake8655"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=musjj">
+      <Image
+        src="https://avatars.githubusercontent.com/u/72612857?v=4"
+        alt="User musjj"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
     <a href="https://github.com/biomejs/biome/commits?author=chrisgrieser">
       <Image
         src="https://avatars.githubusercontent.com/u/73286100?v=4"
@@ -4146,10 +5206,30 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
+    <a href="https://github.com/biomejs/biome/commits?author=quadratz">
+      <Image
+        src="https://avatars.githubusercontent.com/u/74030149?v=4"
+        alt="User quadratz"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
     <a href="https://github.com/biomejs/biome/commits?author=birkskyum">
       <Image
         src="https://avatars.githubusercontent.com/u/74932975?v=4"
         alt="User birkskyum"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=spacexim">
+      <Image
+        src="https://avatars.githubusercontent.com/u/75986258?v=4"
+        alt="User spacexim"
         width="57"
         height="57"
       />
@@ -4176,10 +5256,40 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
-    <a href="https://github.com/biomejs/biome/commits?author=ddanielsantos">
+    <a href="https://github.com/biomejs/biome/commits?author=AshutoshNanaware">
       <Image
-        src="https://avatars.githubusercontent.com/u/80872981?v=4"
-        alt="User ddanielsantos"
+        src="https://avatars.githubusercontent.com/u/81151784?v=4"
+        alt="User AshutoshNanaware"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=ToBinio">
+      <Image
+        src="https://avatars.githubusercontent.com/u/81473300?v=4"
+        alt="User ToBinio"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=torabit">
+      <Image
+        src="https://avatars.githubusercontent.com/u/82490317?v=4"
+        alt="User torabit"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=ryu1013-job">
+      <Image
+        src="https://avatars.githubusercontent.com/u/82691952?v=4"
+        alt="User ryu1013-job"
         width="57"
         height="57"
       />
@@ -4216,6 +5326,16 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
+    <a href="https://github.com/biomejs/biome/commits?author=ryohiy">
+      <Image
+        src="https://avatars.githubusercontent.com/u/90129428?v=4"
+        alt="User ryohiy"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
     <a href="https://github.com/biomejs/biome/commits?author=NikolaRHristov">
       <Image
         src="https://avatars.githubusercontent.com/u/90222871?v=4"
@@ -4236,10 +5356,130 @@ import { Image } from "astro:assets";
     </a>
   </li>
   <li>
+    <a href="https://github.com/biomejs/biome/commits?author=satoru2727">
+      <Image
+        src="https://avatars.githubusercontent.com/u/92915718?v=4"
+        alt="User satoru2727"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=sanoojes">
+      <Image
+        src="https://avatars.githubusercontent.com/u/93819264?v=4"
+        alt="User sanoojes"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=baptiste-prunot">
+      <Image
+        src="https://avatars.githubusercontent.com/u/93978502?v=4"
+        alt="User baptiste-prunot"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=ShadowWolf308">
+      <Image
+        src="https://avatars.githubusercontent.com/u/94675101?v=4"
+        alt="User ShadowWolf308"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
     <a href="https://github.com/biomejs/biome/commits?author=ethanniser">
       <Image
         src="https://avatars.githubusercontent.com/u/100045248?v=4"
         alt="User ethanniser"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=andreluiz901">
+      <Image
+        src="https://avatars.githubusercontent.com/u/102039345?v=4"
+        alt="User andreluiz901"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=AvaYnE2">
+      <Image
+        src="https://avatars.githubusercontent.com/u/103201879?v=4"
+        alt="User AvaYnE2"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=ridwanyinus">
+      <Image
+        src="https://avatars.githubusercontent.com/u/104158911?v=4"
+        alt="User ridwanyinus"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=radovanovic-stevan">
+      <Image
+        src="https://avatars.githubusercontent.com/u/107929243?v=4"
+        alt="User radovanovic-stevan"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=minagishl">
+      <Image
+        src="https://avatars.githubusercontent.com/u/114616680?v=4"
+        alt="User minagishl"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=sunsunmonkey">
+      <Image
+        src="https://avatars.githubusercontent.com/u/116412388?v=4"
+        alt="User sunsunmonkey"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=CHE1RON">
+      <Image
+        src="https://avatars.githubusercontent.com/u/122524301?v=4"
+        alt="User CHE1RON"
+        width="57"
+        height="57"
+      />
+    </a>
+  </li>
+  <li>
+    <a href="https://github.com/biomejs/biome/commits?author=nka21">
+      <Image
+        src="https://avatars.githubusercontent.com/u/133028205?v=4"
+        alt="User nka21"
         width="57"
         height="57"
       />


### PR DESCRIPTION
## Summary

This PR updates the contributors script to fetch contributions across repositories, instead of using only `biomejs/biome`. 

The code was vibe coded using Claude Code 

> I would like to refactor update-contributors.js to take into account multiple repositories across the github org. At the moment, the script only checks for `biomejs/biome`. We want to 
refactor the code to fetch also the `biomejs/website`, `biomejs/biome-vscode`, `biomejs/biome-zed`, and `biomejs/biome-intellij` repositories. We should refactor the code in this way. First, 
try to understand the criteria and make a plan. The `getContributors` function should accept a link to the repository, so make it a paramter. We should create a function that call 
`getContributors` for each repository, and then merges the results. The results should be merged using the id, and the contributions field should be increased if there are multiple id across 
repositories. Eventually, the soring logic should be moved out of `getContributors`, and moved in after the merging logic

The code was tested locally, and the components were correctly updated and committed 