### PR TITLE
docs(fr): fix wrong default type

### DIFF
--- a/src/content/docs/fr/reference/configuration.mdx
+++ b/src/content/docs/fr/reference/configuration.mdx
@@ -820,7 +820,7 @@ Détermine si les tableaux et objets doivent être formatés sur plusieurs ligne
 - `"always"` : les objets et tableaux sont toujours formatés sur plusieurs lignes, quelle que soit leur longueur.
 - `"never"` : les objets et tableaux sont formatés sur une seule ligne s’ils tiennent dans la largeur.
 
-> Valeur par défaut&nbsp;: `"after"`.
+> Valeur par défaut&nbsp;: `"auto"`.
 
 ### `javascript.formatter.operatorLinebreak`
 


### PR DESCRIPTION
## Summary

Fixes the default value of the "javascript.formatter.expand" rule for French documentation