### PR TITLE
fix(schema): make options optional

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,17 +1,17 @@
 [package]
-description = "Crate used to generate pages from the Rust source code of Biome"
-edition = "2024"
-name = "codegen"
-publish = false
-version = "0.1.0"
+	description = "Crate used to generate pages from the Rust source code of Biome"
+	edition     = "2024"
+	name        = "codegen"
+	publish     = false
+	version     = "0.1.0"
 
 [[bin]]
-name = "codegen"
-path = "codegen/src/main.rs"
+	name = "codegen"
+	path = "codegen/src/main.rs"
 
 [lib]
-name = "codegen"
-path = "codegen/src/lib.rs"
+	name = "codegen"
+	path = "codegen/src/lib.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]

--- a/codegen/src/website.rs
+++ b/codegen/src/website.rs
@@ -199,19 +199,17 @@ fn rename_partial_references_in_schema(mut schema: RootSchema) -> RootSchema {
         .definitions
         .into_iter()
         .map(|(mut key, mut schema)| {
-            if let Some(stripped) = key.strip_prefix("Partial") {
-                key = stripped.to_string();
-            } else if key == "RuleWithOptions_for_Null" || key == "RuleWithFixOptions_for_Null" {
+            if key == "RuleWithOptions_for_Null" || key == "RuleWithFixOptions_for_Null" {
                 key = if key == "RuleWithOptions_for_Null" {
                     "RuleWithNoOptions".to_string()
                 } else {
                     "RuleWithFixNoOptions".to_string()
                 };
-                if let Schema::Object(schema_object) = &mut schema {
-                    if let Some(object) = &mut schema_object.object {
-                        object.required.remove("options");
-                        object.properties.remove("options");
-                    }
+                if let Schema::Object(schema_object) = &mut schema
+                    && let Some(object) = &mut schema_object.object
+                {
+                    object.required.remove("options");
+                    object.properties.remove("options");
                 }
             } else if key == "RuleConfiguration_for_Null" {
                 key = "RuleConfiguration".to_string();
@@ -219,8 +217,18 @@ fn rename_partial_references_in_schema(mut schema: RootSchema) -> RootSchema {
                 key = "RuleFixConfiguration".to_string();
             } else if let Some(stripped) = key.strip_prefix("RuleWithOptions_for_") {
                 key = format!("RuleWith{stripped}");
+                if let Schema::Object(schema_object) = &mut schema
+                    && let Some(object) = &mut schema_object.object
+                {
+                    object.required.remove("options");
+                }
             } else if let Some(stripped) = key.strip_prefix("RuleWithFixOptions_for_") {
                 key = format!("RuleWith{stripped}");
+                if let Schema::Object(schema_object) = &mut schema
+                    && let Some(object) = &mut schema_object.object
+                {
+                    object.required.remove("options");
+                }
             } else if let Some(stripped) = key
                 .strip_prefix("RuleConfiguration_for_")
                 .map(|x| x.strip_suffix("Options").unwrap_or(x))

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-# The default profile includes rustc, rust-std, cargo, rust-docs, rustfmt and clippy.
-# https://rust-lang.github.io/rustup/concepts/profiles.html
-channel = "1.90.0"
-profile = "default"
+	# The default profile includes rustc, rust-std, cargo, rust-docs, rustfmt and clippy.
+	# https://rust-lang.github.io/rustup/concepts/profiles.html
+	channel = "1.90.0"
+	profile = "default"

--- a/src/pages/schemas/1.9.3/schema.json.js
+++ b/src/pages/schemas/1.9.3/schema.json.js
@@ -2745,7 +2745,7 @@ export function GET() {
 			},
 			RuleWithAllowDomainOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -2764,7 +2764,7 @@ export function GET() {
 			},
 			RuleWithComplexityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -2779,7 +2779,7 @@ export function GET() {
 			},
 			RuleWithConsistentArrayTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -2798,7 +2798,7 @@ export function GET() {
 			},
 			RuleWithConsistentMemberAccessibilityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -2815,7 +2815,7 @@ export function GET() {
 			},
 			RuleWithDeprecatedHooksOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -2830,7 +2830,7 @@ export function GET() {
 			},
 			RuleWithFilenamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -2860,7 +2860,7 @@ export function GET() {
 			},
 			RuleWithNamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -2879,7 +2879,7 @@ export function GET() {
 			},
 			RuleWithNoConsoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -2898,7 +2898,7 @@ export function GET() {
 			},
 			RuleWithNoDoubleEqualsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -2917,7 +2917,7 @@ export function GET() {
 			},
 			RuleWithNoLabelWithoutControlOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -2943,7 +2943,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -2962,7 +2962,7 @@ export function GET() {
 			},
 			RuleWithRestrictedGlobalsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -2977,7 +2977,7 @@ export function GET() {
 			},
 			RuleWithRestrictedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -2992,7 +2992,7 @@ export function GET() {
 			},
 			RuleWithUseComponentExportOnlyModulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3009,7 +3009,7 @@ export function GET() {
 			},
 			RuleWithUseExhaustiveDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3024,7 +3024,7 @@ export function GET() {
 			},
 			RuleWithUseImportExtensionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3043,7 +3043,7 @@ export function GET() {
 			},
 			RuleWithUseValidAutocompleteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3058,7 +3058,7 @@ export function GET() {
 			},
 			RuleWithUtilityClassSortingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3077,7 +3077,7 @@ export function GET() {
 			},
 			RuleWithValidAriaRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",

--- a/src/pages/schemas/1.9.4/schema.json.js
+++ b/src/pages/schemas/1.9.4/schema.json.js
@@ -2855,7 +2855,7 @@ export function GET() {
 			},
 			RuleWithAllowDomainOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -2874,7 +2874,7 @@ export function GET() {
 			},
 			RuleWithComplexityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -2889,7 +2889,7 @@ export function GET() {
 			},
 			RuleWithConsistentArrayTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -2908,7 +2908,7 @@ export function GET() {
 			},
 			RuleWithConsistentMemberAccessibilityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -2925,7 +2925,7 @@ export function GET() {
 			},
 			RuleWithDeprecatedHooksOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -2940,7 +2940,7 @@ export function GET() {
 			},
 			RuleWithFilenamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -2970,7 +2970,7 @@ export function GET() {
 			},
 			RuleWithNamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -2989,7 +2989,7 @@ export function GET() {
 			},
 			RuleWithNoConsoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3008,7 +3008,7 @@ export function GET() {
 			},
 			RuleWithNoDoubleEqualsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3027,7 +3027,7 @@ export function GET() {
 			},
 			RuleWithNoLabelWithoutControlOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3053,7 +3053,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3072,7 +3072,7 @@ export function GET() {
 			},
 			RuleWithNoSecretsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3087,7 +3087,7 @@ export function GET() {
 			},
 			RuleWithRestrictedGlobalsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3102,7 +3102,7 @@ export function GET() {
 			},
 			RuleWithRestrictedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3117,7 +3117,7 @@ export function GET() {
 			},
 			RuleWithUseComponentExportOnlyModulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3134,7 +3134,7 @@ export function GET() {
 			},
 			RuleWithUseExhaustiveDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3149,7 +3149,7 @@ export function GET() {
 			},
 			RuleWithUseImportExtensionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3168,7 +3168,7 @@ export function GET() {
 			},
 			RuleWithUseValidAutocompleteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3183,7 +3183,7 @@ export function GET() {
 			},
 			RuleWithUtilityClassSortingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3202,7 +3202,7 @@ export function GET() {
 			},
 			RuleWithValidAriaRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",

--- a/src/pages/schemas/2.0.0-beta.1/schema.json.js
+++ b/src/pages/schemas/2.0.0-beta.1/schema.json.js
@@ -3571,7 +3571,7 @@ export function GET() {
             RuleAssistPlainConfiguration: {type: "string", enum: ["off", "on"]},
             RuleAssistWithOptions_for_Null: {
                 type: "object",
-                required: ["level", "options"],
+                required: ["level"],
                 properties: {
                     level: {
                         description: "The severity of the emitted diagnostics by the rule",
@@ -3583,7 +3583,7 @@ export function GET() {
             },
             RuleAssistWithOptions_for_Options: {
                 type: "object",
-                required: ["level", "options"],
+                required: ["level"],
                 properties: {
                     level: {
                         description: "The severity of the emitted diagnostics by the rule",
@@ -3685,7 +3685,7 @@ export function GET() {
             },
             RuleWithAllowDomainOptions: {
                 type: "object",
-                required: ["level", "options"],
+                required: ["level"],
                 properties: {
                     fix: {
                         description: "The kind of the code actions emitted by the rule",
@@ -3704,7 +3704,7 @@ export function GET() {
             },
             RuleWithComplexityOptions: {
                 type: "object",
-                required: ["level", "options"],
+                required: ["level"],
                 properties: {
                     level: {
                         description: "The severity of the emitted diagnostics by the rule",
@@ -3719,7 +3719,7 @@ export function GET() {
             },
             RuleWithConsistentArrayTypeOptions: {
                 type: "object",
-                required: ["level", "options"],
+                required: ["level"],
                 properties: {
                     fix: {
                         description: "The kind of the code actions emitted by the rule",
@@ -3738,7 +3738,7 @@ export function GET() {
             },
             RuleWithConsistentMemberAccessibilityOptions: {
                 type: "object",
-                required: ["level", "options"],
+                required: ["level"],
                 properties: {
                     level: {
                         description: "The severity of the emitted diagnostics by the rule",
@@ -3755,7 +3755,7 @@ export function GET() {
             },
             RuleWithDeprecatedHooksOptions: {
                 type: "object",
-                required: ["level", "options"],
+                required: ["level"],
                 properties: {
                     level: {
                         description: "The severity of the emitted diagnostics by the rule",
@@ -3770,7 +3770,7 @@ export function GET() {
             },
             RuleWithFilenamingConventionOptions: {
                 type: "object",
-                required: ["level", "options"],
+                required: ["level"],
                 properties: {
                     level: {
                         description: "The severity of the emitted diagnostics by the rule",
@@ -3800,7 +3800,7 @@ export function GET() {
             },
             RuleWithNamingConventionOptions: {
                 type: "object",
-                required: ["level", "options"],
+                required: ["level"],
                 properties: {
                     fix: {
                         description: "The kind of the code actions emitted by the rule",
@@ -3819,7 +3819,7 @@ export function GET() {
             },
             RuleWithNoBitwiseOperatorsOptions: {
                 type: "object",
-                required: ["level", "options"],
+                required: ["level"],
                 properties: {
                     level: {
                         description: "The severity of the emitted diagnostics by the rule",
@@ -3834,7 +3834,7 @@ export function GET() {
             },
             RuleWithNoConfusingLabelsOptions: {
                 type: "object",
-                required: ["level", "options"],
+                required: ["level"],
                 properties: {
                     level: {
                         description: "The severity of the emitted diagnostics by the rule",
@@ -3849,7 +3849,7 @@ export function GET() {
             },
             RuleWithNoConsoleOptions: {
                 type: "object",
-                required: ["level", "options"],
+                required: ["level"],
                 properties: {
                     fix: {
                         description: "The kind of the code actions emitted by the rule",
@@ -3868,7 +3868,7 @@ export function GET() {
             },
             RuleWithNoDoubleEqualsOptions: {
                 type: "object",
-                required: ["level", "options"],
+                required: ["level"],
                 properties: {
                     fix: {
                         description: "The kind of the code actions emitted by the rule",
@@ -3887,7 +3887,7 @@ export function GET() {
             },
             RuleWithNoForEachOptions: {
                 type: "object",
-                required: ["level", "options"],
+                required: ["level"],
                 properties: {
                     level: {
                         description: "The severity of the emitted diagnostics by the rule",
@@ -3902,7 +3902,7 @@ export function GET() {
             },
             RuleWithNoLabelWithoutControlOptions: {
                 type: "object",
-                required: ["level", "options"],
+                required: ["level"],
                 properties: {
                     level: {
                         description: "The severity of the emitted diagnostics by the rule",
@@ -3928,7 +3928,7 @@ export function GET() {
             },
             RuleWithNoPrivateImportsOptions: {
                 type: "object",
-                required: ["level", "options"],
+                required: ["level"],
                 properties: {
                     level: {
                         description: "The severity of the emitted diagnostics by the rule",
@@ -3943,7 +3943,7 @@ export function GET() {
             },
             RuleWithNoRestrictedTypesOptions: {
                 type: "object",
-                required: ["level", "options"],
+                required: ["level"],
                 properties: {
                     fix: {
                         description: "The kind of the code actions emitted by the rule",
@@ -3962,7 +3962,7 @@ export function GET() {
             },
             RuleWithNoSecretsOptions: {
                 type: "object",
-                required: ["level", "options"],
+                required: ["level"],
                 properties: {
                     level: {
                         description: "The severity of the emitted diagnostics by the rule",
@@ -3977,7 +3977,7 @@ export function GET() {
             },
             RuleWithNoUndeclaredDependenciesOptions: {
                 type: "object",
-                required: ["level", "options"],
+                required: ["level"],
                 properties: {
                     level: {
                         description: "The severity of the emitted diagnostics by the rule",
@@ -3992,7 +3992,7 @@ export function GET() {
             },
             RuleWithNoUnusedVariablesOptions: {
                 type: "object",
-                required: ["level", "options"],
+                required: ["level"],
                 properties: {
                     fix: {
                         description: "The kind of the code actions emitted by the rule",
@@ -4011,7 +4011,7 @@ export function GET() {
             },
             RuleWithRestrictedGlobalsOptions: {
                 type: "object",
-                required: ["level", "options"],
+                required: ["level"],
                 properties: {
                     level: {
                         description: "The severity of the emitted diagnostics by the rule",
@@ -4026,7 +4026,7 @@ export function GET() {
             },
             RuleWithRestrictedImportsOptions: {
                 type: "object",
-                required: ["level", "options"],
+                required: ["level"],
                 properties: {
                     level: {
                         description: "The severity of the emitted diagnostics by the rule",
@@ -4041,7 +4041,7 @@ export function GET() {
             },
             RuleWithUndeclaredVariablesOptions: {
                 type: "object",
-                required: ["level", "options"],
+                required: ["level"],
                 properties: {
                     level: {
                         description: "The severity of the emitted diagnostics by the rule",
@@ -4056,7 +4056,7 @@ export function GET() {
             },
             RuleWithUseComponentExportOnlyModulesOptions: {
                 type: "object",
-                required: ["level", "options"],
+                required: ["level"],
                 properties: {
                     level: {
                         description: "The severity of the emitted diagnostics by the rule",
@@ -4073,7 +4073,7 @@ export function GET() {
             },
             RuleWithUseConsistentObjectDefinitionOptions: {
                 type: "object",
-                required: ["level", "options"],
+                required: ["level"],
                 properties: {
                     level: {
                         description: "The severity of the emitted diagnostics by the rule",
@@ -4090,7 +4090,7 @@ export function GET() {
             },
             RuleWithUseExhaustiveDependenciesOptions: {
                 type: "object",
-                required: ["level", "options"],
+                required: ["level"],
                 properties: {
                     fix: {
                         description: "The kind of the code actions emitted by the rule",
@@ -4109,7 +4109,7 @@ export function GET() {
             },
             RuleWithUseImportExtensionsOptions: {
                 type: "object",
-                required: ["level", "options"],
+                required: ["level"],
                 properties: {
                     fix: {
                         description: "The kind of the code actions emitted by the rule",
@@ -4128,7 +4128,7 @@ export function GET() {
             },
             RuleWithUseSelfClosingElementsOptions: {
                 type: "object",
-                required: ["level", "options"],
+                required: ["level"],
                 properties: {
                     fix: {
                         description: "The kind of the code actions emitted by the rule",
@@ -4147,7 +4147,7 @@ export function GET() {
             },
             RuleWithUseValidAutocompleteOptions: {
                 type: "object",
-                required: ["level", "options"],
+                required: ["level"],
                 properties: {
                     level: {
                         description: "The severity of the emitted diagnostics by the rule",
@@ -4162,7 +4162,7 @@ export function GET() {
             },
             RuleWithUtilityClassSortingOptions: {
                 type: "object",
-                required: ["level", "options"],
+                required: ["level"],
                 properties: {
                     fix: {
                         description: "The kind of the code actions emitted by the rule",
@@ -4181,7 +4181,7 @@ export function GET() {
             },
             RuleWithValidAriaRoleOptions: {
                 type: "object",
-                required: ["level", "options"],
+                required: ["level"],
                 properties: {
                     fix: {
                         description: "The kind of the code actions emitted by the rule",

--- a/src/pages/schemas/2.0.0-beta.2/schema.json.js
+++ b/src/pages/schemas/2.0.0-beta.2/schema.json.js
@@ -3654,7 +3654,7 @@ export function GET() {
 			RuleAssistPlainConfiguration: { type: "string", enum: ["off", "on"] },
 			RuleAssistWithOptions_for_Null: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3666,7 +3666,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_Options: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3774,7 +3774,7 @@ export function GET() {
 			},
 			RuleWithComplexityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3789,7 +3789,7 @@ export function GET() {
 			},
 			RuleWithConsistentArrayTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3808,7 +3808,7 @@ export function GET() {
 			},
 			RuleWithConsistentMemberAccessibilityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3825,7 +3825,7 @@ export function GET() {
 			},
 			RuleWithDeprecatedHooksOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3840,7 +3840,7 @@ export function GET() {
 			},
 			RuleWithFilenamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3870,7 +3870,7 @@ export function GET() {
 			},
 			RuleWithImportTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3889,7 +3889,7 @@ export function GET() {
 			},
 			RuleWithNamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3908,7 +3908,7 @@ export function GET() {
 			},
 			RuleWithNoBitwiseOperatorsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3923,7 +3923,7 @@ export function GET() {
 			},
 			RuleWithNoBlankTargetOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3942,7 +3942,7 @@ export function GET() {
 			},
 			RuleWithNoConfusingLabelsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3957,7 +3957,7 @@ export function GET() {
 			},
 			RuleWithNoConsoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3976,7 +3976,7 @@ export function GET() {
 			},
 			RuleWithNoDoubleEqualsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3995,7 +3995,7 @@ export function GET() {
 			},
 			RuleWithNoForEachOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4010,7 +4010,7 @@ export function GET() {
 			},
 			RuleWithNoLabelWithoutControlOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4036,7 +4036,7 @@ export function GET() {
 			},
 			RuleWithNoPrivateImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4051,7 +4051,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4066,7 +4066,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4085,7 +4085,7 @@ export function GET() {
 			},
 			RuleWithNoSecretsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4100,7 +4100,7 @@ export function GET() {
 			},
 			RuleWithNoUndeclaredDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4115,7 +4115,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4134,7 +4134,7 @@ export function GET() {
 			},
 			RuleWithRestrictedGlobalsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4149,7 +4149,7 @@ export function GET() {
 			},
 			RuleWithRestrictedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4164,7 +4164,7 @@ export function GET() {
 			},
 			RuleWithUndeclaredVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4179,7 +4179,7 @@ export function GET() {
 			},
 			RuleWithUseComponentExportOnlyModulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4196,7 +4196,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentObjectDefinitionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4217,7 +4217,7 @@ export function GET() {
 			},
 			RuleWithUseExhaustiveDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4236,7 +4236,7 @@ export function GET() {
 			},
 			RuleWithUseImportExtensionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4255,7 +4255,7 @@ export function GET() {
 			},
 			RuleWithUseSelfClosingElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4274,7 +4274,7 @@ export function GET() {
 			},
 			RuleWithUseValidAutocompleteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4289,7 +4289,7 @@ export function GET() {
 			},
 			RuleWithUtilityClassSortingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4308,7 +4308,7 @@ export function GET() {
 			},
 			RuleWithValidAriaRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",

--- a/src/pages/schemas/2.0.0-beta.3/schema.json.js
+++ b/src/pages/schemas/2.0.0-beta.3/schema.json.js
@@ -3440,7 +3440,7 @@ export function GET() {
 			RuleAssistPlainConfiguration: { type: "string", enum: ["off", "on"] },
 			RuleAssistWithOptions_for_Null: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3452,7 +3452,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_Options: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3560,7 +3560,7 @@ export function GET() {
 			},
 			RuleWithComplexityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3575,7 +3575,7 @@ export function GET() {
 			},
 			RuleWithConsistentArrayTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3594,7 +3594,7 @@ export function GET() {
 			},
 			RuleWithConsistentMemberAccessibilityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3611,7 +3611,7 @@ export function GET() {
 			},
 			RuleWithDeprecatedHooksOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3626,7 +3626,7 @@ export function GET() {
 			},
 			RuleWithFilenamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3656,7 +3656,7 @@ export function GET() {
 			},
 			RuleWithImportTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3675,7 +3675,7 @@ export function GET() {
 			},
 			RuleWithNamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3694,7 +3694,7 @@ export function GET() {
 			},
 			RuleWithNoBitwiseOperatorsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3709,7 +3709,7 @@ export function GET() {
 			},
 			RuleWithNoBlankTargetOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3728,7 +3728,7 @@ export function GET() {
 			},
 			RuleWithNoConfusingLabelsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3743,7 +3743,7 @@ export function GET() {
 			},
 			RuleWithNoConsoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3762,7 +3762,7 @@ export function GET() {
 			},
 			RuleWithNoDoubleEqualsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3781,7 +3781,7 @@ export function GET() {
 			},
 			RuleWithNoForEachOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3796,7 +3796,7 @@ export function GET() {
 			},
 			RuleWithNoLabelWithoutControlOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3822,7 +3822,7 @@ export function GET() {
 			},
 			RuleWithNoPrivateImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3837,7 +3837,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3852,7 +3852,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3871,7 +3871,7 @@ export function GET() {
 			},
 			RuleWithNoSecretsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3886,7 +3886,7 @@ export function GET() {
 			},
 			RuleWithNoUndeclaredDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3901,7 +3901,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3920,7 +3920,7 @@ export function GET() {
 			},
 			RuleWithRestrictedGlobalsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3935,7 +3935,7 @@ export function GET() {
 			},
 			RuleWithRestrictedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3950,7 +3950,7 @@ export function GET() {
 			},
 			RuleWithUndeclaredVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3965,7 +3965,7 @@ export function GET() {
 			},
 			RuleWithUseComponentExportOnlyModulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3982,7 +3982,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentObjectDefinitionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4003,7 +4003,7 @@ export function GET() {
 			},
 			RuleWithUseExhaustiveDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4022,7 +4022,7 @@ export function GET() {
 			},
 			RuleWithUseImportExtensionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4041,7 +4041,7 @@ export function GET() {
 			},
 			RuleWithUseJsxKeyInIterableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4056,7 +4056,7 @@ export function GET() {
 			},
 			RuleWithUseSelfClosingElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4075,7 +4075,7 @@ export function GET() {
 			},
 			RuleWithUseValidAutocompleteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4090,7 +4090,7 @@ export function GET() {
 			},
 			RuleWithUtilityClassSortingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4109,7 +4109,7 @@ export function GET() {
 			},
 			RuleWithValidAriaRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",

--- a/src/pages/schemas/2.0.0-beta.4/schema.json.js
+++ b/src/pages/schemas/2.0.0-beta.4/schema.json.js
@@ -3440,7 +3440,7 @@ export function GET() {
 			RuleAssistPlainConfiguration: { type: "string", enum: ["off", "on"] },
 			RuleAssistWithOptions_for_Null: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3452,7 +3452,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_Options: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3560,7 +3560,7 @@ export function GET() {
 			},
 			RuleWithComplexityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3575,7 +3575,7 @@ export function GET() {
 			},
 			RuleWithConsistentArrayTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3594,7 +3594,7 @@ export function GET() {
 			},
 			RuleWithConsistentMemberAccessibilityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3611,7 +3611,7 @@ export function GET() {
 			},
 			RuleWithDeprecatedHooksOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3626,7 +3626,7 @@ export function GET() {
 			},
 			RuleWithFilenamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3656,7 +3656,7 @@ export function GET() {
 			},
 			RuleWithImportTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3675,7 +3675,7 @@ export function GET() {
 			},
 			RuleWithNamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3694,7 +3694,7 @@ export function GET() {
 			},
 			RuleWithNoBitwiseOperatorsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3709,7 +3709,7 @@ export function GET() {
 			},
 			RuleWithNoBlankTargetOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3728,7 +3728,7 @@ export function GET() {
 			},
 			RuleWithNoConfusingLabelsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3743,7 +3743,7 @@ export function GET() {
 			},
 			RuleWithNoConsoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3762,7 +3762,7 @@ export function GET() {
 			},
 			RuleWithNoDoubleEqualsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3781,7 +3781,7 @@ export function GET() {
 			},
 			RuleWithNoForEachOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3796,7 +3796,7 @@ export function GET() {
 			},
 			RuleWithNoLabelWithoutControlOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3822,7 +3822,7 @@ export function GET() {
 			},
 			RuleWithNoPrivateImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3837,7 +3837,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3852,7 +3852,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3871,7 +3871,7 @@ export function GET() {
 			},
 			RuleWithNoSecretsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3886,7 +3886,7 @@ export function GET() {
 			},
 			RuleWithNoUndeclaredDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3901,7 +3901,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3920,7 +3920,7 @@ export function GET() {
 			},
 			RuleWithRestrictedGlobalsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3935,7 +3935,7 @@ export function GET() {
 			},
 			RuleWithRestrictedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3950,7 +3950,7 @@ export function GET() {
 			},
 			RuleWithUndeclaredVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3965,7 +3965,7 @@ export function GET() {
 			},
 			RuleWithUseComponentExportOnlyModulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3982,7 +3982,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentObjectDefinitionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4003,7 +4003,7 @@ export function GET() {
 			},
 			RuleWithUseExhaustiveDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4022,7 +4022,7 @@ export function GET() {
 			},
 			RuleWithUseImportExtensionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4041,7 +4041,7 @@ export function GET() {
 			},
 			RuleWithUseJsxKeyInIterableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4056,7 +4056,7 @@ export function GET() {
 			},
 			RuleWithUseSelfClosingElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4075,7 +4075,7 @@ export function GET() {
 			},
 			RuleWithUseValidAutocompleteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4090,7 +4090,7 @@ export function GET() {
 			},
 			RuleWithUtilityClassSortingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4109,7 +4109,7 @@ export function GET() {
 			},
 			RuleWithValidAriaRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",

--- a/src/pages/schemas/2.0.0-beta.5/schema.json.js
+++ b/src/pages/schemas/2.0.0-beta.5/schema.json.js
@@ -3482,7 +3482,7 @@ export function GET() {
 			RuleAssistPlainConfiguration: { type: "string", enum: ["off", "on"] },
 			RuleAssistWithOptions_for_Null: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3494,7 +3494,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_Options: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3602,7 +3602,7 @@ export function GET() {
 			},
 			RuleWithComplexityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3617,7 +3617,7 @@ export function GET() {
 			},
 			RuleWithConsistentArrayTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3636,7 +3636,7 @@ export function GET() {
 			},
 			RuleWithConsistentMemberAccessibilityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3653,7 +3653,7 @@ export function GET() {
 			},
 			RuleWithDeprecatedHooksOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3668,7 +3668,7 @@ export function GET() {
 			},
 			RuleWithFilenamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3698,7 +3698,7 @@ export function GET() {
 			},
 			RuleWithImportTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3717,7 +3717,7 @@ export function GET() {
 			},
 			RuleWithNamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3736,7 +3736,7 @@ export function GET() {
 			},
 			RuleWithNoBitwiseOperatorsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3751,7 +3751,7 @@ export function GET() {
 			},
 			RuleWithNoBlankTargetOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3770,7 +3770,7 @@ export function GET() {
 			},
 			RuleWithNoConfusingLabelsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3785,7 +3785,7 @@ export function GET() {
 			},
 			RuleWithNoConsoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3804,7 +3804,7 @@ export function GET() {
 			},
 			RuleWithNoDoubleEqualsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3823,7 +3823,7 @@ export function GET() {
 			},
 			RuleWithNoForEachOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3838,7 +3838,7 @@ export function GET() {
 			},
 			RuleWithNoLabelWithoutControlOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3864,7 +3864,7 @@ export function GET() {
 			},
 			RuleWithNoPrivateImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3879,7 +3879,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3894,7 +3894,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3913,7 +3913,7 @@ export function GET() {
 			},
 			RuleWithNoSecretsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3928,7 +3928,7 @@ export function GET() {
 			},
 			RuleWithNoUndeclaredDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3943,7 +3943,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3962,7 +3962,7 @@ export function GET() {
 			},
 			RuleWithRestrictedGlobalsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3977,7 +3977,7 @@ export function GET() {
 			},
 			RuleWithRestrictedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3992,7 +3992,7 @@ export function GET() {
 			},
 			RuleWithUndeclaredVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4007,7 +4007,7 @@ export function GET() {
 			},
 			RuleWithUseComponentExportOnlyModulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4024,7 +4024,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentObjectDefinitionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4045,7 +4045,7 @@ export function GET() {
 			},
 			RuleWithUseExhaustiveDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4064,7 +4064,7 @@ export function GET() {
 			},
 			RuleWithUseImportExtensionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4083,7 +4083,7 @@ export function GET() {
 			},
 			RuleWithUseJsxKeyInIterableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4098,7 +4098,7 @@ export function GET() {
 			},
 			RuleWithUseSelfClosingElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4117,7 +4117,7 @@ export function GET() {
 			},
 			RuleWithUseValidAutocompleteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4132,7 +4132,7 @@ export function GET() {
 			},
 			RuleWithUtilityClassSortingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4151,7 +4151,7 @@ export function GET() {
 			},
 			RuleWithValidAriaRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",

--- a/src/pages/schemas/2.0.0-beta.6/schema.json.js
+++ b/src/pages/schemas/2.0.0-beta.6/schema.json.js
@@ -3543,7 +3543,7 @@ export function GET() {
 			RuleAssistPlainConfiguration: { type: "string", enum: ["off", "on"] },
 			RuleAssistWithOptions_for_Null: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3555,7 +3555,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_Options: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3663,7 +3663,7 @@ export function GET() {
 			},
 			RuleWithComplexityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3678,7 +3678,7 @@ export function GET() {
 			},
 			RuleWithConsistentArrayTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3697,7 +3697,7 @@ export function GET() {
 			},
 			RuleWithConsistentMemberAccessibilityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3714,7 +3714,7 @@ export function GET() {
 			},
 			RuleWithDeprecatedHooksOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3729,7 +3729,7 @@ export function GET() {
 			},
 			RuleWithFilenamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3759,7 +3759,7 @@ export function GET() {
 			},
 			RuleWithImportTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3778,7 +3778,7 @@ export function GET() {
 			},
 			RuleWithNamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3797,7 +3797,7 @@ export function GET() {
 			},
 			RuleWithNoBitwiseOperatorsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3812,7 +3812,7 @@ export function GET() {
 			},
 			RuleWithNoBlankTargetOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3831,7 +3831,7 @@ export function GET() {
 			},
 			RuleWithNoConfusingLabelsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3846,7 +3846,7 @@ export function GET() {
 			},
 			RuleWithNoConsoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3865,7 +3865,7 @@ export function GET() {
 			},
 			RuleWithNoDoubleEqualsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3884,7 +3884,7 @@ export function GET() {
 			},
 			RuleWithNoForEachOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3899,7 +3899,7 @@ export function GET() {
 			},
 			RuleWithNoLabelWithoutControlOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3925,7 +3925,7 @@ export function GET() {
 			},
 			RuleWithNoPrivateImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3940,7 +3940,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3955,7 +3955,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3974,7 +3974,7 @@ export function GET() {
 			},
 			RuleWithNoSecretsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3989,7 +3989,7 @@ export function GET() {
 			},
 			RuleWithNoUndeclaredDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4004,7 +4004,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4023,7 +4023,7 @@ export function GET() {
 			},
 			RuleWithRestrictedGlobalsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4038,7 +4038,7 @@ export function GET() {
 			},
 			RuleWithRestrictedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4053,7 +4053,7 @@ export function GET() {
 			},
 			RuleWithUndeclaredVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4068,7 +4068,7 @@ export function GET() {
 			},
 			RuleWithUseComponentExportOnlyModulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4085,7 +4085,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentObjectDefinitionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4106,7 +4106,7 @@ export function GET() {
 			},
 			RuleWithUseExhaustiveDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4125,7 +4125,7 @@ export function GET() {
 			},
 			RuleWithUseImportExtensionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4144,7 +4144,7 @@ export function GET() {
 			},
 			RuleWithUseJsxKeyInIterableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4159,7 +4159,7 @@ export function GET() {
 			},
 			RuleWithUseSelfClosingElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4178,7 +4178,7 @@ export function GET() {
 			},
 			RuleWithUseValidAutocompleteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4193,7 +4193,7 @@ export function GET() {
 			},
 			RuleWithUtilityClassSortingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4212,7 +4212,7 @@ export function GET() {
 			},
 			RuleWithValidAriaRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",

--- a/src/pages/schemas/2.0.0-beta/schema.json.js
+++ b/src/pages/schemas/2.0.0-beta/schema.json.js
@@ -3515,7 +3515,7 @@ export function GET() {
 			RuleAssistPlainConfiguration: { type: "string", enum: ["off", "on"] },
 			RuleAssistWithOptions_for_Null: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3527,7 +3527,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_Options: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3629,7 +3629,7 @@ export function GET() {
 			},
 			RuleWithAllowDomainOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3648,7 +3648,7 @@ export function GET() {
 			},
 			RuleWithComplexityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3663,7 +3663,7 @@ export function GET() {
 			},
 			RuleWithConsistentArrayTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3682,7 +3682,7 @@ export function GET() {
 			},
 			RuleWithConsistentMemberAccessibilityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3699,7 +3699,7 @@ export function GET() {
 			},
 			RuleWithDeprecatedHooksOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3714,7 +3714,7 @@ export function GET() {
 			},
 			RuleWithFilenamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3744,7 +3744,7 @@ export function GET() {
 			},
 			RuleWithNamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3763,7 +3763,7 @@ export function GET() {
 			},
 			RuleWithNoBitwiseOperatorsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3778,7 +3778,7 @@ export function GET() {
 			},
 			RuleWithNoConfusingLabelsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3793,7 +3793,7 @@ export function GET() {
 			},
 			RuleWithNoConsoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3812,7 +3812,7 @@ export function GET() {
 			},
 			RuleWithNoDoubleEqualsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3831,7 +3831,7 @@ export function GET() {
 			},
 			RuleWithNoForEachOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3846,7 +3846,7 @@ export function GET() {
 			},
 			RuleWithNoLabelWithoutControlOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3872,7 +3872,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3891,7 +3891,7 @@ export function GET() {
 			},
 			RuleWithNoSecretsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3906,7 +3906,7 @@ export function GET() {
 			},
 			RuleWithNoUndeclaredDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3921,7 +3921,7 @@ export function GET() {
 			},
 			RuleWithRestrictedGlobalsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3936,7 +3936,7 @@ export function GET() {
 			},
 			RuleWithRestrictedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3951,7 +3951,7 @@ export function GET() {
 			},
 			RuleWithUndeclaredVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3966,7 +3966,7 @@ export function GET() {
 			},
 			RuleWithUseComponentExportOnlyModulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3983,7 +3983,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentObjectDefinitionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4000,7 +4000,7 @@ export function GET() {
 			},
 			RuleWithUseExhaustiveDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4015,7 +4015,7 @@ export function GET() {
 			},
 			RuleWithUseImportExtensionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4034,7 +4034,7 @@ export function GET() {
 			},
 			RuleWithUseSelfClosingElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4053,7 +4053,7 @@ export function GET() {
 			},
 			RuleWithUseValidAutocompleteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4068,7 +4068,7 @@ export function GET() {
 			},
 			RuleWithUtilityClassSortingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4087,7 +4087,7 @@ export function GET() {
 			},
 			RuleWithValidAriaRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",

--- a/src/pages/schemas/2.0.0/schema.json.js
+++ b/src/pages/schemas/2.0.0/schema.json.js
@@ -3595,7 +3595,7 @@ export function GET() {
 			RuleAssistPlainConfiguration: { type: "string", enum: ["off", "on"] },
 			RuleAssistWithOptions_for_Null: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3607,7 +3607,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_Options: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3720,7 +3720,7 @@ export function GET() {
 			},
 			RuleWithComplexityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3735,7 +3735,7 @@ export function GET() {
 			},
 			RuleWithConsistentArrayTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3754,7 +3754,7 @@ export function GET() {
 			},
 			RuleWithConsistentMemberAccessibilityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3771,7 +3771,7 @@ export function GET() {
 			},
 			RuleWithDeprecatedHooksOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3786,7 +3786,7 @@ export function GET() {
 			},
 			RuleWithFilenamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3816,7 +3816,7 @@ export function GET() {
 			},
 			RuleWithImportTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3835,7 +3835,7 @@ export function GET() {
 			},
 			RuleWithNamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3854,7 +3854,7 @@ export function GET() {
 			},
 			RuleWithNoBitwiseOperatorsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3869,7 +3869,7 @@ export function GET() {
 			},
 			RuleWithNoBlankTargetOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3888,7 +3888,7 @@ export function GET() {
 			},
 			RuleWithNoConfusingLabelsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3903,7 +3903,7 @@ export function GET() {
 			},
 			RuleWithNoConsoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3922,7 +3922,7 @@ export function GET() {
 			},
 			RuleWithNoDoubleEqualsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3941,7 +3941,7 @@ export function GET() {
 			},
 			RuleWithNoForEachOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3956,7 +3956,7 @@ export function GET() {
 			},
 			RuleWithNoLabelWithoutControlOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3982,7 +3982,7 @@ export function GET() {
 			},
 			RuleWithNoParameterAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3997,7 +3997,7 @@ export function GET() {
 			},
 			RuleWithNoPrivateImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4012,7 +4012,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4027,7 +4027,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4046,7 +4046,7 @@ export function GET() {
 			},
 			RuleWithNoSecretsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4061,7 +4061,7 @@ export function GET() {
 			},
 			RuleWithNoUndeclaredDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4076,7 +4076,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4095,7 +4095,7 @@ export function GET() {
 			},
 			RuleWithRestrictedGlobalsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4110,7 +4110,7 @@ export function GET() {
 			},
 			RuleWithRestrictedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4125,7 +4125,7 @@ export function GET() {
 			},
 			RuleWithUndeclaredVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4140,7 +4140,7 @@ export function GET() {
 			},
 			RuleWithUseComponentExportOnlyModulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4157,7 +4157,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentObjectDefinitionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4178,7 +4178,7 @@ export function GET() {
 			},
 			RuleWithUseExhaustiveDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4197,7 +4197,7 @@ export function GET() {
 			},
 			RuleWithUseImportExtensionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4216,7 +4216,7 @@ export function GET() {
 			},
 			RuleWithUseJsxKeyInIterableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4231,7 +4231,7 @@ export function GET() {
 			},
 			RuleWithUseSelfClosingElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4250,7 +4250,7 @@ export function GET() {
 			},
 			RuleWithUseValidAutocompleteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4265,7 +4265,7 @@ export function GET() {
 			},
 			RuleWithUtilityClassSortingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4284,7 +4284,7 @@ export function GET() {
 			},
 			RuleWithValidAriaRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",

--- a/src/pages/schemas/2.0.2/schema.json.js
+++ b/src/pages/schemas/2.0.2/schema.json.js
@@ -3595,7 +3595,7 @@ export function GET() {
 			RuleAssistPlainConfiguration: { type: "string", enum: ["off", "on"] },
 			RuleAssistWithOptions_for_Null: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3607,7 +3607,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_Options: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3720,7 +3720,7 @@ export function GET() {
 			},
 			RuleWithComplexityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3735,7 +3735,7 @@ export function GET() {
 			},
 			RuleWithConsistentArrayTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3754,7 +3754,7 @@ export function GET() {
 			},
 			RuleWithConsistentMemberAccessibilityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3771,7 +3771,7 @@ export function GET() {
 			},
 			RuleWithDeprecatedHooksOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3786,7 +3786,7 @@ export function GET() {
 			},
 			RuleWithFilenamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3816,7 +3816,7 @@ export function GET() {
 			},
 			RuleWithImportTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3835,7 +3835,7 @@ export function GET() {
 			},
 			RuleWithNamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3854,7 +3854,7 @@ export function GET() {
 			},
 			RuleWithNoBitwiseOperatorsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3869,7 +3869,7 @@ export function GET() {
 			},
 			RuleWithNoBlankTargetOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3888,7 +3888,7 @@ export function GET() {
 			},
 			RuleWithNoConfusingLabelsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3903,7 +3903,7 @@ export function GET() {
 			},
 			RuleWithNoConsoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3922,7 +3922,7 @@ export function GET() {
 			},
 			RuleWithNoDoubleEqualsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3941,7 +3941,7 @@ export function GET() {
 			},
 			RuleWithNoForEachOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3956,7 +3956,7 @@ export function GET() {
 			},
 			RuleWithNoLabelWithoutControlOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3982,7 +3982,7 @@ export function GET() {
 			},
 			RuleWithNoParameterAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3997,7 +3997,7 @@ export function GET() {
 			},
 			RuleWithNoPrivateImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4012,7 +4012,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4027,7 +4027,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4046,7 +4046,7 @@ export function GET() {
 			},
 			RuleWithNoSecretsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4061,7 +4061,7 @@ export function GET() {
 			},
 			RuleWithNoUndeclaredDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4076,7 +4076,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4095,7 +4095,7 @@ export function GET() {
 			},
 			RuleWithRestrictedGlobalsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4110,7 +4110,7 @@ export function GET() {
 			},
 			RuleWithRestrictedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4125,7 +4125,7 @@ export function GET() {
 			},
 			RuleWithUndeclaredVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4140,7 +4140,7 @@ export function GET() {
 			},
 			RuleWithUseComponentExportOnlyModulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4157,7 +4157,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentObjectDefinitionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4178,7 +4178,7 @@ export function GET() {
 			},
 			RuleWithUseExhaustiveDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4197,7 +4197,7 @@ export function GET() {
 			},
 			RuleWithUseImportExtensionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4216,7 +4216,7 @@ export function GET() {
 			},
 			RuleWithUseJsxKeyInIterableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4231,7 +4231,7 @@ export function GET() {
 			},
 			RuleWithUseSelfClosingElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4250,7 +4250,7 @@ export function GET() {
 			},
 			RuleWithUseValidAutocompleteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4265,7 +4265,7 @@ export function GET() {
 			},
 			RuleWithUtilityClassSortingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4284,7 +4284,7 @@ export function GET() {
 			},
 			RuleWithValidAriaRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",

--- a/src/pages/schemas/2.0.4/schema.json.js
+++ b/src/pages/schemas/2.0.4/schema.json.js
@@ -3621,7 +3621,7 @@ export function GET() {
 			RuleAssistPlainConfiguration: { type: "string", enum: ["off", "on"] },
 			RuleAssistWithOptions_for_Null: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3633,7 +3633,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_Options: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3746,7 +3746,7 @@ export function GET() {
 			},
 			RuleWithComplexityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3761,7 +3761,7 @@ export function GET() {
 			},
 			RuleWithConsistentArrayTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3780,7 +3780,7 @@ export function GET() {
 			},
 			RuleWithConsistentMemberAccessibilityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3797,7 +3797,7 @@ export function GET() {
 			},
 			RuleWithDeprecatedHooksOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3812,7 +3812,7 @@ export function GET() {
 			},
 			RuleWithFilenamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3842,7 +3842,7 @@ export function GET() {
 			},
 			RuleWithImportTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3861,7 +3861,7 @@ export function GET() {
 			},
 			RuleWithNamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3880,7 +3880,7 @@ export function GET() {
 			},
 			RuleWithNoBitwiseOperatorsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3895,7 +3895,7 @@ export function GET() {
 			},
 			RuleWithNoBlankTargetOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3914,7 +3914,7 @@ export function GET() {
 			},
 			RuleWithNoConfusingLabelsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3929,7 +3929,7 @@ export function GET() {
 			},
 			RuleWithNoConsoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3948,7 +3948,7 @@ export function GET() {
 			},
 			RuleWithNoDoubleEqualsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3967,7 +3967,7 @@ export function GET() {
 			},
 			RuleWithNoForEachOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3982,7 +3982,7 @@ export function GET() {
 			},
 			RuleWithNoLabelWithoutControlOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4008,7 +4008,7 @@ export function GET() {
 			},
 			RuleWithNoParameterAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4023,7 +4023,7 @@ export function GET() {
 			},
 			RuleWithNoPrivateImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4038,7 +4038,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4053,7 +4053,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4072,7 +4072,7 @@ export function GET() {
 			},
 			RuleWithNoSecretsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4087,7 +4087,7 @@ export function GET() {
 			},
 			RuleWithNoUndeclaredDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4102,7 +4102,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4121,7 +4121,7 @@ export function GET() {
 			},
 			RuleWithReadonlyClassPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4140,7 +4140,7 @@ export function GET() {
 			},
 			RuleWithRestrictedGlobalsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4155,7 +4155,7 @@ export function GET() {
 			},
 			RuleWithRestrictedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4170,7 +4170,7 @@ export function GET() {
 			},
 			RuleWithUndeclaredVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4185,7 +4185,7 @@ export function GET() {
 			},
 			RuleWithUseComponentExportOnlyModulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4202,7 +4202,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentObjectDefinitionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4223,7 +4223,7 @@ export function GET() {
 			},
 			RuleWithUseExhaustiveDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4242,7 +4242,7 @@ export function GET() {
 			},
 			RuleWithUseImportExtensionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4261,7 +4261,7 @@ export function GET() {
 			},
 			RuleWithUseJsxKeyInIterableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4276,7 +4276,7 @@ export function GET() {
 			},
 			RuleWithUseSelfClosingElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4295,7 +4295,7 @@ export function GET() {
 			},
 			RuleWithUseValidAutocompleteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4310,7 +4310,7 @@ export function GET() {
 			},
 			RuleWithUtilityClassSortingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4329,7 +4329,7 @@ export function GET() {
 			},
 			RuleWithValidAriaRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",

--- a/src/pages/schemas/2.0.5/schema.json.js
+++ b/src/pages/schemas/2.0.5/schema.json.js
@@ -3621,7 +3621,7 @@ export function GET() {
 			RuleAssistPlainConfiguration: { type: "string", enum: ["off", "on"] },
 			RuleAssistWithOptions_for_Null: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3633,7 +3633,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_Options: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3746,7 +3746,7 @@ export function GET() {
 			},
 			RuleWithComplexityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3761,7 +3761,7 @@ export function GET() {
 			},
 			RuleWithConsistentArrayTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3780,7 +3780,7 @@ export function GET() {
 			},
 			RuleWithConsistentMemberAccessibilityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3797,7 +3797,7 @@ export function GET() {
 			},
 			RuleWithDeprecatedHooksOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3812,7 +3812,7 @@ export function GET() {
 			},
 			RuleWithFilenamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3842,7 +3842,7 @@ export function GET() {
 			},
 			RuleWithImportTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3861,7 +3861,7 @@ export function GET() {
 			},
 			RuleWithNamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3880,7 +3880,7 @@ export function GET() {
 			},
 			RuleWithNoBitwiseOperatorsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3895,7 +3895,7 @@ export function GET() {
 			},
 			RuleWithNoBlankTargetOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3914,7 +3914,7 @@ export function GET() {
 			},
 			RuleWithNoConfusingLabelsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3929,7 +3929,7 @@ export function GET() {
 			},
 			RuleWithNoConsoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3948,7 +3948,7 @@ export function GET() {
 			},
 			RuleWithNoDoubleEqualsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3967,7 +3967,7 @@ export function GET() {
 			},
 			RuleWithNoForEachOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3982,7 +3982,7 @@ export function GET() {
 			},
 			RuleWithNoLabelWithoutControlOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4008,7 +4008,7 @@ export function GET() {
 			},
 			RuleWithNoParameterAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4023,7 +4023,7 @@ export function GET() {
 			},
 			RuleWithNoPrivateImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4038,7 +4038,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4053,7 +4053,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4072,7 +4072,7 @@ export function GET() {
 			},
 			RuleWithNoSecretsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4087,7 +4087,7 @@ export function GET() {
 			},
 			RuleWithNoUndeclaredDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4102,7 +4102,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4121,7 +4121,7 @@ export function GET() {
 			},
 			RuleWithReadonlyClassPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4140,7 +4140,7 @@ export function GET() {
 			},
 			RuleWithRestrictedGlobalsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4155,7 +4155,7 @@ export function GET() {
 			},
 			RuleWithRestrictedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4170,7 +4170,7 @@ export function GET() {
 			},
 			RuleWithUndeclaredVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4185,7 +4185,7 @@ export function GET() {
 			},
 			RuleWithUseComponentExportOnlyModulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4202,7 +4202,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentObjectDefinitionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4223,7 +4223,7 @@ export function GET() {
 			},
 			RuleWithUseExhaustiveDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4242,7 +4242,7 @@ export function GET() {
 			},
 			RuleWithUseImportExtensionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4261,7 +4261,7 @@ export function GET() {
 			},
 			RuleWithUseJsxKeyInIterableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4276,7 +4276,7 @@ export function GET() {
 			},
 			RuleWithUseSelfClosingElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4295,7 +4295,7 @@ export function GET() {
 			},
 			RuleWithUseValidAutocompleteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4310,7 +4310,7 @@ export function GET() {
 			},
 			RuleWithUtilityClassSortingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4329,7 +4329,7 @@ export function GET() {
 			},
 			RuleWithValidAriaRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",

--- a/src/pages/schemas/2.0.6/schema.json.js
+++ b/src/pages/schemas/2.0.6/schema.json.js
@@ -3685,7 +3685,7 @@ export function GET() {
 			RuleAssistPlainConfiguration: { type: "string", enum: ["off", "on"] },
 			RuleAssistWithOptions_for_Null: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3697,7 +3697,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_Options: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3810,7 +3810,7 @@ export function GET() {
 			},
 			RuleWithComplexityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3825,7 +3825,7 @@ export function GET() {
 			},
 			RuleWithConsistentArrayTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3844,7 +3844,7 @@ export function GET() {
 			},
 			RuleWithConsistentMemberAccessibilityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3861,7 +3861,7 @@ export function GET() {
 			},
 			RuleWithDeprecatedHooksOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3876,7 +3876,7 @@ export function GET() {
 			},
 			RuleWithFilenamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3906,7 +3906,7 @@ export function GET() {
 			},
 			RuleWithImportTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3925,7 +3925,7 @@ export function GET() {
 			},
 			RuleWithNamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3944,7 +3944,7 @@ export function GET() {
 			},
 			RuleWithNoBitwiseOperatorsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3959,7 +3959,7 @@ export function GET() {
 			},
 			RuleWithNoBlankTargetOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -3978,7 +3978,7 @@ export function GET() {
 			},
 			RuleWithNoConfusingLabelsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -3993,7 +3993,7 @@ export function GET() {
 			},
 			RuleWithNoConsoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4012,7 +4012,7 @@ export function GET() {
 			},
 			RuleWithNoDoubleEqualsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4031,7 +4031,7 @@ export function GET() {
 			},
 			RuleWithNoExcessiveLinesPerFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4048,7 +4048,7 @@ export function GET() {
 			},
 			RuleWithNoForEachOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4063,7 +4063,7 @@ export function GET() {
 			},
 			RuleWithNoLabelWithoutControlOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4089,7 +4089,7 @@ export function GET() {
 			},
 			RuleWithNoParameterAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4104,7 +4104,7 @@ export function GET() {
 			},
 			RuleWithNoPrivateImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4119,7 +4119,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4134,7 +4134,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4153,7 +4153,7 @@ export function GET() {
 			},
 			RuleWithNoSecretsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4168,7 +4168,7 @@ export function GET() {
 			},
 			RuleWithNoUndeclaredDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4183,7 +4183,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4202,7 +4202,7 @@ export function GET() {
 			},
 			RuleWithReadonlyClassPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4221,7 +4221,7 @@ export function GET() {
 			},
 			RuleWithRestrictedGlobalsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4236,7 +4236,7 @@ export function GET() {
 			},
 			RuleWithRestrictedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4251,7 +4251,7 @@ export function GET() {
 			},
 			RuleWithUndeclaredVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4266,7 +4266,7 @@ export function GET() {
 			},
 			RuleWithUseComponentExportOnlyModulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4283,7 +4283,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentObjectDefinitionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4304,7 +4304,7 @@ export function GET() {
 			},
 			RuleWithUseExhaustiveDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4323,7 +4323,7 @@ export function GET() {
 			},
 			RuleWithUseImportExtensionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4342,7 +4342,7 @@ export function GET() {
 			},
 			RuleWithUseJsxKeyInIterableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4357,7 +4357,7 @@ export function GET() {
 			},
 			RuleWithUseSelfClosingElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4376,7 +4376,7 @@ export function GET() {
 			},
 			RuleWithUseValidAutocompleteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -4391,7 +4391,7 @@ export function GET() {
 			},
 			RuleWithUtilityClassSortingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -4410,7 +4410,7 @@ export function GET() {
 			},
 			RuleWithValidAriaRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",

--- a/src/pages/schemas/2.1.0/schema.json.js
+++ b/src/pages/schemas/2.1.0/schema.json.js
@@ -5594,7 +5594,7 @@ export function GET() {
 			RuleAssistPlainConfiguration: { type: "string", enum: ["off", "on"] },
 			RuleAssistWithOptions_for_OrganizeImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5609,7 +5609,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_UseSortedAttributesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5624,7 +5624,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_UseSortedKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5639,7 +5639,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_UseSortedPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5740,7 +5740,7 @@ export function GET() {
 			},
 			RuleWithNoAccessKeyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -5759,7 +5759,7 @@ export function GET() {
 			},
 			RuleWithNoAccumulatingSpreadOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5774,7 +5774,7 @@ export function GET() {
 			},
 			RuleWithNoAdjacentSpacesInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -5793,7 +5793,7 @@ export function GET() {
 			},
 			RuleWithNoAlertOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5808,7 +5808,7 @@ export function GET() {
 			},
 			RuleWithNoApproximativeNumericConstantOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -5829,7 +5829,7 @@ export function GET() {
 			},
 			RuleWithNoArgumentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5844,7 +5844,7 @@ export function GET() {
 			},
 			RuleWithNoAriaHiddenOnFocusableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -5863,7 +5863,7 @@ export function GET() {
 			},
 			RuleWithNoAriaUnsupportedElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -5882,7 +5882,7 @@ export function GET() {
 			},
 			RuleWithNoArrayIndexKeyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5897,7 +5897,7 @@ export function GET() {
 			},
 			RuleWithNoAssignInExpressionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5912,7 +5912,7 @@ export function GET() {
 			},
 			RuleWithNoAsyncPromiseExecutorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5927,7 +5927,7 @@ export function GET() {
 			},
 			RuleWithNoAutofocusOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -5946,7 +5946,7 @@ export function GET() {
 			},
 			RuleWithNoAwaitInLoopOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5961,7 +5961,7 @@ export function GET() {
 			},
 			RuleWithNoBannedTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -5980,7 +5980,7 @@ export function GET() {
 			},
 			RuleWithNoBarrelFileOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5995,7 +5995,7 @@ export function GET() {
 			},
 			RuleWithNoBitwiseOperatorsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6010,7 +6010,7 @@ export function GET() {
 			},
 			RuleWithNoBlankTargetOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6029,7 +6029,7 @@ export function GET() {
 			},
 			RuleWithNoCatchAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6044,7 +6044,7 @@ export function GET() {
 			},
 			RuleWithNoChildrenPropOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6059,7 +6059,7 @@ export function GET() {
 			},
 			RuleWithNoClassAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6074,7 +6074,7 @@ export function GET() {
 			},
 			RuleWithNoCommaOperatorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6089,7 +6089,7 @@ export function GET() {
 			},
 			RuleWithNoCommentTextOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6108,7 +6108,7 @@ export function GET() {
 			},
 			RuleWithNoCommonJsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6123,7 +6123,7 @@ export function GET() {
 			},
 			RuleWithNoCompareNegZeroOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6142,7 +6142,7 @@ export function GET() {
 			},
 			RuleWithNoConfusingLabelsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6157,7 +6157,7 @@ export function GET() {
 			},
 			RuleWithNoConfusingVoidTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6176,7 +6176,7 @@ export function GET() {
 			},
 			RuleWithNoConsoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6195,7 +6195,7 @@ export function GET() {
 			},
 			RuleWithNoConstAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6214,7 +6214,7 @@ export function GET() {
 			},
 			RuleWithNoConstEnumOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6233,7 +6233,7 @@ export function GET() {
 			},
 			RuleWithNoConstantBinaryExpressionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6250,7 +6250,7 @@ export function GET() {
 			},
 			RuleWithNoConstantConditionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6265,7 +6265,7 @@ export function GET() {
 			},
 			RuleWithNoConstantMathMinMaxClampOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6284,7 +6284,7 @@ export function GET() {
 			},
 			RuleWithNoConstructorReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6299,7 +6299,7 @@ export function GET() {
 			},
 			RuleWithNoControlCharactersInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6316,7 +6316,7 @@ export function GET() {
 			},
 			RuleWithNoDangerouslySetInnerHtmlOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6331,7 +6331,7 @@ export function GET() {
 			},
 			RuleWithNoDangerouslySetInnerHtmlWithChildrenOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6350,7 +6350,7 @@ export function GET() {
 			},
 			RuleWithNoDebuggerOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6369,7 +6369,7 @@ export function GET() {
 			},
 			RuleWithNoDefaultExportOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6384,7 +6384,7 @@ export function GET() {
 			},
 			RuleWithNoDeleteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6403,7 +6403,7 @@ export function GET() {
 			},
 			RuleWithNoDescendingSpecificityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6418,7 +6418,7 @@ export function GET() {
 			},
 			RuleWithNoDestructuredPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6433,7 +6433,7 @@ export function GET() {
 			},
 			RuleWithNoDistractingElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6452,7 +6452,7 @@ export function GET() {
 			},
 			RuleWithNoDocumentCookieOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6467,7 +6467,7 @@ export function GET() {
 			},
 			RuleWithNoDocumentImportInPageOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6482,7 +6482,7 @@ export function GET() {
 			},
 			RuleWithNoDoneCallbackOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6497,7 +6497,7 @@ export function GET() {
 			},
 			RuleWithNoDoubleEqualsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6516,7 +6516,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateAtImportRulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6531,7 +6531,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateCaseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6546,7 +6546,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateClassMembersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6561,7 +6561,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateCustomPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6578,7 +6578,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateElseIfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6593,7 +6593,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateFieldsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6608,7 +6608,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateFontNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6623,7 +6623,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateJsxPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6638,7 +6638,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateObjectKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6653,7 +6653,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateParametersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6668,7 +6668,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicatePropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6683,7 +6683,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateSelectorsKeyframeBlockOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6702,7 +6702,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateTestHooksOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6717,7 +6717,7 @@ export function GET() {
 			},
 			RuleWithNoDynamicNamespaceImportAccessOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6734,7 +6734,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyBlockOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6749,7 +6749,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyBlockStatementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6764,7 +6764,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyCharacterClassInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6781,7 +6781,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyInterfaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6800,7 +6800,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyPatternOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6815,7 +6815,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyTypeParametersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6830,7 +6830,7 @@ export function GET() {
 			},
 			RuleWithNoEnumOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6845,7 +6845,7 @@ export function GET() {
 			},
 			RuleWithNoEvolvingTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6860,7 +6860,7 @@ export function GET() {
 			},
 			RuleWithNoExcessiveCognitiveComplexityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6877,7 +6877,7 @@ export function GET() {
 			},
 			RuleWithNoExcessiveLinesPerFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6894,7 +6894,7 @@ export function GET() {
 			},
 			RuleWithNoExcessiveNestedTestSuitesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6911,7 +6911,7 @@ export function GET() {
 			},
 			RuleWithNoExplicitAnyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6926,7 +6926,7 @@ export function GET() {
 			},
 			RuleWithNoExportedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6941,7 +6941,7 @@ export function GET() {
 			},
 			RuleWithNoExportsInTestOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6956,7 +6956,7 @@ export function GET() {
 			},
 			RuleWithNoExtraBooleanCastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6975,7 +6975,7 @@ export function GET() {
 			},
 			RuleWithNoExtraNonNullAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6994,7 +6994,7 @@ export function GET() {
 			},
 			RuleWithNoFallthroughSwitchClauseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7009,7 +7009,7 @@ export function GET() {
 			},
 			RuleWithNoFlatMapIdentityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7028,7 +7028,7 @@ export function GET() {
 			},
 			RuleWithNoFloatingPromisesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7047,7 +7047,7 @@ export function GET() {
 			},
 			RuleWithNoFocusedTestsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7066,7 +7066,7 @@ export function GET() {
 			},
 			RuleWithNoForEachOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7081,7 +7081,7 @@ export function GET() {
 			},
 			RuleWithNoFunctionAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7096,7 +7096,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7111,7 +7111,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalDirnameFilenameOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7130,7 +7130,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalEvalOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7145,7 +7145,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalIsFiniteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7164,7 +7164,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalIsNanOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7183,7 +7183,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalObjectCallsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7198,7 +7198,7 @@ export function GET() {
 			},
 			RuleWithNoHeadElementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7213,7 +7213,7 @@ export function GET() {
 			},
 			RuleWithNoHeadImportInDocumentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7228,7 +7228,7 @@ export function GET() {
 			},
 			RuleWithNoHeaderScopeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7247,7 +7247,7 @@ export function GET() {
 			},
 			RuleWithNoImgElementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7262,7 +7262,7 @@ export function GET() {
 			},
 			RuleWithNoImplicitAnyLetOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7277,7 +7277,7 @@ export function GET() {
 			},
 			RuleWithNoImplicitBooleanOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7296,7 +7296,7 @@ export function GET() {
 			},
 			RuleWithNoImplicitCoercionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7315,7 +7315,7 @@ export function GET() {
 			},
 			RuleWithNoImportAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7330,7 +7330,7 @@ export function GET() {
 			},
 			RuleWithNoImportCyclesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7345,7 +7345,7 @@ export function GET() {
 			},
 			RuleWithNoImportantInKeyframeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7360,7 +7360,7 @@ export function GET() {
 			},
 			RuleWithNoImportantStylesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7379,7 +7379,7 @@ export function GET() {
 			},
 			RuleWithNoInferrableTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7398,7 +7398,7 @@ export function GET() {
 			},
 			RuleWithNoInnerDeclarationsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7413,7 +7413,7 @@ export function GET() {
 			},
 			RuleWithNoInteractiveElementToNoninteractiveRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7436,7 +7436,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidBuiltinInstantiationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7457,7 +7457,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidConstructorSuperOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7472,7 +7472,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidDirectionInLinearGradientOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7491,7 +7491,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidGridAreasOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7506,7 +7506,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidPositionAtImportRuleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7523,7 +7523,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidUseBeforeDeclarationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7540,7 +7540,7 @@ export function GET() {
 			},
 			RuleWithNoIrregularWhitespaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7555,7 +7555,7 @@ export function GET() {
 			},
 			RuleWithNoLabelVarOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7570,7 +7570,7 @@ export function GET() {
 			},
 			RuleWithNoLabelWithoutControlOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7585,7 +7585,7 @@ export function GET() {
 			},
 			RuleWithNoMagicNumbersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7600,7 +7600,7 @@ export function GET() {
 			},
 			RuleWithNoMisleadingCharacterClassOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7621,7 +7621,7 @@ export function GET() {
 			},
 			RuleWithNoMisleadingInstantiatorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7636,7 +7636,7 @@ export function GET() {
 			},
 			RuleWithNoMisplacedAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7651,7 +7651,7 @@ export function GET() {
 			},
 			RuleWithNoMisrefactoredShorthandAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7672,7 +7672,7 @@ export function GET() {
 			},
 			RuleWithNoMissingVarFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7687,7 +7687,7 @@ export function GET() {
 			},
 			RuleWithNoMisusedPromisesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7706,7 +7706,7 @@ export function GET() {
 			},
 			RuleWithNoNamespaceImportOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7721,7 +7721,7 @@ export function GET() {
 			},
 			RuleWithNoNamespaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7736,7 +7736,7 @@ export function GET() {
 			},
 			RuleWithNoNegationElseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7755,7 +7755,7 @@ export function GET() {
 			},
 			RuleWithNoNestedComponentDefinitionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7772,7 +7772,7 @@ export function GET() {
 			},
 			RuleWithNoNestedTernaryOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7787,7 +7787,7 @@ export function GET() {
 			},
 			RuleWithNoNodejsModulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7802,7 +7802,7 @@ export function GET() {
 			},
 			RuleWithNoNonNullAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7821,7 +7821,7 @@ export function GET() {
 			},
 			RuleWithNoNoninteractiveElementInteractionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7840,7 +7840,7 @@ export function GET() {
 			},
 			RuleWithNoNoninteractiveElementToInteractiveRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7863,7 +7863,7 @@ export function GET() {
 			},
 			RuleWithNoNoninteractiveTabindexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7882,7 +7882,7 @@ export function GET() {
 			},
 			RuleWithNoNonoctalDecimalEscapeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7901,7 +7901,7 @@ export function GET() {
 			},
 			RuleWithNoOctalEscapeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7920,7 +7920,7 @@ export function GET() {
 			},
 			RuleWithNoParameterAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7935,7 +7935,7 @@ export function GET() {
 			},
 			RuleWithNoParameterPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7950,7 +7950,7 @@ export function GET() {
 			},
 			RuleWithNoPositiveTabindexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7969,7 +7969,7 @@ export function GET() {
 			},
 			RuleWithNoPrecisionLossOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7984,7 +7984,7 @@ export function GET() {
 			},
 			RuleWithNoPrivateImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7999,7 +7999,7 @@ export function GET() {
 			},
 			RuleWithNoProcessEnvOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8014,7 +8014,7 @@ export function GET() {
 			},
 			RuleWithNoProcessGlobalOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8033,7 +8033,7 @@ export function GET() {
 			},
 			RuleWithNoPrototypeBuiltinsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8052,7 +8052,7 @@ export function GET() {
 			},
 			RuleWithNoReExportAllOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8067,7 +8067,7 @@ export function GET() {
 			},
 			RuleWithNoReactPropAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8082,7 +8082,7 @@ export function GET() {
 			},
 			RuleWithNoReactSpecificPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8101,7 +8101,7 @@ export function GET() {
 			},
 			RuleWithNoRedeclareOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8116,7 +8116,7 @@ export function GET() {
 			},
 			RuleWithNoRedundantAltOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8131,7 +8131,7 @@ export function GET() {
 			},
 			RuleWithNoRedundantRolesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8150,7 +8150,7 @@ export function GET() {
 			},
 			RuleWithNoRedundantUseStrictOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8169,7 +8169,7 @@ export function GET() {
 			},
 			RuleWithNoRenderReturnValueOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8184,7 +8184,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8199,7 +8199,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedGlobalsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8214,7 +8214,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8229,7 +8229,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8248,7 +8248,7 @@ export function GET() {
 			},
 			RuleWithNoSecretsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8263,7 +8263,7 @@ export function GET() {
 			},
 			RuleWithNoSelfAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8278,7 +8278,7 @@ export function GET() {
 			},
 			RuleWithNoSelfCompareOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8293,7 +8293,7 @@ export function GET() {
 			},
 			RuleWithNoSetterReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8308,7 +8308,7 @@ export function GET() {
 			},
 			RuleWithNoShadowOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8323,7 +8323,7 @@ export function GET() {
 			},
 			RuleWithNoShadowRestrictedNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8338,7 +8338,7 @@ export function GET() {
 			},
 			RuleWithNoShorthandPropertyOverridesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8355,7 +8355,7 @@ export function GET() {
 			},
 			RuleWithNoShoutyConstantsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8374,7 +8374,7 @@ export function GET() {
 			},
 			RuleWithNoSkippedTestsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8393,7 +8393,7 @@ export function GET() {
 			},
 			RuleWithNoSparseArrayOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8412,7 +8412,7 @@ export function GET() {
 			},
 			RuleWithNoStaticElementInteractionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8429,7 +8429,7 @@ export function GET() {
 			},
 			RuleWithNoStaticOnlyClassOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8444,7 +8444,7 @@ export function GET() {
 			},
 			RuleWithNoStringCaseMismatchOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8463,7 +8463,7 @@ export function GET() {
 			},
 			RuleWithNoSubstrOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8482,7 +8482,7 @@ export function GET() {
 			},
 			RuleWithNoSuspiciousSemicolonInJsxOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8499,7 +8499,7 @@ export function GET() {
 			},
 			RuleWithNoSvgWithoutTitleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8514,7 +8514,7 @@ export function GET() {
 			},
 			RuleWithNoSwitchDeclarationsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8533,7 +8533,7 @@ export function GET() {
 			},
 			RuleWithNoTemplateCurlyInStringOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8548,7 +8548,7 @@ export function GET() {
 			},
 			RuleWithNoThenPropertyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8563,7 +8563,7 @@ export function GET() {
 			},
 			RuleWithNoThisInStaticOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8582,7 +8582,7 @@ export function GET() {
 			},
 			RuleWithNoTsIgnoreOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8601,7 +8601,7 @@ export function GET() {
 			},
 			RuleWithNoUnassignedVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8616,7 +8616,7 @@ export function GET() {
 			},
 			RuleWithNoUndeclaredDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8631,7 +8631,7 @@ export function GET() {
 			},
 			RuleWithNoUndeclaredVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8646,7 +8646,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownAtRuleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8661,7 +8661,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8676,7 +8676,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownMediaFeatureNameOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8691,7 +8691,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownPropertyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8706,7 +8706,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownPseudoClassOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8721,7 +8721,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownPseudoElementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8736,7 +8736,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownTypeSelectorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8751,7 +8751,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownUnitOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8766,7 +8766,7 @@ export function GET() {
 			},
 			RuleWithNoUnmatchableAnbSelectorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8781,7 +8781,7 @@ export function GET() {
 			},
 			RuleWithNoUnreachableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8796,7 +8796,7 @@ export function GET() {
 			},
 			RuleWithNoUnreachableSuperOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8811,7 +8811,7 @@ export function GET() {
 			},
 			RuleWithNoUnresolvedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8826,7 +8826,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeDeclarationMergingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8843,7 +8843,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeFinallyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8858,7 +8858,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeNegationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8877,7 +8877,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeOptionalChainingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8892,7 +8892,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedFunctionParametersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8913,7 +8913,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8932,7 +8932,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedLabelsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8951,7 +8951,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedPrivateClassMembersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8972,7 +8972,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedTemplateLiteralOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8991,7 +8991,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9010,7 +9010,7 @@ export function GET() {
 			},
 			RuleWithNoUnwantedPolyfillioOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9025,7 +9025,7 @@ export function GET() {
 			},
 			RuleWithNoUselessBackrefInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9040,7 +9040,7 @@ export function GET() {
 			},
 			RuleWithNoUselessCatchOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9059,7 +9059,7 @@ export function GET() {
 			},
 			RuleWithNoUselessConstructorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9078,7 +9078,7 @@ export function GET() {
 			},
 			RuleWithNoUselessContinueOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9097,7 +9097,7 @@ export function GET() {
 			},
 			RuleWithNoUselessElseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9116,7 +9116,7 @@ export function GET() {
 			},
 			RuleWithNoUselessEmptyExportOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9135,7 +9135,7 @@ export function GET() {
 			},
 			RuleWithNoUselessEscapeInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9154,7 +9154,7 @@ export function GET() {
 			},
 			RuleWithNoUselessEscapeInStringOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9173,7 +9173,7 @@ export function GET() {
 			},
 			RuleWithNoUselessFragmentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9192,7 +9192,7 @@ export function GET() {
 			},
 			RuleWithNoUselessLabelOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9211,7 +9211,7 @@ export function GET() {
 			},
 			RuleWithNoUselessLoneBlockStatementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9232,7 +9232,7 @@ export function GET() {
 			},
 			RuleWithNoUselessRenameOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9251,7 +9251,7 @@ export function GET() {
 			},
 			RuleWithNoUselessStringConcatOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9270,7 +9270,7 @@ export function GET() {
 			},
 			RuleWithNoUselessStringRawOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9285,7 +9285,7 @@ export function GET() {
 			},
 			RuleWithNoUselessSwitchCaseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9304,7 +9304,7 @@ export function GET() {
 			},
 			RuleWithNoUselessTernaryOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9323,7 +9323,7 @@ export function GET() {
 			},
 			RuleWithNoUselessThisAliasOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9342,7 +9342,7 @@ export function GET() {
 			},
 			RuleWithNoUselessTypeConstraintOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9361,7 +9361,7 @@ export function GET() {
 			},
 			RuleWithNoUselessUndefinedInitializationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9382,7 +9382,7 @@ export function GET() {
 			},
 			RuleWithNoUselessUndefinedOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9401,7 +9401,7 @@ export function GET() {
 			},
 			RuleWithNoValueAtRuleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9416,7 +9416,7 @@ export function GET() {
 			},
 			RuleWithNoVarOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9435,7 +9435,7 @@ export function GET() {
 			},
 			RuleWithNoVoidElementsWithChildrenOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9456,7 +9456,7 @@ export function GET() {
 			},
 			RuleWithNoVoidOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9471,7 +9471,7 @@ export function GET() {
 			},
 			RuleWithNoVoidTypeReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9486,7 +9486,7 @@ export function GET() {
 			},
 			RuleWithNoWithOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9501,7 +9501,7 @@ export function GET() {
 			},
 			RuleWithNoYodaExpressionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9520,7 +9520,7 @@ export function GET() {
 			},
 			RuleWithUseAdjacentGetterSetterOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9535,7 +9535,7 @@ export function GET() {
 			},
 			RuleWithUseAdjacentOverloadSignaturesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9552,7 +9552,7 @@ export function GET() {
 			},
 			RuleWithUseAltTextOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9567,7 +9567,7 @@ export function GET() {
 			},
 			RuleWithUseAnchorContentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9586,7 +9586,7 @@ export function GET() {
 			},
 			RuleWithUseAriaActivedescendantWithTabindexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9609,7 +9609,7 @@ export function GET() {
 			},
 			RuleWithUseAriaPropsForRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9624,7 +9624,7 @@ export function GET() {
 			},
 			RuleWithUseAriaPropsSupportedByRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9641,7 +9641,7 @@ export function GET() {
 			},
 			RuleWithUseArrayLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9660,7 +9660,7 @@ export function GET() {
 			},
 			RuleWithUseArrowFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9679,7 +9679,7 @@ export function GET() {
 			},
 			RuleWithUseAsConstAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9698,7 +9698,7 @@ export function GET() {
 			},
 			RuleWithUseAtIndexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9717,7 +9717,7 @@ export function GET() {
 			},
 			RuleWithUseAwaitOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9732,7 +9732,7 @@ export function GET() {
 			},
 			RuleWithUseBlockStatementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9751,7 +9751,7 @@ export function GET() {
 			},
 			RuleWithUseButtonTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9766,7 +9766,7 @@ export function GET() {
 			},
 			RuleWithUseCollapsedElseIfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9785,7 +9785,7 @@ export function GET() {
 			},
 			RuleWithUseCollapsedIfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9804,7 +9804,7 @@ export function GET() {
 			},
 			RuleWithUseComponentExportOnlyModulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9821,7 +9821,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentArrayTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9840,7 +9840,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentBuiltinInstantiationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9863,7 +9863,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentCurlyBracesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9882,7 +9882,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentMemberAccessibilityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9899,7 +9899,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentObjectDefinitionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9920,7 +9920,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentResponseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9939,7 +9939,7 @@ export function GET() {
 			},
 			RuleWithUseConstOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9958,7 +9958,7 @@ export function GET() {
 			},
 			RuleWithUseDateNowOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9977,7 +9977,7 @@ export function GET() {
 			},
 			RuleWithUseDefaultParameterLastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9996,7 +9996,7 @@ export function GET() {
 			},
 			RuleWithUseDefaultSwitchClauseLastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10013,7 +10013,7 @@ export function GET() {
 			},
 			RuleWithUseDefaultSwitchClauseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10028,7 +10028,7 @@ export function GET() {
 			},
 			RuleWithUseDeprecatedReasonOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10043,7 +10043,7 @@ export function GET() {
 			},
 			RuleWithUseEnumInitializersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10062,7 +10062,7 @@ export function GET() {
 			},
 			RuleWithUseErrorMessageOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10077,7 +10077,7 @@ export function GET() {
 			},
 			RuleWithUseExhaustiveDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10096,7 +10096,7 @@ export function GET() {
 			},
 			RuleWithUseExhaustiveSwitchCasesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10115,7 +10115,7 @@ export function GET() {
 			},
 			RuleWithUseExplicitLengthCheckOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10134,7 +10134,7 @@ export function GET() {
 			},
 			RuleWithUseExplicitTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10149,7 +10149,7 @@ export function GET() {
 			},
 			RuleWithUseExponentiationOperatorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10168,7 +10168,7 @@ export function GET() {
 			},
 			RuleWithUseExportTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10187,7 +10187,7 @@ export function GET() {
 			},
 			RuleWithUseExportsLastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10202,7 +10202,7 @@ export function GET() {
 			},
 			RuleWithUseFilenamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10217,7 +10217,7 @@ export function GET() {
 			},
 			RuleWithUseFlatMapOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10236,7 +10236,7 @@ export function GET() {
 			},
 			RuleWithUseFocusableInteractiveOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10251,7 +10251,7 @@ export function GET() {
 			},
 			RuleWithUseForComponentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10266,7 +10266,7 @@ export function GET() {
 			},
 			RuleWithUseForOfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10281,7 +10281,7 @@ export function GET() {
 			},
 			RuleWithUseFragmentSyntaxOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10300,7 +10300,7 @@ export function GET() {
 			},
 			RuleWithUseGenericFontNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10315,7 +10315,7 @@ export function GET() {
 			},
 			RuleWithUseGetterReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10330,7 +10330,7 @@ export function GET() {
 			},
 			RuleWithUseGoogleFontDisplayOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10345,7 +10345,7 @@ export function GET() {
 			},
 			RuleWithUseGoogleFontPreconnectOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10364,7 +10364,7 @@ export function GET() {
 			},
 			RuleWithUseGuardForInOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10379,7 +10379,7 @@ export function GET() {
 			},
 			RuleWithUseHeadingContentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10394,7 +10394,7 @@ export function GET() {
 			},
 			RuleWithUseHookAtTopLevelOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10409,7 +10409,7 @@ export function GET() {
 			},
 			RuleWithUseHtmlLangOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10424,7 +10424,7 @@ export function GET() {
 			},
 			RuleWithUseIframeTitleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10439,7 +10439,7 @@ export function GET() {
 			},
 			RuleWithUseImportExtensionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10458,7 +10458,7 @@ export function GET() {
 			},
 			RuleWithUseImportTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10477,7 +10477,7 @@ export function GET() {
 			},
 			RuleWithUseIndexOfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10496,7 +10496,7 @@ export function GET() {
 			},
 			RuleWithUseIsArrayOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10515,7 +10515,7 @@ export function GET() {
 			},
 			RuleWithUseIsNanOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10534,7 +10534,7 @@ export function GET() {
 			},
 			RuleWithUseIterableCallbackReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10549,7 +10549,7 @@ export function GET() {
 			},
 			RuleWithUseJsonImportAttributeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10568,7 +10568,7 @@ export function GET() {
 			},
 			RuleWithUseJsxKeyInIterableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10583,7 +10583,7 @@ export function GET() {
 			},
 			RuleWithUseKeyWithClickEventsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10598,7 +10598,7 @@ export function GET() {
 			},
 			RuleWithUseKeyWithMouseEventsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10613,7 +10613,7 @@ export function GET() {
 			},
 			RuleWithUseLiteralEnumMembersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10628,7 +10628,7 @@ export function GET() {
 			},
 			RuleWithUseLiteralKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10647,7 +10647,7 @@ export function GET() {
 			},
 			RuleWithUseMediaCaptionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10662,7 +10662,7 @@ export function GET() {
 			},
 			RuleWithUseNamedOperationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10681,7 +10681,7 @@ export function GET() {
 			},
 			RuleWithUseNamespaceKeywordOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10700,7 +10700,7 @@ export function GET() {
 			},
 			RuleWithUseNamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10715,7 +10715,7 @@ export function GET() {
 			},
 			RuleWithUseNodeAssertStrictOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10734,7 +10734,7 @@ export function GET() {
 			},
 			RuleWithUseNodejsImportProtocolOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10753,7 +10753,7 @@ export function GET() {
 			},
 			RuleWithUseNumberNamespaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10772,7 +10772,7 @@ export function GET() {
 			},
 			RuleWithUseNumberToFixedDigitsArgumentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10793,7 +10793,7 @@ export function GET() {
 			},
 			RuleWithUseNumericLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10812,7 +10812,7 @@ export function GET() {
 			},
 			RuleWithUseNumericSeparatorsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10831,7 +10831,7 @@ export function GET() {
 			},
 			RuleWithUseObjectSpreadOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10850,7 +10850,7 @@ export function GET() {
 			},
 			RuleWithUseOptionalChainOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10869,7 +10869,7 @@ export function GET() {
 			},
 			RuleWithUseParseIntRadixOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10888,7 +10888,7 @@ export function GET() {
 			},
 			RuleWithUseReadonlyClassPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10909,7 +10909,7 @@ export function GET() {
 			},
 			RuleWithUseRegexLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10928,7 +10928,7 @@ export function GET() {
 			},
 			RuleWithUseSelfClosingElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10947,7 +10947,7 @@ export function GET() {
 			},
 			RuleWithUseSemanticElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10962,7 +10962,7 @@ export function GET() {
 			},
 			RuleWithUseShorthandAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10981,7 +10981,7 @@ export function GET() {
 			},
 			RuleWithUseShorthandFunctionTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11000,7 +11000,7 @@ export function GET() {
 			},
 			RuleWithUseSimpleNumberKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11019,7 +11019,7 @@ export function GET() {
 			},
 			RuleWithUseSimplifiedLogicExpressionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11040,7 +11040,7 @@ export function GET() {
 			},
 			RuleWithUseSingleJsDocAsteriskOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11059,7 +11059,7 @@ export function GET() {
 			},
 			RuleWithUseSingleVarDeclaratorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11078,7 +11078,7 @@ export function GET() {
 			},
 			RuleWithUseSortedClassesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11097,7 +11097,7 @@ export function GET() {
 			},
 			RuleWithUseStrictModeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11116,7 +11116,7 @@ export function GET() {
 			},
 			RuleWithUseSymbolDescriptionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11131,7 +11131,7 @@ export function GET() {
 			},
 			RuleWithUseTemplateOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11150,7 +11150,7 @@ export function GET() {
 			},
 			RuleWithUseThrowNewErrorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11169,7 +11169,7 @@ export function GET() {
 			},
 			RuleWithUseThrowOnlyErrorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11184,7 +11184,7 @@ export function GET() {
 			},
 			RuleWithUseTopLevelRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11199,7 +11199,7 @@ export function GET() {
 			},
 			RuleWithUseTrimStartEndOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11218,7 +11218,7 @@ export function GET() {
 			},
 			RuleWithUseUnifiedTypeSignatureOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11237,7 +11237,7 @@ export function GET() {
 			},
 			RuleWithUseUniqueElementIdsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11252,7 +11252,7 @@ export function GET() {
 			},
 			RuleWithUseValidAnchorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11267,7 +11267,7 @@ export function GET() {
 			},
 			RuleWithUseValidAriaPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11286,7 +11286,7 @@ export function GET() {
 			},
 			RuleWithUseValidAriaRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11305,7 +11305,7 @@ export function GET() {
 			},
 			RuleWithUseValidAriaValuesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11320,7 +11320,7 @@ export function GET() {
 			},
 			RuleWithUseValidAutocompleteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11335,7 +11335,7 @@ export function GET() {
 			},
 			RuleWithUseValidForDirectionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11350,7 +11350,7 @@ export function GET() {
 			},
 			RuleWithUseValidLangOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11365,7 +11365,7 @@ export function GET() {
 			},
 			RuleWithUseValidTypeofOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11384,7 +11384,7 @@ export function GET() {
 			},
 			RuleWithUseWhileOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11403,7 +11403,7 @@ export function GET() {
 			},
 			RuleWithUseYieldOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",

--- a/src/pages/schemas/2.1.1/schema.json.js
+++ b/src/pages/schemas/2.1.1/schema.json.js
@@ -5594,7 +5594,7 @@ export function GET() {
 			RuleAssistPlainConfiguration: { type: "string", enum: ["off", "on"] },
 			RuleAssistWithOptions_for_OrganizeImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5609,7 +5609,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_UseSortedAttributesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5624,7 +5624,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_UseSortedKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5639,7 +5639,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_UseSortedPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5740,7 +5740,7 @@ export function GET() {
 			},
 			RuleWithNoAccessKeyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -5759,7 +5759,7 @@ export function GET() {
 			},
 			RuleWithNoAccumulatingSpreadOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5774,7 +5774,7 @@ export function GET() {
 			},
 			RuleWithNoAdjacentSpacesInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -5793,7 +5793,7 @@ export function GET() {
 			},
 			RuleWithNoAlertOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5808,7 +5808,7 @@ export function GET() {
 			},
 			RuleWithNoApproximativeNumericConstantOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -5829,7 +5829,7 @@ export function GET() {
 			},
 			RuleWithNoArgumentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5844,7 +5844,7 @@ export function GET() {
 			},
 			RuleWithNoAriaHiddenOnFocusableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -5863,7 +5863,7 @@ export function GET() {
 			},
 			RuleWithNoAriaUnsupportedElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -5882,7 +5882,7 @@ export function GET() {
 			},
 			RuleWithNoArrayIndexKeyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5897,7 +5897,7 @@ export function GET() {
 			},
 			RuleWithNoAssignInExpressionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5912,7 +5912,7 @@ export function GET() {
 			},
 			RuleWithNoAsyncPromiseExecutorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5927,7 +5927,7 @@ export function GET() {
 			},
 			RuleWithNoAutofocusOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -5946,7 +5946,7 @@ export function GET() {
 			},
 			RuleWithNoAwaitInLoopOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5961,7 +5961,7 @@ export function GET() {
 			},
 			RuleWithNoBannedTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -5980,7 +5980,7 @@ export function GET() {
 			},
 			RuleWithNoBarrelFileOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5995,7 +5995,7 @@ export function GET() {
 			},
 			RuleWithNoBitwiseOperatorsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6010,7 +6010,7 @@ export function GET() {
 			},
 			RuleWithNoBlankTargetOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6029,7 +6029,7 @@ export function GET() {
 			},
 			RuleWithNoCatchAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6044,7 +6044,7 @@ export function GET() {
 			},
 			RuleWithNoChildrenPropOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6059,7 +6059,7 @@ export function GET() {
 			},
 			RuleWithNoClassAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6074,7 +6074,7 @@ export function GET() {
 			},
 			RuleWithNoCommaOperatorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6089,7 +6089,7 @@ export function GET() {
 			},
 			RuleWithNoCommentTextOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6108,7 +6108,7 @@ export function GET() {
 			},
 			RuleWithNoCommonJsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6123,7 +6123,7 @@ export function GET() {
 			},
 			RuleWithNoCompareNegZeroOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6142,7 +6142,7 @@ export function GET() {
 			},
 			RuleWithNoConfusingLabelsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6157,7 +6157,7 @@ export function GET() {
 			},
 			RuleWithNoConfusingVoidTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6176,7 +6176,7 @@ export function GET() {
 			},
 			RuleWithNoConsoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6195,7 +6195,7 @@ export function GET() {
 			},
 			RuleWithNoConstAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6214,7 +6214,7 @@ export function GET() {
 			},
 			RuleWithNoConstEnumOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6233,7 +6233,7 @@ export function GET() {
 			},
 			RuleWithNoConstantBinaryExpressionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6250,7 +6250,7 @@ export function GET() {
 			},
 			RuleWithNoConstantConditionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6265,7 +6265,7 @@ export function GET() {
 			},
 			RuleWithNoConstantMathMinMaxClampOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6284,7 +6284,7 @@ export function GET() {
 			},
 			RuleWithNoConstructorReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6299,7 +6299,7 @@ export function GET() {
 			},
 			RuleWithNoControlCharactersInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6316,7 +6316,7 @@ export function GET() {
 			},
 			RuleWithNoDangerouslySetInnerHtmlOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6331,7 +6331,7 @@ export function GET() {
 			},
 			RuleWithNoDangerouslySetInnerHtmlWithChildrenOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6350,7 +6350,7 @@ export function GET() {
 			},
 			RuleWithNoDebuggerOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6369,7 +6369,7 @@ export function GET() {
 			},
 			RuleWithNoDefaultExportOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6384,7 +6384,7 @@ export function GET() {
 			},
 			RuleWithNoDeleteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6403,7 +6403,7 @@ export function GET() {
 			},
 			RuleWithNoDescendingSpecificityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6418,7 +6418,7 @@ export function GET() {
 			},
 			RuleWithNoDestructuredPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6433,7 +6433,7 @@ export function GET() {
 			},
 			RuleWithNoDistractingElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6452,7 +6452,7 @@ export function GET() {
 			},
 			RuleWithNoDocumentCookieOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6467,7 +6467,7 @@ export function GET() {
 			},
 			RuleWithNoDocumentImportInPageOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6482,7 +6482,7 @@ export function GET() {
 			},
 			RuleWithNoDoneCallbackOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6497,7 +6497,7 @@ export function GET() {
 			},
 			RuleWithNoDoubleEqualsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6516,7 +6516,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateAtImportRulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6531,7 +6531,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateCaseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6546,7 +6546,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateClassMembersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6561,7 +6561,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateCustomPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6578,7 +6578,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateElseIfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6593,7 +6593,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateFieldsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6608,7 +6608,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateFontNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6623,7 +6623,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateJsxPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6638,7 +6638,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateObjectKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6653,7 +6653,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateParametersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6668,7 +6668,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicatePropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6683,7 +6683,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateSelectorsKeyframeBlockOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6702,7 +6702,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateTestHooksOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6717,7 +6717,7 @@ export function GET() {
 			},
 			RuleWithNoDynamicNamespaceImportAccessOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6734,7 +6734,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyBlockOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6749,7 +6749,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyBlockStatementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6764,7 +6764,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyCharacterClassInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6781,7 +6781,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyInterfaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6800,7 +6800,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyPatternOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6815,7 +6815,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyTypeParametersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6830,7 +6830,7 @@ export function GET() {
 			},
 			RuleWithNoEnumOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6845,7 +6845,7 @@ export function GET() {
 			},
 			RuleWithNoEvolvingTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6860,7 +6860,7 @@ export function GET() {
 			},
 			RuleWithNoExcessiveCognitiveComplexityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6877,7 +6877,7 @@ export function GET() {
 			},
 			RuleWithNoExcessiveLinesPerFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6894,7 +6894,7 @@ export function GET() {
 			},
 			RuleWithNoExcessiveNestedTestSuitesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6911,7 +6911,7 @@ export function GET() {
 			},
 			RuleWithNoExplicitAnyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6926,7 +6926,7 @@ export function GET() {
 			},
 			RuleWithNoExportedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6941,7 +6941,7 @@ export function GET() {
 			},
 			RuleWithNoExportsInTestOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6956,7 +6956,7 @@ export function GET() {
 			},
 			RuleWithNoExtraBooleanCastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6975,7 +6975,7 @@ export function GET() {
 			},
 			RuleWithNoExtraNonNullAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6994,7 +6994,7 @@ export function GET() {
 			},
 			RuleWithNoFallthroughSwitchClauseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7009,7 +7009,7 @@ export function GET() {
 			},
 			RuleWithNoFlatMapIdentityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7028,7 +7028,7 @@ export function GET() {
 			},
 			RuleWithNoFloatingPromisesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7047,7 +7047,7 @@ export function GET() {
 			},
 			RuleWithNoFocusedTestsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7066,7 +7066,7 @@ export function GET() {
 			},
 			RuleWithNoForEachOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7081,7 +7081,7 @@ export function GET() {
 			},
 			RuleWithNoFunctionAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7096,7 +7096,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7111,7 +7111,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalDirnameFilenameOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7130,7 +7130,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalEvalOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7145,7 +7145,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalIsFiniteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7164,7 +7164,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalIsNanOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7183,7 +7183,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalObjectCallsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7198,7 +7198,7 @@ export function GET() {
 			},
 			RuleWithNoHeadElementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7213,7 +7213,7 @@ export function GET() {
 			},
 			RuleWithNoHeadImportInDocumentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7228,7 +7228,7 @@ export function GET() {
 			},
 			RuleWithNoHeaderScopeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7247,7 +7247,7 @@ export function GET() {
 			},
 			RuleWithNoImgElementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7262,7 +7262,7 @@ export function GET() {
 			},
 			RuleWithNoImplicitAnyLetOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7277,7 +7277,7 @@ export function GET() {
 			},
 			RuleWithNoImplicitBooleanOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7296,7 +7296,7 @@ export function GET() {
 			},
 			RuleWithNoImplicitCoercionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7315,7 +7315,7 @@ export function GET() {
 			},
 			RuleWithNoImportAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7330,7 +7330,7 @@ export function GET() {
 			},
 			RuleWithNoImportCyclesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7345,7 +7345,7 @@ export function GET() {
 			},
 			RuleWithNoImportantInKeyframeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7360,7 +7360,7 @@ export function GET() {
 			},
 			RuleWithNoImportantStylesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7379,7 +7379,7 @@ export function GET() {
 			},
 			RuleWithNoInferrableTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7398,7 +7398,7 @@ export function GET() {
 			},
 			RuleWithNoInnerDeclarationsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7413,7 +7413,7 @@ export function GET() {
 			},
 			RuleWithNoInteractiveElementToNoninteractiveRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7436,7 +7436,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidBuiltinInstantiationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7457,7 +7457,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidConstructorSuperOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7472,7 +7472,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidDirectionInLinearGradientOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7491,7 +7491,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidGridAreasOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7506,7 +7506,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidPositionAtImportRuleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7523,7 +7523,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidUseBeforeDeclarationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7540,7 +7540,7 @@ export function GET() {
 			},
 			RuleWithNoIrregularWhitespaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7555,7 +7555,7 @@ export function GET() {
 			},
 			RuleWithNoLabelVarOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7570,7 +7570,7 @@ export function GET() {
 			},
 			RuleWithNoLabelWithoutControlOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7585,7 +7585,7 @@ export function GET() {
 			},
 			RuleWithNoMagicNumbersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7600,7 +7600,7 @@ export function GET() {
 			},
 			RuleWithNoMisleadingCharacterClassOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7621,7 +7621,7 @@ export function GET() {
 			},
 			RuleWithNoMisleadingInstantiatorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7636,7 +7636,7 @@ export function GET() {
 			},
 			RuleWithNoMisplacedAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7651,7 +7651,7 @@ export function GET() {
 			},
 			RuleWithNoMisrefactoredShorthandAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7672,7 +7672,7 @@ export function GET() {
 			},
 			RuleWithNoMissingVarFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7687,7 +7687,7 @@ export function GET() {
 			},
 			RuleWithNoMisusedPromisesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7706,7 +7706,7 @@ export function GET() {
 			},
 			RuleWithNoNamespaceImportOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7721,7 +7721,7 @@ export function GET() {
 			},
 			RuleWithNoNamespaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7736,7 +7736,7 @@ export function GET() {
 			},
 			RuleWithNoNegationElseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7755,7 +7755,7 @@ export function GET() {
 			},
 			RuleWithNoNestedComponentDefinitionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7772,7 +7772,7 @@ export function GET() {
 			},
 			RuleWithNoNestedTernaryOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7787,7 +7787,7 @@ export function GET() {
 			},
 			RuleWithNoNodejsModulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7802,7 +7802,7 @@ export function GET() {
 			},
 			RuleWithNoNonNullAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7821,7 +7821,7 @@ export function GET() {
 			},
 			RuleWithNoNoninteractiveElementInteractionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7840,7 +7840,7 @@ export function GET() {
 			},
 			RuleWithNoNoninteractiveElementToInteractiveRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7863,7 +7863,7 @@ export function GET() {
 			},
 			RuleWithNoNoninteractiveTabindexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7882,7 +7882,7 @@ export function GET() {
 			},
 			RuleWithNoNonoctalDecimalEscapeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7901,7 +7901,7 @@ export function GET() {
 			},
 			RuleWithNoOctalEscapeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7920,7 +7920,7 @@ export function GET() {
 			},
 			RuleWithNoParameterAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7935,7 +7935,7 @@ export function GET() {
 			},
 			RuleWithNoParameterPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7950,7 +7950,7 @@ export function GET() {
 			},
 			RuleWithNoPositiveTabindexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7969,7 +7969,7 @@ export function GET() {
 			},
 			RuleWithNoPrecisionLossOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7984,7 +7984,7 @@ export function GET() {
 			},
 			RuleWithNoPrivateImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7999,7 +7999,7 @@ export function GET() {
 			},
 			RuleWithNoProcessEnvOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8014,7 +8014,7 @@ export function GET() {
 			},
 			RuleWithNoProcessGlobalOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8033,7 +8033,7 @@ export function GET() {
 			},
 			RuleWithNoPrototypeBuiltinsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8052,7 +8052,7 @@ export function GET() {
 			},
 			RuleWithNoReExportAllOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8067,7 +8067,7 @@ export function GET() {
 			},
 			RuleWithNoReactPropAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8082,7 +8082,7 @@ export function GET() {
 			},
 			RuleWithNoReactSpecificPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8101,7 +8101,7 @@ export function GET() {
 			},
 			RuleWithNoRedeclareOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8116,7 +8116,7 @@ export function GET() {
 			},
 			RuleWithNoRedundantAltOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8131,7 +8131,7 @@ export function GET() {
 			},
 			RuleWithNoRedundantRolesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8150,7 +8150,7 @@ export function GET() {
 			},
 			RuleWithNoRedundantUseStrictOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8169,7 +8169,7 @@ export function GET() {
 			},
 			RuleWithNoRenderReturnValueOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8184,7 +8184,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8199,7 +8199,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedGlobalsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8214,7 +8214,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8229,7 +8229,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8248,7 +8248,7 @@ export function GET() {
 			},
 			RuleWithNoSecretsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8263,7 +8263,7 @@ export function GET() {
 			},
 			RuleWithNoSelfAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8278,7 +8278,7 @@ export function GET() {
 			},
 			RuleWithNoSelfCompareOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8293,7 +8293,7 @@ export function GET() {
 			},
 			RuleWithNoSetterReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8308,7 +8308,7 @@ export function GET() {
 			},
 			RuleWithNoShadowOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8323,7 +8323,7 @@ export function GET() {
 			},
 			RuleWithNoShadowRestrictedNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8338,7 +8338,7 @@ export function GET() {
 			},
 			RuleWithNoShorthandPropertyOverridesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8355,7 +8355,7 @@ export function GET() {
 			},
 			RuleWithNoShoutyConstantsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8374,7 +8374,7 @@ export function GET() {
 			},
 			RuleWithNoSkippedTestsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8393,7 +8393,7 @@ export function GET() {
 			},
 			RuleWithNoSparseArrayOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8412,7 +8412,7 @@ export function GET() {
 			},
 			RuleWithNoStaticElementInteractionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8429,7 +8429,7 @@ export function GET() {
 			},
 			RuleWithNoStaticOnlyClassOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8444,7 +8444,7 @@ export function GET() {
 			},
 			RuleWithNoStringCaseMismatchOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8463,7 +8463,7 @@ export function GET() {
 			},
 			RuleWithNoSubstrOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8482,7 +8482,7 @@ export function GET() {
 			},
 			RuleWithNoSuspiciousSemicolonInJsxOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8499,7 +8499,7 @@ export function GET() {
 			},
 			RuleWithNoSvgWithoutTitleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8514,7 +8514,7 @@ export function GET() {
 			},
 			RuleWithNoSwitchDeclarationsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8533,7 +8533,7 @@ export function GET() {
 			},
 			RuleWithNoTemplateCurlyInStringOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8548,7 +8548,7 @@ export function GET() {
 			},
 			RuleWithNoThenPropertyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8563,7 +8563,7 @@ export function GET() {
 			},
 			RuleWithNoThisInStaticOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8582,7 +8582,7 @@ export function GET() {
 			},
 			RuleWithNoTsIgnoreOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8601,7 +8601,7 @@ export function GET() {
 			},
 			RuleWithNoUnassignedVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8616,7 +8616,7 @@ export function GET() {
 			},
 			RuleWithNoUndeclaredDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8631,7 +8631,7 @@ export function GET() {
 			},
 			RuleWithNoUndeclaredVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8646,7 +8646,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownAtRuleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8661,7 +8661,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8676,7 +8676,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownMediaFeatureNameOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8691,7 +8691,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownPropertyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8706,7 +8706,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownPseudoClassOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8721,7 +8721,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownPseudoElementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8736,7 +8736,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownTypeSelectorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8751,7 +8751,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownUnitOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8766,7 +8766,7 @@ export function GET() {
 			},
 			RuleWithNoUnmatchableAnbSelectorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8781,7 +8781,7 @@ export function GET() {
 			},
 			RuleWithNoUnreachableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8796,7 +8796,7 @@ export function GET() {
 			},
 			RuleWithNoUnreachableSuperOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8811,7 +8811,7 @@ export function GET() {
 			},
 			RuleWithNoUnresolvedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8826,7 +8826,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeDeclarationMergingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8843,7 +8843,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeFinallyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8858,7 +8858,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeNegationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8877,7 +8877,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeOptionalChainingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8892,7 +8892,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedFunctionParametersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8913,7 +8913,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8932,7 +8932,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedLabelsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8951,7 +8951,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedPrivateClassMembersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8972,7 +8972,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedTemplateLiteralOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8991,7 +8991,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9010,7 +9010,7 @@ export function GET() {
 			},
 			RuleWithNoUnwantedPolyfillioOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9025,7 +9025,7 @@ export function GET() {
 			},
 			RuleWithNoUselessBackrefInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9040,7 +9040,7 @@ export function GET() {
 			},
 			RuleWithNoUselessCatchOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9059,7 +9059,7 @@ export function GET() {
 			},
 			RuleWithNoUselessConstructorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9078,7 +9078,7 @@ export function GET() {
 			},
 			RuleWithNoUselessContinueOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9097,7 +9097,7 @@ export function GET() {
 			},
 			RuleWithNoUselessElseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9116,7 +9116,7 @@ export function GET() {
 			},
 			RuleWithNoUselessEmptyExportOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9135,7 +9135,7 @@ export function GET() {
 			},
 			RuleWithNoUselessEscapeInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9154,7 +9154,7 @@ export function GET() {
 			},
 			RuleWithNoUselessEscapeInStringOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9173,7 +9173,7 @@ export function GET() {
 			},
 			RuleWithNoUselessFragmentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9192,7 +9192,7 @@ export function GET() {
 			},
 			RuleWithNoUselessLabelOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9211,7 +9211,7 @@ export function GET() {
 			},
 			RuleWithNoUselessLoneBlockStatementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9232,7 +9232,7 @@ export function GET() {
 			},
 			RuleWithNoUselessRenameOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9251,7 +9251,7 @@ export function GET() {
 			},
 			RuleWithNoUselessStringConcatOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9270,7 +9270,7 @@ export function GET() {
 			},
 			RuleWithNoUselessStringRawOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9285,7 +9285,7 @@ export function GET() {
 			},
 			RuleWithNoUselessSwitchCaseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9304,7 +9304,7 @@ export function GET() {
 			},
 			RuleWithNoUselessTernaryOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9323,7 +9323,7 @@ export function GET() {
 			},
 			RuleWithNoUselessThisAliasOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9342,7 +9342,7 @@ export function GET() {
 			},
 			RuleWithNoUselessTypeConstraintOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9361,7 +9361,7 @@ export function GET() {
 			},
 			RuleWithNoUselessUndefinedInitializationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9382,7 +9382,7 @@ export function GET() {
 			},
 			RuleWithNoUselessUndefinedOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9401,7 +9401,7 @@ export function GET() {
 			},
 			RuleWithNoValueAtRuleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9416,7 +9416,7 @@ export function GET() {
 			},
 			RuleWithNoVarOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9435,7 +9435,7 @@ export function GET() {
 			},
 			RuleWithNoVoidElementsWithChildrenOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9456,7 +9456,7 @@ export function GET() {
 			},
 			RuleWithNoVoidOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9471,7 +9471,7 @@ export function GET() {
 			},
 			RuleWithNoVoidTypeReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9486,7 +9486,7 @@ export function GET() {
 			},
 			RuleWithNoWithOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9501,7 +9501,7 @@ export function GET() {
 			},
 			RuleWithNoYodaExpressionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9520,7 +9520,7 @@ export function GET() {
 			},
 			RuleWithUseAdjacentGetterSetterOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9535,7 +9535,7 @@ export function GET() {
 			},
 			RuleWithUseAdjacentOverloadSignaturesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9552,7 +9552,7 @@ export function GET() {
 			},
 			RuleWithUseAltTextOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9567,7 +9567,7 @@ export function GET() {
 			},
 			RuleWithUseAnchorContentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9586,7 +9586,7 @@ export function GET() {
 			},
 			RuleWithUseAriaActivedescendantWithTabindexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9609,7 +9609,7 @@ export function GET() {
 			},
 			RuleWithUseAriaPropsForRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9624,7 +9624,7 @@ export function GET() {
 			},
 			RuleWithUseAriaPropsSupportedByRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9641,7 +9641,7 @@ export function GET() {
 			},
 			RuleWithUseArrayLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9660,7 +9660,7 @@ export function GET() {
 			},
 			RuleWithUseArrowFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9679,7 +9679,7 @@ export function GET() {
 			},
 			RuleWithUseAsConstAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9698,7 +9698,7 @@ export function GET() {
 			},
 			RuleWithUseAtIndexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9717,7 +9717,7 @@ export function GET() {
 			},
 			RuleWithUseAwaitOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9732,7 +9732,7 @@ export function GET() {
 			},
 			RuleWithUseBlockStatementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9751,7 +9751,7 @@ export function GET() {
 			},
 			RuleWithUseButtonTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9766,7 +9766,7 @@ export function GET() {
 			},
 			RuleWithUseCollapsedElseIfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9785,7 +9785,7 @@ export function GET() {
 			},
 			RuleWithUseCollapsedIfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9804,7 +9804,7 @@ export function GET() {
 			},
 			RuleWithUseComponentExportOnlyModulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9821,7 +9821,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentArrayTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9840,7 +9840,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentBuiltinInstantiationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9863,7 +9863,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentCurlyBracesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9882,7 +9882,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentMemberAccessibilityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9899,7 +9899,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentObjectDefinitionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9920,7 +9920,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentResponseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9939,7 +9939,7 @@ export function GET() {
 			},
 			RuleWithUseConstOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9958,7 +9958,7 @@ export function GET() {
 			},
 			RuleWithUseDateNowOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9977,7 +9977,7 @@ export function GET() {
 			},
 			RuleWithUseDefaultParameterLastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9996,7 +9996,7 @@ export function GET() {
 			},
 			RuleWithUseDefaultSwitchClauseLastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10013,7 +10013,7 @@ export function GET() {
 			},
 			RuleWithUseDefaultSwitchClauseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10028,7 +10028,7 @@ export function GET() {
 			},
 			RuleWithUseDeprecatedReasonOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10043,7 +10043,7 @@ export function GET() {
 			},
 			RuleWithUseEnumInitializersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10062,7 +10062,7 @@ export function GET() {
 			},
 			RuleWithUseErrorMessageOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10077,7 +10077,7 @@ export function GET() {
 			},
 			RuleWithUseExhaustiveDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10096,7 +10096,7 @@ export function GET() {
 			},
 			RuleWithUseExhaustiveSwitchCasesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10115,7 +10115,7 @@ export function GET() {
 			},
 			RuleWithUseExplicitLengthCheckOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10134,7 +10134,7 @@ export function GET() {
 			},
 			RuleWithUseExplicitTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10149,7 +10149,7 @@ export function GET() {
 			},
 			RuleWithUseExponentiationOperatorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10168,7 +10168,7 @@ export function GET() {
 			},
 			RuleWithUseExportTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10187,7 +10187,7 @@ export function GET() {
 			},
 			RuleWithUseExportsLastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10202,7 +10202,7 @@ export function GET() {
 			},
 			RuleWithUseFilenamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10217,7 +10217,7 @@ export function GET() {
 			},
 			RuleWithUseFlatMapOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10236,7 +10236,7 @@ export function GET() {
 			},
 			RuleWithUseFocusableInteractiveOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10251,7 +10251,7 @@ export function GET() {
 			},
 			RuleWithUseForComponentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10266,7 +10266,7 @@ export function GET() {
 			},
 			RuleWithUseForOfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10281,7 +10281,7 @@ export function GET() {
 			},
 			RuleWithUseFragmentSyntaxOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10300,7 +10300,7 @@ export function GET() {
 			},
 			RuleWithUseGenericFontNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10315,7 +10315,7 @@ export function GET() {
 			},
 			RuleWithUseGetterReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10330,7 +10330,7 @@ export function GET() {
 			},
 			RuleWithUseGoogleFontDisplayOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10345,7 +10345,7 @@ export function GET() {
 			},
 			RuleWithUseGoogleFontPreconnectOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10364,7 +10364,7 @@ export function GET() {
 			},
 			RuleWithUseGuardForInOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10379,7 +10379,7 @@ export function GET() {
 			},
 			RuleWithUseHeadingContentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10394,7 +10394,7 @@ export function GET() {
 			},
 			RuleWithUseHookAtTopLevelOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10409,7 +10409,7 @@ export function GET() {
 			},
 			RuleWithUseHtmlLangOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10424,7 +10424,7 @@ export function GET() {
 			},
 			RuleWithUseIframeTitleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10439,7 +10439,7 @@ export function GET() {
 			},
 			RuleWithUseImportExtensionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10458,7 +10458,7 @@ export function GET() {
 			},
 			RuleWithUseImportTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10477,7 +10477,7 @@ export function GET() {
 			},
 			RuleWithUseIndexOfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10496,7 +10496,7 @@ export function GET() {
 			},
 			RuleWithUseIsArrayOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10515,7 +10515,7 @@ export function GET() {
 			},
 			RuleWithUseIsNanOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10534,7 +10534,7 @@ export function GET() {
 			},
 			RuleWithUseIterableCallbackReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10549,7 +10549,7 @@ export function GET() {
 			},
 			RuleWithUseJsonImportAttributeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10568,7 +10568,7 @@ export function GET() {
 			},
 			RuleWithUseJsxKeyInIterableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10583,7 +10583,7 @@ export function GET() {
 			},
 			RuleWithUseKeyWithClickEventsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10598,7 +10598,7 @@ export function GET() {
 			},
 			RuleWithUseKeyWithMouseEventsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10613,7 +10613,7 @@ export function GET() {
 			},
 			RuleWithUseLiteralEnumMembersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10628,7 +10628,7 @@ export function GET() {
 			},
 			RuleWithUseLiteralKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10647,7 +10647,7 @@ export function GET() {
 			},
 			RuleWithUseMediaCaptionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10662,7 +10662,7 @@ export function GET() {
 			},
 			RuleWithUseNamedOperationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10681,7 +10681,7 @@ export function GET() {
 			},
 			RuleWithUseNamespaceKeywordOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10700,7 +10700,7 @@ export function GET() {
 			},
 			RuleWithUseNamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10715,7 +10715,7 @@ export function GET() {
 			},
 			RuleWithUseNodeAssertStrictOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10734,7 +10734,7 @@ export function GET() {
 			},
 			RuleWithUseNodejsImportProtocolOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10753,7 +10753,7 @@ export function GET() {
 			},
 			RuleWithUseNumberNamespaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10772,7 +10772,7 @@ export function GET() {
 			},
 			RuleWithUseNumberToFixedDigitsArgumentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10793,7 +10793,7 @@ export function GET() {
 			},
 			RuleWithUseNumericLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10812,7 +10812,7 @@ export function GET() {
 			},
 			RuleWithUseNumericSeparatorsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10831,7 +10831,7 @@ export function GET() {
 			},
 			RuleWithUseObjectSpreadOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10850,7 +10850,7 @@ export function GET() {
 			},
 			RuleWithUseOptionalChainOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10869,7 +10869,7 @@ export function GET() {
 			},
 			RuleWithUseParseIntRadixOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10888,7 +10888,7 @@ export function GET() {
 			},
 			RuleWithUseReadonlyClassPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10909,7 +10909,7 @@ export function GET() {
 			},
 			RuleWithUseRegexLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10928,7 +10928,7 @@ export function GET() {
 			},
 			RuleWithUseSelfClosingElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10947,7 +10947,7 @@ export function GET() {
 			},
 			RuleWithUseSemanticElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10962,7 +10962,7 @@ export function GET() {
 			},
 			RuleWithUseShorthandAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10981,7 +10981,7 @@ export function GET() {
 			},
 			RuleWithUseShorthandFunctionTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11000,7 +11000,7 @@ export function GET() {
 			},
 			RuleWithUseSimpleNumberKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11019,7 +11019,7 @@ export function GET() {
 			},
 			RuleWithUseSimplifiedLogicExpressionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11040,7 +11040,7 @@ export function GET() {
 			},
 			RuleWithUseSingleJsDocAsteriskOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11059,7 +11059,7 @@ export function GET() {
 			},
 			RuleWithUseSingleVarDeclaratorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11078,7 +11078,7 @@ export function GET() {
 			},
 			RuleWithUseSortedClassesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11097,7 +11097,7 @@ export function GET() {
 			},
 			RuleWithUseStrictModeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11116,7 +11116,7 @@ export function GET() {
 			},
 			RuleWithUseSymbolDescriptionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11131,7 +11131,7 @@ export function GET() {
 			},
 			RuleWithUseTemplateOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11150,7 +11150,7 @@ export function GET() {
 			},
 			RuleWithUseThrowNewErrorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11169,7 +11169,7 @@ export function GET() {
 			},
 			RuleWithUseThrowOnlyErrorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11184,7 +11184,7 @@ export function GET() {
 			},
 			RuleWithUseTopLevelRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11199,7 +11199,7 @@ export function GET() {
 			},
 			RuleWithUseTrimStartEndOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11218,7 +11218,7 @@ export function GET() {
 			},
 			RuleWithUseUnifiedTypeSignatureOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11237,7 +11237,7 @@ export function GET() {
 			},
 			RuleWithUseUniqueElementIdsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11252,7 +11252,7 @@ export function GET() {
 			},
 			RuleWithUseValidAnchorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11267,7 +11267,7 @@ export function GET() {
 			},
 			RuleWithUseValidAriaPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11286,7 +11286,7 @@ export function GET() {
 			},
 			RuleWithUseValidAriaRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11305,7 +11305,7 @@ export function GET() {
 			},
 			RuleWithUseValidAriaValuesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11320,7 +11320,7 @@ export function GET() {
 			},
 			RuleWithUseValidAutocompleteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11335,7 +11335,7 @@ export function GET() {
 			},
 			RuleWithUseValidForDirectionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11350,7 +11350,7 @@ export function GET() {
 			},
 			RuleWithUseValidLangOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11365,7 +11365,7 @@ export function GET() {
 			},
 			RuleWithUseValidTypeofOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11384,7 +11384,7 @@ export function GET() {
 			},
 			RuleWithUseWhileOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11403,7 +11403,7 @@ export function GET() {
 			},
 			RuleWithUseYieldOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",

--- a/src/pages/schemas/2.1.2/schema.json.js
+++ b/src/pages/schemas/2.1.2/schema.json.js
@@ -5611,7 +5611,7 @@ export function GET() {
 			RuleAssistPlainConfiguration: { type: "string", enum: ["off", "on"] },
 			RuleAssistWithOptions_for_OrganizeImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5626,7 +5626,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_UseSortedAttributesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5641,7 +5641,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_UseSortedKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5656,7 +5656,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_UseSortedPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5757,7 +5757,7 @@ export function GET() {
 			},
 			RuleWithNoAccessKeyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -5776,7 +5776,7 @@ export function GET() {
 			},
 			RuleWithNoAccumulatingSpreadOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5791,7 +5791,7 @@ export function GET() {
 			},
 			RuleWithNoAdjacentSpacesInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -5810,7 +5810,7 @@ export function GET() {
 			},
 			RuleWithNoAlertOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5825,7 +5825,7 @@ export function GET() {
 			},
 			RuleWithNoApproximativeNumericConstantOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -5846,7 +5846,7 @@ export function GET() {
 			},
 			RuleWithNoArgumentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5861,7 +5861,7 @@ export function GET() {
 			},
 			RuleWithNoAriaHiddenOnFocusableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -5880,7 +5880,7 @@ export function GET() {
 			},
 			RuleWithNoAriaUnsupportedElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -5899,7 +5899,7 @@ export function GET() {
 			},
 			RuleWithNoArrayIndexKeyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5914,7 +5914,7 @@ export function GET() {
 			},
 			RuleWithNoAssignInExpressionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5929,7 +5929,7 @@ export function GET() {
 			},
 			RuleWithNoAsyncPromiseExecutorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5944,7 +5944,7 @@ export function GET() {
 			},
 			RuleWithNoAutofocusOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -5963,7 +5963,7 @@ export function GET() {
 			},
 			RuleWithNoAwaitInLoopOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5978,7 +5978,7 @@ export function GET() {
 			},
 			RuleWithNoBannedTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -5997,7 +5997,7 @@ export function GET() {
 			},
 			RuleWithNoBarrelFileOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6012,7 +6012,7 @@ export function GET() {
 			},
 			RuleWithNoBitwiseOperatorsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6027,7 +6027,7 @@ export function GET() {
 			},
 			RuleWithNoBlankTargetOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6046,7 +6046,7 @@ export function GET() {
 			},
 			RuleWithNoCatchAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6061,7 +6061,7 @@ export function GET() {
 			},
 			RuleWithNoChildrenPropOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6076,7 +6076,7 @@ export function GET() {
 			},
 			RuleWithNoClassAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6091,7 +6091,7 @@ export function GET() {
 			},
 			RuleWithNoCommaOperatorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6106,7 +6106,7 @@ export function GET() {
 			},
 			RuleWithNoCommentTextOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6125,7 +6125,7 @@ export function GET() {
 			},
 			RuleWithNoCommonJsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6140,7 +6140,7 @@ export function GET() {
 			},
 			RuleWithNoCompareNegZeroOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6159,7 +6159,7 @@ export function GET() {
 			},
 			RuleWithNoConfusingLabelsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6174,7 +6174,7 @@ export function GET() {
 			},
 			RuleWithNoConfusingVoidTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6193,7 +6193,7 @@ export function GET() {
 			},
 			RuleWithNoConsoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6212,7 +6212,7 @@ export function GET() {
 			},
 			RuleWithNoConstAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6231,7 +6231,7 @@ export function GET() {
 			},
 			RuleWithNoConstEnumOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6250,7 +6250,7 @@ export function GET() {
 			},
 			RuleWithNoConstantBinaryExpressionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6267,7 +6267,7 @@ export function GET() {
 			},
 			RuleWithNoConstantConditionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6282,7 +6282,7 @@ export function GET() {
 			},
 			RuleWithNoConstantMathMinMaxClampOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6301,7 +6301,7 @@ export function GET() {
 			},
 			RuleWithNoConstructorReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6316,7 +6316,7 @@ export function GET() {
 			},
 			RuleWithNoControlCharactersInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6333,7 +6333,7 @@ export function GET() {
 			},
 			RuleWithNoDangerouslySetInnerHtmlOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6348,7 +6348,7 @@ export function GET() {
 			},
 			RuleWithNoDangerouslySetInnerHtmlWithChildrenOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6367,7 +6367,7 @@ export function GET() {
 			},
 			RuleWithNoDebuggerOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6386,7 +6386,7 @@ export function GET() {
 			},
 			RuleWithNoDefaultExportOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6401,7 +6401,7 @@ export function GET() {
 			},
 			RuleWithNoDeleteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6420,7 +6420,7 @@ export function GET() {
 			},
 			RuleWithNoDescendingSpecificityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6435,7 +6435,7 @@ export function GET() {
 			},
 			RuleWithNoDestructuredPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6450,7 +6450,7 @@ export function GET() {
 			},
 			RuleWithNoDistractingElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6469,7 +6469,7 @@ export function GET() {
 			},
 			RuleWithNoDocumentCookieOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6484,7 +6484,7 @@ export function GET() {
 			},
 			RuleWithNoDocumentImportInPageOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6499,7 +6499,7 @@ export function GET() {
 			},
 			RuleWithNoDoneCallbackOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6514,7 +6514,7 @@ export function GET() {
 			},
 			RuleWithNoDoubleEqualsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6533,7 +6533,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateAtImportRulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6548,7 +6548,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateCaseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6563,7 +6563,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateClassMembersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6578,7 +6578,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateCustomPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6595,7 +6595,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateElseIfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6610,7 +6610,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateFieldsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6625,7 +6625,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateFontNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6640,7 +6640,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateJsxPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6655,7 +6655,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateObjectKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6670,7 +6670,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateParametersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6685,7 +6685,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicatePropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6700,7 +6700,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateSelectorsKeyframeBlockOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6719,7 +6719,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateTestHooksOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6734,7 +6734,7 @@ export function GET() {
 			},
 			RuleWithNoDynamicNamespaceImportAccessOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6751,7 +6751,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyBlockOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6766,7 +6766,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyBlockStatementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6781,7 +6781,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyCharacterClassInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6798,7 +6798,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyInterfaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6817,7 +6817,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyPatternOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6832,7 +6832,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyTypeParametersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6847,7 +6847,7 @@ export function GET() {
 			},
 			RuleWithNoEnumOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6862,7 +6862,7 @@ export function GET() {
 			},
 			RuleWithNoEvolvingTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6877,7 +6877,7 @@ export function GET() {
 			},
 			RuleWithNoExcessiveCognitiveComplexityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6894,7 +6894,7 @@ export function GET() {
 			},
 			RuleWithNoExcessiveLinesPerFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6911,7 +6911,7 @@ export function GET() {
 			},
 			RuleWithNoExcessiveNestedTestSuitesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6928,7 +6928,7 @@ export function GET() {
 			},
 			RuleWithNoExplicitAnyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6943,7 +6943,7 @@ export function GET() {
 			},
 			RuleWithNoExportedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6958,7 +6958,7 @@ export function GET() {
 			},
 			RuleWithNoExportsInTestOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6973,7 +6973,7 @@ export function GET() {
 			},
 			RuleWithNoExtraBooleanCastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6992,7 +6992,7 @@ export function GET() {
 			},
 			RuleWithNoExtraNonNullAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7011,7 +7011,7 @@ export function GET() {
 			},
 			RuleWithNoFallthroughSwitchClauseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7026,7 +7026,7 @@ export function GET() {
 			},
 			RuleWithNoFlatMapIdentityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7045,7 +7045,7 @@ export function GET() {
 			},
 			RuleWithNoFloatingPromisesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7064,7 +7064,7 @@ export function GET() {
 			},
 			RuleWithNoFocusedTestsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7083,7 +7083,7 @@ export function GET() {
 			},
 			RuleWithNoForEachOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7098,7 +7098,7 @@ export function GET() {
 			},
 			RuleWithNoFunctionAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7113,7 +7113,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7128,7 +7128,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalDirnameFilenameOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7147,7 +7147,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalEvalOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7162,7 +7162,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalIsFiniteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7181,7 +7181,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalIsNanOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7200,7 +7200,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalObjectCallsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7215,7 +7215,7 @@ export function GET() {
 			},
 			RuleWithNoHeadElementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7230,7 +7230,7 @@ export function GET() {
 			},
 			RuleWithNoHeadImportInDocumentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7245,7 +7245,7 @@ export function GET() {
 			},
 			RuleWithNoHeaderScopeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7264,7 +7264,7 @@ export function GET() {
 			},
 			RuleWithNoImgElementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7279,7 +7279,7 @@ export function GET() {
 			},
 			RuleWithNoImplicitAnyLetOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7294,7 +7294,7 @@ export function GET() {
 			},
 			RuleWithNoImplicitBooleanOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7313,7 +7313,7 @@ export function GET() {
 			},
 			RuleWithNoImplicitCoercionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7332,7 +7332,7 @@ export function GET() {
 			},
 			RuleWithNoImportAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7347,7 +7347,7 @@ export function GET() {
 			},
 			RuleWithNoImportCyclesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7362,7 +7362,7 @@ export function GET() {
 			},
 			RuleWithNoImportantInKeyframeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7377,7 +7377,7 @@ export function GET() {
 			},
 			RuleWithNoImportantStylesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7396,7 +7396,7 @@ export function GET() {
 			},
 			RuleWithNoInferrableTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7415,7 +7415,7 @@ export function GET() {
 			},
 			RuleWithNoInnerDeclarationsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7430,7 +7430,7 @@ export function GET() {
 			},
 			RuleWithNoInteractiveElementToNoninteractiveRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7453,7 +7453,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidBuiltinInstantiationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7474,7 +7474,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidConstructorSuperOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7489,7 +7489,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidDirectionInLinearGradientOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7508,7 +7508,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidGridAreasOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7523,7 +7523,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidPositionAtImportRuleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7540,7 +7540,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidUseBeforeDeclarationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7557,7 +7557,7 @@ export function GET() {
 			},
 			RuleWithNoIrregularWhitespaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7572,7 +7572,7 @@ export function GET() {
 			},
 			RuleWithNoLabelVarOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7587,7 +7587,7 @@ export function GET() {
 			},
 			RuleWithNoLabelWithoutControlOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7602,7 +7602,7 @@ export function GET() {
 			},
 			RuleWithNoMagicNumbersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7617,7 +7617,7 @@ export function GET() {
 			},
 			RuleWithNoMisleadingCharacterClassOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7638,7 +7638,7 @@ export function GET() {
 			},
 			RuleWithNoMisleadingInstantiatorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7653,7 +7653,7 @@ export function GET() {
 			},
 			RuleWithNoMisplacedAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7668,7 +7668,7 @@ export function GET() {
 			},
 			RuleWithNoMisrefactoredShorthandAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7689,7 +7689,7 @@ export function GET() {
 			},
 			RuleWithNoMissingVarFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7704,7 +7704,7 @@ export function GET() {
 			},
 			RuleWithNoMisusedPromisesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7723,7 +7723,7 @@ export function GET() {
 			},
 			RuleWithNoNamespaceImportOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7738,7 +7738,7 @@ export function GET() {
 			},
 			RuleWithNoNamespaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7753,7 +7753,7 @@ export function GET() {
 			},
 			RuleWithNoNegationElseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7772,7 +7772,7 @@ export function GET() {
 			},
 			RuleWithNoNestedComponentDefinitionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7789,7 +7789,7 @@ export function GET() {
 			},
 			RuleWithNoNestedTernaryOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7804,7 +7804,7 @@ export function GET() {
 			},
 			RuleWithNoNodejsModulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7819,7 +7819,7 @@ export function GET() {
 			},
 			RuleWithNoNonNullAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7838,7 +7838,7 @@ export function GET() {
 			},
 			RuleWithNoNoninteractiveElementInteractionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7857,7 +7857,7 @@ export function GET() {
 			},
 			RuleWithNoNoninteractiveElementToInteractiveRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7880,7 +7880,7 @@ export function GET() {
 			},
 			RuleWithNoNoninteractiveTabindexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7899,7 +7899,7 @@ export function GET() {
 			},
 			RuleWithNoNonoctalDecimalEscapeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7918,7 +7918,7 @@ export function GET() {
 			},
 			RuleWithNoOctalEscapeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7937,7 +7937,7 @@ export function GET() {
 			},
 			RuleWithNoParameterAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7952,7 +7952,7 @@ export function GET() {
 			},
 			RuleWithNoParameterPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7967,7 +7967,7 @@ export function GET() {
 			},
 			RuleWithNoPositiveTabindexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7986,7 +7986,7 @@ export function GET() {
 			},
 			RuleWithNoPrecisionLossOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8001,7 +8001,7 @@ export function GET() {
 			},
 			RuleWithNoPrivateImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8016,7 +8016,7 @@ export function GET() {
 			},
 			RuleWithNoProcessEnvOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8031,7 +8031,7 @@ export function GET() {
 			},
 			RuleWithNoProcessGlobalOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8050,7 +8050,7 @@ export function GET() {
 			},
 			RuleWithNoPrototypeBuiltinsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8069,7 +8069,7 @@ export function GET() {
 			},
 			RuleWithNoReExportAllOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8084,7 +8084,7 @@ export function GET() {
 			},
 			RuleWithNoReactPropAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8099,7 +8099,7 @@ export function GET() {
 			},
 			RuleWithNoReactSpecificPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8118,7 +8118,7 @@ export function GET() {
 			},
 			RuleWithNoRedeclareOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8133,7 +8133,7 @@ export function GET() {
 			},
 			RuleWithNoRedundantAltOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8148,7 +8148,7 @@ export function GET() {
 			},
 			RuleWithNoRedundantRolesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8167,7 +8167,7 @@ export function GET() {
 			},
 			RuleWithNoRedundantUseStrictOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8186,7 +8186,7 @@ export function GET() {
 			},
 			RuleWithNoRenderReturnValueOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8201,7 +8201,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8216,7 +8216,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedGlobalsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8231,7 +8231,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8246,7 +8246,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8265,7 +8265,7 @@ export function GET() {
 			},
 			RuleWithNoSecretsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8280,7 +8280,7 @@ export function GET() {
 			},
 			RuleWithNoSelfAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8295,7 +8295,7 @@ export function GET() {
 			},
 			RuleWithNoSelfCompareOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8310,7 +8310,7 @@ export function GET() {
 			},
 			RuleWithNoSetterReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8325,7 +8325,7 @@ export function GET() {
 			},
 			RuleWithNoShadowOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8340,7 +8340,7 @@ export function GET() {
 			},
 			RuleWithNoShadowRestrictedNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8355,7 +8355,7 @@ export function GET() {
 			},
 			RuleWithNoShorthandPropertyOverridesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8372,7 +8372,7 @@ export function GET() {
 			},
 			RuleWithNoShoutyConstantsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8391,7 +8391,7 @@ export function GET() {
 			},
 			RuleWithNoSkippedTestsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8410,7 +8410,7 @@ export function GET() {
 			},
 			RuleWithNoSparseArrayOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8429,7 +8429,7 @@ export function GET() {
 			},
 			RuleWithNoStaticElementInteractionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8446,7 +8446,7 @@ export function GET() {
 			},
 			RuleWithNoStaticOnlyClassOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8461,7 +8461,7 @@ export function GET() {
 			},
 			RuleWithNoStringCaseMismatchOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8480,7 +8480,7 @@ export function GET() {
 			},
 			RuleWithNoSubstrOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8499,7 +8499,7 @@ export function GET() {
 			},
 			RuleWithNoSuspiciousSemicolonInJsxOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8516,7 +8516,7 @@ export function GET() {
 			},
 			RuleWithNoSvgWithoutTitleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8531,7 +8531,7 @@ export function GET() {
 			},
 			RuleWithNoSwitchDeclarationsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8550,7 +8550,7 @@ export function GET() {
 			},
 			RuleWithNoTemplateCurlyInStringOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8565,7 +8565,7 @@ export function GET() {
 			},
 			RuleWithNoThenPropertyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8580,7 +8580,7 @@ export function GET() {
 			},
 			RuleWithNoThisInStaticOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8599,7 +8599,7 @@ export function GET() {
 			},
 			RuleWithNoTsIgnoreOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8618,7 +8618,7 @@ export function GET() {
 			},
 			RuleWithNoUnassignedVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8633,7 +8633,7 @@ export function GET() {
 			},
 			RuleWithNoUndeclaredDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8648,7 +8648,7 @@ export function GET() {
 			},
 			RuleWithNoUndeclaredVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8663,7 +8663,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownAtRuleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8678,7 +8678,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8693,7 +8693,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownMediaFeatureNameOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8708,7 +8708,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownPropertyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8723,7 +8723,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownPseudoClassOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8738,7 +8738,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownPseudoElementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8753,7 +8753,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownTypeSelectorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8768,7 +8768,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownUnitOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8783,7 +8783,7 @@ export function GET() {
 			},
 			RuleWithNoUnmatchableAnbSelectorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8798,7 +8798,7 @@ export function GET() {
 			},
 			RuleWithNoUnreachableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8813,7 +8813,7 @@ export function GET() {
 			},
 			RuleWithNoUnreachableSuperOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8828,7 +8828,7 @@ export function GET() {
 			},
 			RuleWithNoUnresolvedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8843,7 +8843,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeDeclarationMergingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8860,7 +8860,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeFinallyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8875,7 +8875,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeNegationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8894,7 +8894,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeOptionalChainingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8909,7 +8909,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedFunctionParametersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8930,7 +8930,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8949,7 +8949,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedLabelsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8968,7 +8968,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedPrivateClassMembersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8989,7 +8989,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedTemplateLiteralOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9008,7 +9008,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9027,7 +9027,7 @@ export function GET() {
 			},
 			RuleWithNoUnwantedPolyfillioOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9042,7 +9042,7 @@ export function GET() {
 			},
 			RuleWithNoUselessBackrefInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9057,7 +9057,7 @@ export function GET() {
 			},
 			RuleWithNoUselessCatchOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9076,7 +9076,7 @@ export function GET() {
 			},
 			RuleWithNoUselessConstructorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9095,7 +9095,7 @@ export function GET() {
 			},
 			RuleWithNoUselessContinueOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9114,7 +9114,7 @@ export function GET() {
 			},
 			RuleWithNoUselessElseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9133,7 +9133,7 @@ export function GET() {
 			},
 			RuleWithNoUselessEmptyExportOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9152,7 +9152,7 @@ export function GET() {
 			},
 			RuleWithNoUselessEscapeInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9171,7 +9171,7 @@ export function GET() {
 			},
 			RuleWithNoUselessEscapeInStringOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9190,7 +9190,7 @@ export function GET() {
 			},
 			RuleWithNoUselessFragmentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9209,7 +9209,7 @@ export function GET() {
 			},
 			RuleWithNoUselessLabelOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9228,7 +9228,7 @@ export function GET() {
 			},
 			RuleWithNoUselessLoneBlockStatementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9249,7 +9249,7 @@ export function GET() {
 			},
 			RuleWithNoUselessRenameOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9268,7 +9268,7 @@ export function GET() {
 			},
 			RuleWithNoUselessStringConcatOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9287,7 +9287,7 @@ export function GET() {
 			},
 			RuleWithNoUselessStringRawOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9302,7 +9302,7 @@ export function GET() {
 			},
 			RuleWithNoUselessSwitchCaseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9321,7 +9321,7 @@ export function GET() {
 			},
 			RuleWithNoUselessTernaryOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9340,7 +9340,7 @@ export function GET() {
 			},
 			RuleWithNoUselessThisAliasOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9359,7 +9359,7 @@ export function GET() {
 			},
 			RuleWithNoUselessTypeConstraintOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9378,7 +9378,7 @@ export function GET() {
 			},
 			RuleWithNoUselessUndefinedInitializationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9399,7 +9399,7 @@ export function GET() {
 			},
 			RuleWithNoUselessUndefinedOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9418,7 +9418,7 @@ export function GET() {
 			},
 			RuleWithNoValueAtRuleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9433,7 +9433,7 @@ export function GET() {
 			},
 			RuleWithNoVarOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9452,7 +9452,7 @@ export function GET() {
 			},
 			RuleWithNoVoidElementsWithChildrenOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9473,7 +9473,7 @@ export function GET() {
 			},
 			RuleWithNoVoidOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9488,7 +9488,7 @@ export function GET() {
 			},
 			RuleWithNoVoidTypeReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9503,7 +9503,7 @@ export function GET() {
 			},
 			RuleWithNoVueReservedPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9518,7 +9518,7 @@ export function GET() {
 			},
 			RuleWithNoWithOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9533,7 +9533,7 @@ export function GET() {
 			},
 			RuleWithNoYodaExpressionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9552,7 +9552,7 @@ export function GET() {
 			},
 			RuleWithUseAdjacentGetterSetterOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9567,7 +9567,7 @@ export function GET() {
 			},
 			RuleWithUseAdjacentOverloadSignaturesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9584,7 +9584,7 @@ export function GET() {
 			},
 			RuleWithUseAltTextOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9599,7 +9599,7 @@ export function GET() {
 			},
 			RuleWithUseAnchorContentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9618,7 +9618,7 @@ export function GET() {
 			},
 			RuleWithUseAriaActivedescendantWithTabindexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9641,7 +9641,7 @@ export function GET() {
 			},
 			RuleWithUseAriaPropsForRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9656,7 +9656,7 @@ export function GET() {
 			},
 			RuleWithUseAriaPropsSupportedByRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9673,7 +9673,7 @@ export function GET() {
 			},
 			RuleWithUseArrayLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9692,7 +9692,7 @@ export function GET() {
 			},
 			RuleWithUseArrowFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9711,7 +9711,7 @@ export function GET() {
 			},
 			RuleWithUseAsConstAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9730,7 +9730,7 @@ export function GET() {
 			},
 			RuleWithUseAtIndexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9749,7 +9749,7 @@ export function GET() {
 			},
 			RuleWithUseAwaitOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9764,7 +9764,7 @@ export function GET() {
 			},
 			RuleWithUseBlockStatementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9783,7 +9783,7 @@ export function GET() {
 			},
 			RuleWithUseButtonTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9798,7 +9798,7 @@ export function GET() {
 			},
 			RuleWithUseCollapsedElseIfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9817,7 +9817,7 @@ export function GET() {
 			},
 			RuleWithUseCollapsedIfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9836,7 +9836,7 @@ export function GET() {
 			},
 			RuleWithUseComponentExportOnlyModulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9853,7 +9853,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentArrayTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9872,7 +9872,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentBuiltinInstantiationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9895,7 +9895,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentCurlyBracesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9914,7 +9914,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentMemberAccessibilityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9931,7 +9931,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentObjectDefinitionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9952,7 +9952,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentResponseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9971,7 +9971,7 @@ export function GET() {
 			},
 			RuleWithUseConstOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9990,7 +9990,7 @@ export function GET() {
 			},
 			RuleWithUseDateNowOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10009,7 +10009,7 @@ export function GET() {
 			},
 			RuleWithUseDefaultParameterLastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10028,7 +10028,7 @@ export function GET() {
 			},
 			RuleWithUseDefaultSwitchClauseLastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10045,7 +10045,7 @@ export function GET() {
 			},
 			RuleWithUseDefaultSwitchClauseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10060,7 +10060,7 @@ export function GET() {
 			},
 			RuleWithUseDeprecatedReasonOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10075,7 +10075,7 @@ export function GET() {
 			},
 			RuleWithUseEnumInitializersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10094,7 +10094,7 @@ export function GET() {
 			},
 			RuleWithUseErrorMessageOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10109,7 +10109,7 @@ export function GET() {
 			},
 			RuleWithUseExhaustiveDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10128,7 +10128,7 @@ export function GET() {
 			},
 			RuleWithUseExhaustiveSwitchCasesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10147,7 +10147,7 @@ export function GET() {
 			},
 			RuleWithUseExplicitLengthCheckOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10166,7 +10166,7 @@ export function GET() {
 			},
 			RuleWithUseExplicitTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10181,7 +10181,7 @@ export function GET() {
 			},
 			RuleWithUseExponentiationOperatorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10200,7 +10200,7 @@ export function GET() {
 			},
 			RuleWithUseExportTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10219,7 +10219,7 @@ export function GET() {
 			},
 			RuleWithUseExportsLastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10234,7 +10234,7 @@ export function GET() {
 			},
 			RuleWithUseFilenamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10249,7 +10249,7 @@ export function GET() {
 			},
 			RuleWithUseFlatMapOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10268,7 +10268,7 @@ export function GET() {
 			},
 			RuleWithUseFocusableInteractiveOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10283,7 +10283,7 @@ export function GET() {
 			},
 			RuleWithUseForComponentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10298,7 +10298,7 @@ export function GET() {
 			},
 			RuleWithUseForOfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10313,7 +10313,7 @@ export function GET() {
 			},
 			RuleWithUseFragmentSyntaxOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10332,7 +10332,7 @@ export function GET() {
 			},
 			RuleWithUseGenericFontNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10347,7 +10347,7 @@ export function GET() {
 			},
 			RuleWithUseGetterReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10362,7 +10362,7 @@ export function GET() {
 			},
 			RuleWithUseGoogleFontDisplayOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10377,7 +10377,7 @@ export function GET() {
 			},
 			RuleWithUseGoogleFontPreconnectOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10396,7 +10396,7 @@ export function GET() {
 			},
 			RuleWithUseGuardForInOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10411,7 +10411,7 @@ export function GET() {
 			},
 			RuleWithUseHeadingContentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10426,7 +10426,7 @@ export function GET() {
 			},
 			RuleWithUseHookAtTopLevelOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10441,7 +10441,7 @@ export function GET() {
 			},
 			RuleWithUseHtmlLangOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10456,7 +10456,7 @@ export function GET() {
 			},
 			RuleWithUseIframeTitleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10471,7 +10471,7 @@ export function GET() {
 			},
 			RuleWithUseImportExtensionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10490,7 +10490,7 @@ export function GET() {
 			},
 			RuleWithUseImportTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10509,7 +10509,7 @@ export function GET() {
 			},
 			RuleWithUseIndexOfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10528,7 +10528,7 @@ export function GET() {
 			},
 			RuleWithUseIsArrayOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10547,7 +10547,7 @@ export function GET() {
 			},
 			RuleWithUseIsNanOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10566,7 +10566,7 @@ export function GET() {
 			},
 			RuleWithUseIterableCallbackReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10581,7 +10581,7 @@ export function GET() {
 			},
 			RuleWithUseJsonImportAttributeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10600,7 +10600,7 @@ export function GET() {
 			},
 			RuleWithUseJsxKeyInIterableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10615,7 +10615,7 @@ export function GET() {
 			},
 			RuleWithUseKeyWithClickEventsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10630,7 +10630,7 @@ export function GET() {
 			},
 			RuleWithUseKeyWithMouseEventsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10645,7 +10645,7 @@ export function GET() {
 			},
 			RuleWithUseLiteralEnumMembersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10660,7 +10660,7 @@ export function GET() {
 			},
 			RuleWithUseLiteralKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10679,7 +10679,7 @@ export function GET() {
 			},
 			RuleWithUseMediaCaptionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10694,7 +10694,7 @@ export function GET() {
 			},
 			RuleWithUseNamedOperationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10713,7 +10713,7 @@ export function GET() {
 			},
 			RuleWithUseNamespaceKeywordOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10732,7 +10732,7 @@ export function GET() {
 			},
 			RuleWithUseNamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10747,7 +10747,7 @@ export function GET() {
 			},
 			RuleWithUseNodeAssertStrictOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10766,7 +10766,7 @@ export function GET() {
 			},
 			RuleWithUseNodejsImportProtocolOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10785,7 +10785,7 @@ export function GET() {
 			},
 			RuleWithUseNumberNamespaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10804,7 +10804,7 @@ export function GET() {
 			},
 			RuleWithUseNumberToFixedDigitsArgumentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10825,7 +10825,7 @@ export function GET() {
 			},
 			RuleWithUseNumericLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10844,7 +10844,7 @@ export function GET() {
 			},
 			RuleWithUseNumericSeparatorsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10863,7 +10863,7 @@ export function GET() {
 			},
 			RuleWithUseObjectSpreadOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10882,7 +10882,7 @@ export function GET() {
 			},
 			RuleWithUseOptionalChainOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10901,7 +10901,7 @@ export function GET() {
 			},
 			RuleWithUseParseIntRadixOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10920,7 +10920,7 @@ export function GET() {
 			},
 			RuleWithUseReadonlyClassPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10941,7 +10941,7 @@ export function GET() {
 			},
 			RuleWithUseRegexLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10960,7 +10960,7 @@ export function GET() {
 			},
 			RuleWithUseSelfClosingElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10979,7 +10979,7 @@ export function GET() {
 			},
 			RuleWithUseSemanticElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10994,7 +10994,7 @@ export function GET() {
 			},
 			RuleWithUseShorthandAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11013,7 +11013,7 @@ export function GET() {
 			},
 			RuleWithUseShorthandFunctionTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11032,7 +11032,7 @@ export function GET() {
 			},
 			RuleWithUseSimpleNumberKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11051,7 +11051,7 @@ export function GET() {
 			},
 			RuleWithUseSimplifiedLogicExpressionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11072,7 +11072,7 @@ export function GET() {
 			},
 			RuleWithUseSingleJsDocAsteriskOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11091,7 +11091,7 @@ export function GET() {
 			},
 			RuleWithUseSingleVarDeclaratorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11110,7 +11110,7 @@ export function GET() {
 			},
 			RuleWithUseSortedClassesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11129,7 +11129,7 @@ export function GET() {
 			},
 			RuleWithUseStrictModeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11148,7 +11148,7 @@ export function GET() {
 			},
 			RuleWithUseSymbolDescriptionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11163,7 +11163,7 @@ export function GET() {
 			},
 			RuleWithUseTemplateOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11182,7 +11182,7 @@ export function GET() {
 			},
 			RuleWithUseThrowNewErrorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11201,7 +11201,7 @@ export function GET() {
 			},
 			RuleWithUseThrowOnlyErrorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11216,7 +11216,7 @@ export function GET() {
 			},
 			RuleWithUseTopLevelRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11231,7 +11231,7 @@ export function GET() {
 			},
 			RuleWithUseTrimStartEndOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11250,7 +11250,7 @@ export function GET() {
 			},
 			RuleWithUseUnifiedTypeSignatureOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11269,7 +11269,7 @@ export function GET() {
 			},
 			RuleWithUseUniqueElementIdsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11284,7 +11284,7 @@ export function GET() {
 			},
 			RuleWithUseValidAnchorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11299,7 +11299,7 @@ export function GET() {
 			},
 			RuleWithUseValidAriaPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11318,7 +11318,7 @@ export function GET() {
 			},
 			RuleWithUseValidAriaRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11337,7 +11337,7 @@ export function GET() {
 			},
 			RuleWithUseValidAriaValuesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11352,7 +11352,7 @@ export function GET() {
 			},
 			RuleWithUseValidAutocompleteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11367,7 +11367,7 @@ export function GET() {
 			},
 			RuleWithUseValidForDirectionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11382,7 +11382,7 @@ export function GET() {
 			},
 			RuleWithUseValidLangOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11397,7 +11397,7 @@ export function GET() {
 			},
 			RuleWithUseValidTypeofOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11416,7 +11416,7 @@ export function GET() {
 			},
 			RuleWithUseWhileOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11435,7 +11435,7 @@ export function GET() {
 			},
 			RuleWithUseYieldOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",

--- a/src/pages/schemas/2.1.3/schema.json.js
+++ b/src/pages/schemas/2.1.3/schema.json.js
@@ -5638,7 +5638,7 @@ export function GET() {
 			RuleAssistPlainConfiguration: { type: "string", enum: ["off", "on"] },
 			RuleAssistWithOptions_for_OrganizeImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5653,7 +5653,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_UseSortedAttributesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5668,7 +5668,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_UseSortedKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5683,7 +5683,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_UseSortedPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5784,7 +5784,7 @@ export function GET() {
 			},
 			RuleWithNoAccessKeyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -5803,7 +5803,7 @@ export function GET() {
 			},
 			RuleWithNoAccumulatingSpreadOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5818,7 +5818,7 @@ export function GET() {
 			},
 			RuleWithNoAdjacentSpacesInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -5837,7 +5837,7 @@ export function GET() {
 			},
 			RuleWithNoAlertOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5852,7 +5852,7 @@ export function GET() {
 			},
 			RuleWithNoApproximativeNumericConstantOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -5873,7 +5873,7 @@ export function GET() {
 			},
 			RuleWithNoArgumentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5888,7 +5888,7 @@ export function GET() {
 			},
 			RuleWithNoAriaHiddenOnFocusableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -5907,7 +5907,7 @@ export function GET() {
 			},
 			RuleWithNoAriaUnsupportedElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -5926,7 +5926,7 @@ export function GET() {
 			},
 			RuleWithNoArrayIndexKeyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5941,7 +5941,7 @@ export function GET() {
 			},
 			RuleWithNoAssignInExpressionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5956,7 +5956,7 @@ export function GET() {
 			},
 			RuleWithNoAsyncPromiseExecutorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5971,7 +5971,7 @@ export function GET() {
 			},
 			RuleWithNoAutofocusOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -5990,7 +5990,7 @@ export function GET() {
 			},
 			RuleWithNoAwaitInLoopOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6005,7 +6005,7 @@ export function GET() {
 			},
 			RuleWithNoBannedTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6024,7 +6024,7 @@ export function GET() {
 			},
 			RuleWithNoBarrelFileOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6039,7 +6039,7 @@ export function GET() {
 			},
 			RuleWithNoBitwiseOperatorsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6054,7 +6054,7 @@ export function GET() {
 			},
 			RuleWithNoBlankTargetOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6073,7 +6073,7 @@ export function GET() {
 			},
 			RuleWithNoCatchAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6088,7 +6088,7 @@ export function GET() {
 			},
 			RuleWithNoChildrenPropOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6103,7 +6103,7 @@ export function GET() {
 			},
 			RuleWithNoClassAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6118,7 +6118,7 @@ export function GET() {
 			},
 			RuleWithNoCommaOperatorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6133,7 +6133,7 @@ export function GET() {
 			},
 			RuleWithNoCommentTextOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6152,7 +6152,7 @@ export function GET() {
 			},
 			RuleWithNoCommonJsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6167,7 +6167,7 @@ export function GET() {
 			},
 			RuleWithNoCompareNegZeroOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6186,7 +6186,7 @@ export function GET() {
 			},
 			RuleWithNoConfusingLabelsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6201,7 +6201,7 @@ export function GET() {
 			},
 			RuleWithNoConfusingVoidTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6220,7 +6220,7 @@ export function GET() {
 			},
 			RuleWithNoConsoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6239,7 +6239,7 @@ export function GET() {
 			},
 			RuleWithNoConstAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6258,7 +6258,7 @@ export function GET() {
 			},
 			RuleWithNoConstEnumOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6277,7 +6277,7 @@ export function GET() {
 			},
 			RuleWithNoConstantBinaryExpressionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6294,7 +6294,7 @@ export function GET() {
 			},
 			RuleWithNoConstantConditionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6309,7 +6309,7 @@ export function GET() {
 			},
 			RuleWithNoConstantMathMinMaxClampOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6328,7 +6328,7 @@ export function GET() {
 			},
 			RuleWithNoConstructorReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6343,7 +6343,7 @@ export function GET() {
 			},
 			RuleWithNoControlCharactersInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6360,7 +6360,7 @@ export function GET() {
 			},
 			RuleWithNoDangerouslySetInnerHtmlOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6375,7 +6375,7 @@ export function GET() {
 			},
 			RuleWithNoDangerouslySetInnerHtmlWithChildrenOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6394,7 +6394,7 @@ export function GET() {
 			},
 			RuleWithNoDebuggerOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6413,7 +6413,7 @@ export function GET() {
 			},
 			RuleWithNoDefaultExportOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6428,7 +6428,7 @@ export function GET() {
 			},
 			RuleWithNoDeleteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6447,7 +6447,7 @@ export function GET() {
 			},
 			RuleWithNoDescendingSpecificityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6462,7 +6462,7 @@ export function GET() {
 			},
 			RuleWithNoDestructuredPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6477,7 +6477,7 @@ export function GET() {
 			},
 			RuleWithNoDistractingElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6496,7 +6496,7 @@ export function GET() {
 			},
 			RuleWithNoDocumentCookieOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6511,7 +6511,7 @@ export function GET() {
 			},
 			RuleWithNoDocumentImportInPageOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6526,7 +6526,7 @@ export function GET() {
 			},
 			RuleWithNoDoneCallbackOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6541,7 +6541,7 @@ export function GET() {
 			},
 			RuleWithNoDoubleEqualsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6560,7 +6560,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateAtImportRulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6575,7 +6575,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateCaseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6590,7 +6590,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateClassMembersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6605,7 +6605,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateCustomPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6622,7 +6622,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateElseIfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6637,7 +6637,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateFieldsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6652,7 +6652,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateFontNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6667,7 +6667,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateJsxPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6682,7 +6682,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateObjectKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6697,7 +6697,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateParametersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6712,7 +6712,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicatePropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6727,7 +6727,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateSelectorsKeyframeBlockOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6746,7 +6746,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateTestHooksOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6761,7 +6761,7 @@ export function GET() {
 			},
 			RuleWithNoDynamicNamespaceImportAccessOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6778,7 +6778,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyBlockOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6793,7 +6793,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyBlockStatementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6808,7 +6808,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyCharacterClassInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6825,7 +6825,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyInterfaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6844,7 +6844,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyPatternOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6859,7 +6859,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyTypeParametersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6874,7 +6874,7 @@ export function GET() {
 			},
 			RuleWithNoEnumOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6889,7 +6889,7 @@ export function GET() {
 			},
 			RuleWithNoEvolvingTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6904,7 +6904,7 @@ export function GET() {
 			},
 			RuleWithNoExcessiveCognitiveComplexityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6921,7 +6921,7 @@ export function GET() {
 			},
 			RuleWithNoExcessiveLinesPerFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6938,7 +6938,7 @@ export function GET() {
 			},
 			RuleWithNoExcessiveNestedTestSuitesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6955,7 +6955,7 @@ export function GET() {
 			},
 			RuleWithNoExplicitAnyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6970,7 +6970,7 @@ export function GET() {
 			},
 			RuleWithNoExportedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6985,7 +6985,7 @@ export function GET() {
 			},
 			RuleWithNoExportsInTestOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7000,7 +7000,7 @@ export function GET() {
 			},
 			RuleWithNoExtraBooleanCastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7019,7 +7019,7 @@ export function GET() {
 			},
 			RuleWithNoExtraNonNullAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7038,7 +7038,7 @@ export function GET() {
 			},
 			RuleWithNoFallthroughSwitchClauseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7053,7 +7053,7 @@ export function GET() {
 			},
 			RuleWithNoFlatMapIdentityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7072,7 +7072,7 @@ export function GET() {
 			},
 			RuleWithNoFloatingPromisesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7091,7 +7091,7 @@ export function GET() {
 			},
 			RuleWithNoFocusedTestsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7110,7 +7110,7 @@ export function GET() {
 			},
 			RuleWithNoForEachOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7125,7 +7125,7 @@ export function GET() {
 			},
 			RuleWithNoFunctionAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7140,7 +7140,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7155,7 +7155,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalDirnameFilenameOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7174,7 +7174,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalEvalOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7189,7 +7189,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalIsFiniteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7208,7 +7208,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalIsNanOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7227,7 +7227,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalObjectCallsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7242,7 +7242,7 @@ export function GET() {
 			},
 			RuleWithNoHeadElementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7257,7 +7257,7 @@ export function GET() {
 			},
 			RuleWithNoHeadImportInDocumentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7272,7 +7272,7 @@ export function GET() {
 			},
 			RuleWithNoHeaderScopeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7291,7 +7291,7 @@ export function GET() {
 			},
 			RuleWithNoImgElementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7306,7 +7306,7 @@ export function GET() {
 			},
 			RuleWithNoImplicitAnyLetOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7321,7 +7321,7 @@ export function GET() {
 			},
 			RuleWithNoImplicitBooleanOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7340,7 +7340,7 @@ export function GET() {
 			},
 			RuleWithNoImplicitCoercionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7359,7 +7359,7 @@ export function GET() {
 			},
 			RuleWithNoImportAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7374,7 +7374,7 @@ export function GET() {
 			},
 			RuleWithNoImportCyclesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7389,7 +7389,7 @@ export function GET() {
 			},
 			RuleWithNoImportantInKeyframeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7404,7 +7404,7 @@ export function GET() {
 			},
 			RuleWithNoImportantStylesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7423,7 +7423,7 @@ export function GET() {
 			},
 			RuleWithNoInferrableTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7442,7 +7442,7 @@ export function GET() {
 			},
 			RuleWithNoInnerDeclarationsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7457,7 +7457,7 @@ export function GET() {
 			},
 			RuleWithNoInteractiveElementToNoninteractiveRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7480,7 +7480,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidBuiltinInstantiationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7501,7 +7501,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidConstructorSuperOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7516,7 +7516,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidDirectionInLinearGradientOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7535,7 +7535,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidGridAreasOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7550,7 +7550,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidPositionAtImportRuleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7567,7 +7567,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidUseBeforeDeclarationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7584,7 +7584,7 @@ export function GET() {
 			},
 			RuleWithNoIrregularWhitespaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7599,7 +7599,7 @@ export function GET() {
 			},
 			RuleWithNoLabelVarOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7614,7 +7614,7 @@ export function GET() {
 			},
 			RuleWithNoLabelWithoutControlOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7629,7 +7629,7 @@ export function GET() {
 			},
 			RuleWithNoMagicNumbersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7644,7 +7644,7 @@ export function GET() {
 			},
 			RuleWithNoMisleadingCharacterClassOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7665,7 +7665,7 @@ export function GET() {
 			},
 			RuleWithNoMisleadingInstantiatorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7680,7 +7680,7 @@ export function GET() {
 			},
 			RuleWithNoMisplacedAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7695,7 +7695,7 @@ export function GET() {
 			},
 			RuleWithNoMisrefactoredShorthandAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7716,7 +7716,7 @@ export function GET() {
 			},
 			RuleWithNoMissingVarFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7731,7 +7731,7 @@ export function GET() {
 			},
 			RuleWithNoMisusedPromisesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7750,7 +7750,7 @@ export function GET() {
 			},
 			RuleWithNoNamespaceImportOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7765,7 +7765,7 @@ export function GET() {
 			},
 			RuleWithNoNamespaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7780,7 +7780,7 @@ export function GET() {
 			},
 			RuleWithNoNegationElseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7799,7 +7799,7 @@ export function GET() {
 			},
 			RuleWithNoNestedComponentDefinitionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7816,7 +7816,7 @@ export function GET() {
 			},
 			RuleWithNoNestedTernaryOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7831,7 +7831,7 @@ export function GET() {
 			},
 			RuleWithNoNodejsModulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7846,7 +7846,7 @@ export function GET() {
 			},
 			RuleWithNoNonNullAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7865,7 +7865,7 @@ export function GET() {
 			},
 			RuleWithNoNoninteractiveElementInteractionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7884,7 +7884,7 @@ export function GET() {
 			},
 			RuleWithNoNoninteractiveElementToInteractiveRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7907,7 +7907,7 @@ export function GET() {
 			},
 			RuleWithNoNoninteractiveTabindexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7926,7 +7926,7 @@ export function GET() {
 			},
 			RuleWithNoNonoctalDecimalEscapeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7945,7 +7945,7 @@ export function GET() {
 			},
 			RuleWithNoOctalEscapeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7964,7 +7964,7 @@ export function GET() {
 			},
 			RuleWithNoParameterAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7979,7 +7979,7 @@ export function GET() {
 			},
 			RuleWithNoParameterPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7994,7 +7994,7 @@ export function GET() {
 			},
 			RuleWithNoPositiveTabindexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8013,7 +8013,7 @@ export function GET() {
 			},
 			RuleWithNoPrecisionLossOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8028,7 +8028,7 @@ export function GET() {
 			},
 			RuleWithNoPrivateImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8043,7 +8043,7 @@ export function GET() {
 			},
 			RuleWithNoProcessEnvOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8058,7 +8058,7 @@ export function GET() {
 			},
 			RuleWithNoProcessGlobalOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8077,7 +8077,7 @@ export function GET() {
 			},
 			RuleWithNoPrototypeBuiltinsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8096,7 +8096,7 @@ export function GET() {
 			},
 			RuleWithNoQuickfixBiomeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8115,7 +8115,7 @@ export function GET() {
 			},
 			RuleWithNoReExportAllOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8130,7 +8130,7 @@ export function GET() {
 			},
 			RuleWithNoReactPropAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8145,7 +8145,7 @@ export function GET() {
 			},
 			RuleWithNoReactSpecificPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8164,7 +8164,7 @@ export function GET() {
 			},
 			RuleWithNoRedeclareOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8179,7 +8179,7 @@ export function GET() {
 			},
 			RuleWithNoRedundantAltOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8194,7 +8194,7 @@ export function GET() {
 			},
 			RuleWithNoRedundantRolesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8213,7 +8213,7 @@ export function GET() {
 			},
 			RuleWithNoRedundantUseStrictOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8232,7 +8232,7 @@ export function GET() {
 			},
 			RuleWithNoRenderReturnValueOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8247,7 +8247,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8262,7 +8262,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedGlobalsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8277,7 +8277,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8292,7 +8292,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8311,7 +8311,7 @@ export function GET() {
 			},
 			RuleWithNoSecretsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8326,7 +8326,7 @@ export function GET() {
 			},
 			RuleWithNoSelfAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8341,7 +8341,7 @@ export function GET() {
 			},
 			RuleWithNoSelfCompareOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8356,7 +8356,7 @@ export function GET() {
 			},
 			RuleWithNoSetterReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8371,7 +8371,7 @@ export function GET() {
 			},
 			RuleWithNoShadowOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8386,7 +8386,7 @@ export function GET() {
 			},
 			RuleWithNoShadowRestrictedNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8401,7 +8401,7 @@ export function GET() {
 			},
 			RuleWithNoShorthandPropertyOverridesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8418,7 +8418,7 @@ export function GET() {
 			},
 			RuleWithNoShoutyConstantsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8437,7 +8437,7 @@ export function GET() {
 			},
 			RuleWithNoSkippedTestsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8456,7 +8456,7 @@ export function GET() {
 			},
 			RuleWithNoSparseArrayOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8475,7 +8475,7 @@ export function GET() {
 			},
 			RuleWithNoStaticElementInteractionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8492,7 +8492,7 @@ export function GET() {
 			},
 			RuleWithNoStaticOnlyClassOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8507,7 +8507,7 @@ export function GET() {
 			},
 			RuleWithNoStringCaseMismatchOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8526,7 +8526,7 @@ export function GET() {
 			},
 			RuleWithNoSubstrOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8545,7 +8545,7 @@ export function GET() {
 			},
 			RuleWithNoSuspiciousSemicolonInJsxOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8562,7 +8562,7 @@ export function GET() {
 			},
 			RuleWithNoSvgWithoutTitleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8577,7 +8577,7 @@ export function GET() {
 			},
 			RuleWithNoSwitchDeclarationsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8596,7 +8596,7 @@ export function GET() {
 			},
 			RuleWithNoTemplateCurlyInStringOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8611,7 +8611,7 @@ export function GET() {
 			},
 			RuleWithNoThenPropertyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8626,7 +8626,7 @@ export function GET() {
 			},
 			RuleWithNoThisInStaticOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8645,7 +8645,7 @@ export function GET() {
 			},
 			RuleWithNoTsIgnoreOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8664,7 +8664,7 @@ export function GET() {
 			},
 			RuleWithNoUnassignedVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8679,7 +8679,7 @@ export function GET() {
 			},
 			RuleWithNoUndeclaredDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8694,7 +8694,7 @@ export function GET() {
 			},
 			RuleWithNoUndeclaredVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8709,7 +8709,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownAtRuleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8724,7 +8724,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8739,7 +8739,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownMediaFeatureNameOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8754,7 +8754,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownPropertyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8769,7 +8769,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownPseudoClassOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8784,7 +8784,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownPseudoElementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8799,7 +8799,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownTypeSelectorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8814,7 +8814,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownUnitOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8829,7 +8829,7 @@ export function GET() {
 			},
 			RuleWithNoUnmatchableAnbSelectorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8844,7 +8844,7 @@ export function GET() {
 			},
 			RuleWithNoUnreachableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8859,7 +8859,7 @@ export function GET() {
 			},
 			RuleWithNoUnreachableSuperOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8874,7 +8874,7 @@ export function GET() {
 			},
 			RuleWithNoUnresolvedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8889,7 +8889,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeDeclarationMergingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8906,7 +8906,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeFinallyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8921,7 +8921,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeNegationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8940,7 +8940,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeOptionalChainingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8955,7 +8955,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedFunctionParametersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8976,7 +8976,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8995,7 +8995,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedLabelsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9014,7 +9014,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedPrivateClassMembersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9035,7 +9035,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedTemplateLiteralOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9054,7 +9054,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9073,7 +9073,7 @@ export function GET() {
 			},
 			RuleWithNoUnwantedPolyfillioOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9088,7 +9088,7 @@ export function GET() {
 			},
 			RuleWithNoUselessBackrefInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9103,7 +9103,7 @@ export function GET() {
 			},
 			RuleWithNoUselessCatchOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9122,7 +9122,7 @@ export function GET() {
 			},
 			RuleWithNoUselessConstructorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9141,7 +9141,7 @@ export function GET() {
 			},
 			RuleWithNoUselessContinueOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9160,7 +9160,7 @@ export function GET() {
 			},
 			RuleWithNoUselessElseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9179,7 +9179,7 @@ export function GET() {
 			},
 			RuleWithNoUselessEmptyExportOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9198,7 +9198,7 @@ export function GET() {
 			},
 			RuleWithNoUselessEscapeInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9217,7 +9217,7 @@ export function GET() {
 			},
 			RuleWithNoUselessEscapeInStringOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9236,7 +9236,7 @@ export function GET() {
 			},
 			RuleWithNoUselessFragmentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9255,7 +9255,7 @@ export function GET() {
 			},
 			RuleWithNoUselessLabelOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9274,7 +9274,7 @@ export function GET() {
 			},
 			RuleWithNoUselessLoneBlockStatementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9295,7 +9295,7 @@ export function GET() {
 			},
 			RuleWithNoUselessRenameOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9314,7 +9314,7 @@ export function GET() {
 			},
 			RuleWithNoUselessStringConcatOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9333,7 +9333,7 @@ export function GET() {
 			},
 			RuleWithNoUselessStringRawOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9348,7 +9348,7 @@ export function GET() {
 			},
 			RuleWithNoUselessSwitchCaseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9367,7 +9367,7 @@ export function GET() {
 			},
 			RuleWithNoUselessTernaryOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9386,7 +9386,7 @@ export function GET() {
 			},
 			RuleWithNoUselessThisAliasOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9405,7 +9405,7 @@ export function GET() {
 			},
 			RuleWithNoUselessTypeConstraintOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9424,7 +9424,7 @@ export function GET() {
 			},
 			RuleWithNoUselessUndefinedInitializationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9445,7 +9445,7 @@ export function GET() {
 			},
 			RuleWithNoUselessUndefinedOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9464,7 +9464,7 @@ export function GET() {
 			},
 			RuleWithNoValueAtRuleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9479,7 +9479,7 @@ export function GET() {
 			},
 			RuleWithNoVarOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9498,7 +9498,7 @@ export function GET() {
 			},
 			RuleWithNoVoidElementsWithChildrenOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9519,7 +9519,7 @@ export function GET() {
 			},
 			RuleWithNoVoidOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9534,7 +9534,7 @@ export function GET() {
 			},
 			RuleWithNoVoidTypeReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9549,7 +9549,7 @@ export function GET() {
 			},
 			RuleWithNoVueReservedPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9564,7 +9564,7 @@ export function GET() {
 			},
 			RuleWithNoWithOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9579,7 +9579,7 @@ export function GET() {
 			},
 			RuleWithNoYodaExpressionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9598,7 +9598,7 @@ export function GET() {
 			},
 			RuleWithUseAdjacentGetterSetterOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9613,7 +9613,7 @@ export function GET() {
 			},
 			RuleWithUseAdjacentOverloadSignaturesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9630,7 +9630,7 @@ export function GET() {
 			},
 			RuleWithUseAltTextOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9645,7 +9645,7 @@ export function GET() {
 			},
 			RuleWithUseAnchorContentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9664,7 +9664,7 @@ export function GET() {
 			},
 			RuleWithUseAriaActivedescendantWithTabindexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9687,7 +9687,7 @@ export function GET() {
 			},
 			RuleWithUseAriaPropsForRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9702,7 +9702,7 @@ export function GET() {
 			},
 			RuleWithUseAriaPropsSupportedByRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9719,7 +9719,7 @@ export function GET() {
 			},
 			RuleWithUseArrayLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9738,7 +9738,7 @@ export function GET() {
 			},
 			RuleWithUseArrowFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9757,7 +9757,7 @@ export function GET() {
 			},
 			RuleWithUseAsConstAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9776,7 +9776,7 @@ export function GET() {
 			},
 			RuleWithUseAtIndexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9795,7 +9795,7 @@ export function GET() {
 			},
 			RuleWithUseAwaitOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9810,7 +9810,7 @@ export function GET() {
 			},
 			RuleWithUseBlockStatementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9829,7 +9829,7 @@ export function GET() {
 			},
 			RuleWithUseButtonTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9844,7 +9844,7 @@ export function GET() {
 			},
 			RuleWithUseCollapsedElseIfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9863,7 +9863,7 @@ export function GET() {
 			},
 			RuleWithUseCollapsedIfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9882,7 +9882,7 @@ export function GET() {
 			},
 			RuleWithUseComponentExportOnlyModulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9899,7 +9899,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentArrayTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9918,7 +9918,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentBuiltinInstantiationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9941,7 +9941,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentCurlyBracesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9960,7 +9960,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentMemberAccessibilityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9977,7 +9977,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentObjectDefinitionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9998,7 +9998,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentResponseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10017,7 +10017,7 @@ export function GET() {
 			},
 			RuleWithUseConstOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10036,7 +10036,7 @@ export function GET() {
 			},
 			RuleWithUseDateNowOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10055,7 +10055,7 @@ export function GET() {
 			},
 			RuleWithUseDefaultParameterLastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10074,7 +10074,7 @@ export function GET() {
 			},
 			RuleWithUseDefaultSwitchClauseLastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10091,7 +10091,7 @@ export function GET() {
 			},
 			RuleWithUseDefaultSwitchClauseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10106,7 +10106,7 @@ export function GET() {
 			},
 			RuleWithUseDeprecatedReasonOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10121,7 +10121,7 @@ export function GET() {
 			},
 			RuleWithUseEnumInitializersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10140,7 +10140,7 @@ export function GET() {
 			},
 			RuleWithUseErrorMessageOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10155,7 +10155,7 @@ export function GET() {
 			},
 			RuleWithUseExhaustiveDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10174,7 +10174,7 @@ export function GET() {
 			},
 			RuleWithUseExhaustiveSwitchCasesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10193,7 +10193,7 @@ export function GET() {
 			},
 			RuleWithUseExplicitLengthCheckOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10212,7 +10212,7 @@ export function GET() {
 			},
 			RuleWithUseExplicitTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10227,7 +10227,7 @@ export function GET() {
 			},
 			RuleWithUseExponentiationOperatorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10246,7 +10246,7 @@ export function GET() {
 			},
 			RuleWithUseExportTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10265,7 +10265,7 @@ export function GET() {
 			},
 			RuleWithUseExportsLastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10280,7 +10280,7 @@ export function GET() {
 			},
 			RuleWithUseFilenamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10295,7 +10295,7 @@ export function GET() {
 			},
 			RuleWithUseFlatMapOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10314,7 +10314,7 @@ export function GET() {
 			},
 			RuleWithUseFocusableInteractiveOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10329,7 +10329,7 @@ export function GET() {
 			},
 			RuleWithUseForComponentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10344,7 +10344,7 @@ export function GET() {
 			},
 			RuleWithUseForOfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10359,7 +10359,7 @@ export function GET() {
 			},
 			RuleWithUseFragmentSyntaxOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10378,7 +10378,7 @@ export function GET() {
 			},
 			RuleWithUseGenericFontNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10393,7 +10393,7 @@ export function GET() {
 			},
 			RuleWithUseGetterReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10408,7 +10408,7 @@ export function GET() {
 			},
 			RuleWithUseGoogleFontDisplayOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10423,7 +10423,7 @@ export function GET() {
 			},
 			RuleWithUseGoogleFontPreconnectOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10442,7 +10442,7 @@ export function GET() {
 			},
 			RuleWithUseGuardForInOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10457,7 +10457,7 @@ export function GET() {
 			},
 			RuleWithUseHeadingContentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10472,7 +10472,7 @@ export function GET() {
 			},
 			RuleWithUseHookAtTopLevelOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10487,7 +10487,7 @@ export function GET() {
 			},
 			RuleWithUseHtmlLangOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10502,7 +10502,7 @@ export function GET() {
 			},
 			RuleWithUseIframeTitleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10517,7 +10517,7 @@ export function GET() {
 			},
 			RuleWithUseImportExtensionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10536,7 +10536,7 @@ export function GET() {
 			},
 			RuleWithUseImportTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10555,7 +10555,7 @@ export function GET() {
 			},
 			RuleWithUseIndexOfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10574,7 +10574,7 @@ export function GET() {
 			},
 			RuleWithUseIsArrayOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10593,7 +10593,7 @@ export function GET() {
 			},
 			RuleWithUseIsNanOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10612,7 +10612,7 @@ export function GET() {
 			},
 			RuleWithUseIterableCallbackReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10627,7 +10627,7 @@ export function GET() {
 			},
 			RuleWithUseJsonImportAttributeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10646,7 +10646,7 @@ export function GET() {
 			},
 			RuleWithUseJsxKeyInIterableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10661,7 +10661,7 @@ export function GET() {
 			},
 			RuleWithUseKeyWithClickEventsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10676,7 +10676,7 @@ export function GET() {
 			},
 			RuleWithUseKeyWithMouseEventsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10691,7 +10691,7 @@ export function GET() {
 			},
 			RuleWithUseLiteralEnumMembersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10706,7 +10706,7 @@ export function GET() {
 			},
 			RuleWithUseLiteralKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10725,7 +10725,7 @@ export function GET() {
 			},
 			RuleWithUseMediaCaptionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10740,7 +10740,7 @@ export function GET() {
 			},
 			RuleWithUseNamedOperationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10759,7 +10759,7 @@ export function GET() {
 			},
 			RuleWithUseNamespaceKeywordOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10778,7 +10778,7 @@ export function GET() {
 			},
 			RuleWithUseNamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10793,7 +10793,7 @@ export function GET() {
 			},
 			RuleWithUseNodeAssertStrictOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10812,7 +10812,7 @@ export function GET() {
 			},
 			RuleWithUseNodejsImportProtocolOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10831,7 +10831,7 @@ export function GET() {
 			},
 			RuleWithUseNumberNamespaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10850,7 +10850,7 @@ export function GET() {
 			},
 			RuleWithUseNumberToFixedDigitsArgumentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10871,7 +10871,7 @@ export function GET() {
 			},
 			RuleWithUseNumericLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10890,7 +10890,7 @@ export function GET() {
 			},
 			RuleWithUseNumericSeparatorsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10909,7 +10909,7 @@ export function GET() {
 			},
 			RuleWithUseObjectSpreadOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10928,7 +10928,7 @@ export function GET() {
 			},
 			RuleWithUseOptionalChainOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10947,7 +10947,7 @@ export function GET() {
 			},
 			RuleWithUseParseIntRadixOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10966,7 +10966,7 @@ export function GET() {
 			},
 			RuleWithUseReadonlyClassPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10987,7 +10987,7 @@ export function GET() {
 			},
 			RuleWithUseRegexLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11006,7 +11006,7 @@ export function GET() {
 			},
 			RuleWithUseSelfClosingElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11025,7 +11025,7 @@ export function GET() {
 			},
 			RuleWithUseSemanticElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11040,7 +11040,7 @@ export function GET() {
 			},
 			RuleWithUseShorthandAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11059,7 +11059,7 @@ export function GET() {
 			},
 			RuleWithUseShorthandFunctionTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11078,7 +11078,7 @@ export function GET() {
 			},
 			RuleWithUseSimpleNumberKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11097,7 +11097,7 @@ export function GET() {
 			},
 			RuleWithUseSimplifiedLogicExpressionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11118,7 +11118,7 @@ export function GET() {
 			},
 			RuleWithUseSingleJsDocAsteriskOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11137,7 +11137,7 @@ export function GET() {
 			},
 			RuleWithUseSingleVarDeclaratorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11156,7 +11156,7 @@ export function GET() {
 			},
 			RuleWithUseSortedClassesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11175,7 +11175,7 @@ export function GET() {
 			},
 			RuleWithUseStrictModeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11194,7 +11194,7 @@ export function GET() {
 			},
 			RuleWithUseSymbolDescriptionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11209,7 +11209,7 @@ export function GET() {
 			},
 			RuleWithUseTemplateOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11228,7 +11228,7 @@ export function GET() {
 			},
 			RuleWithUseThrowNewErrorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11247,7 +11247,7 @@ export function GET() {
 			},
 			RuleWithUseThrowOnlyErrorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11262,7 +11262,7 @@ export function GET() {
 			},
 			RuleWithUseTopLevelRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11277,7 +11277,7 @@ export function GET() {
 			},
 			RuleWithUseTrimStartEndOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11296,7 +11296,7 @@ export function GET() {
 			},
 			RuleWithUseUnifiedTypeSignatureOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11315,7 +11315,7 @@ export function GET() {
 			},
 			RuleWithUseUniqueElementIdsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11330,7 +11330,7 @@ export function GET() {
 			},
 			RuleWithUseValidAnchorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11345,7 +11345,7 @@ export function GET() {
 			},
 			RuleWithUseValidAriaPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11364,7 +11364,7 @@ export function GET() {
 			},
 			RuleWithUseValidAriaRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11383,7 +11383,7 @@ export function GET() {
 			},
 			RuleWithUseValidAriaValuesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11398,7 +11398,7 @@ export function GET() {
 			},
 			RuleWithUseValidAutocompleteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11413,7 +11413,7 @@ export function GET() {
 			},
 			RuleWithUseValidForDirectionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11428,7 +11428,7 @@ export function GET() {
 			},
 			RuleWithUseValidLangOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11443,7 +11443,7 @@ export function GET() {
 			},
 			RuleWithUseValidTypeofOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11462,7 +11462,7 @@ export function GET() {
 			},
 			RuleWithUseWhileOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11481,7 +11481,7 @@ export function GET() {
 			},
 			RuleWithUseYieldOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",

--- a/src/pages/schemas/2.1.4/schema.json.js
+++ b/src/pages/schemas/2.1.4/schema.json.js
@@ -5795,7 +5795,7 @@ export function GET() {
 			RuleAssistPlainConfiguration: { type: "string", enum: ["off", "on"] },
 			RuleAssistWithOptions_for_OrganizeImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5810,7 +5810,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_UseSortedAttributesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5825,7 +5825,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_UseSortedKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5840,7 +5840,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_UseSortedPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5951,7 +5951,7 @@ export function GET() {
 			},
 			RuleWithNoAccessKeyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -5970,7 +5970,7 @@ export function GET() {
 			},
 			RuleWithNoAccumulatingSpreadOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5985,7 +5985,7 @@ export function GET() {
 			},
 			RuleWithNoAdjacentSpacesInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6004,7 +6004,7 @@ export function GET() {
 			},
 			RuleWithNoAlertOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6019,7 +6019,7 @@ export function GET() {
 			},
 			RuleWithNoApproximativeNumericConstantOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6040,7 +6040,7 @@ export function GET() {
 			},
 			RuleWithNoArgumentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6055,7 +6055,7 @@ export function GET() {
 			},
 			RuleWithNoAriaHiddenOnFocusableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6074,7 +6074,7 @@ export function GET() {
 			},
 			RuleWithNoAriaUnsupportedElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6093,7 +6093,7 @@ export function GET() {
 			},
 			RuleWithNoArrayIndexKeyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6108,7 +6108,7 @@ export function GET() {
 			},
 			RuleWithNoAssignInExpressionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6123,7 +6123,7 @@ export function GET() {
 			},
 			RuleWithNoAsyncPromiseExecutorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6138,7 +6138,7 @@ export function GET() {
 			},
 			RuleWithNoAutofocusOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6157,7 +6157,7 @@ export function GET() {
 			},
 			RuleWithNoAwaitInLoopOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6172,7 +6172,7 @@ export function GET() {
 			},
 			RuleWithNoBannedTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6191,7 +6191,7 @@ export function GET() {
 			},
 			RuleWithNoBarrelFileOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6206,7 +6206,7 @@ export function GET() {
 			},
 			RuleWithNoBitwiseOperatorsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6221,7 +6221,7 @@ export function GET() {
 			},
 			RuleWithNoBlankTargetOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6240,7 +6240,7 @@ export function GET() {
 			},
 			RuleWithNoCatchAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6255,7 +6255,7 @@ export function GET() {
 			},
 			RuleWithNoChildrenPropOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6270,7 +6270,7 @@ export function GET() {
 			},
 			RuleWithNoClassAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6285,7 +6285,7 @@ export function GET() {
 			},
 			RuleWithNoCommaOperatorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6300,7 +6300,7 @@ export function GET() {
 			},
 			RuleWithNoCommentTextOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6319,7 +6319,7 @@ export function GET() {
 			},
 			RuleWithNoCommonJsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6334,7 +6334,7 @@ export function GET() {
 			},
 			RuleWithNoCompareNegZeroOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6353,7 +6353,7 @@ export function GET() {
 			},
 			RuleWithNoConfusingLabelsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6368,7 +6368,7 @@ export function GET() {
 			},
 			RuleWithNoConfusingVoidTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6387,7 +6387,7 @@ export function GET() {
 			},
 			RuleWithNoConsoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6406,7 +6406,7 @@ export function GET() {
 			},
 			RuleWithNoConstAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6425,7 +6425,7 @@ export function GET() {
 			},
 			RuleWithNoConstEnumOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6444,7 +6444,7 @@ export function GET() {
 			},
 			RuleWithNoConstantBinaryExpressionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6461,7 +6461,7 @@ export function GET() {
 			},
 			RuleWithNoConstantConditionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6476,7 +6476,7 @@ export function GET() {
 			},
 			RuleWithNoConstantMathMinMaxClampOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6495,7 +6495,7 @@ export function GET() {
 			},
 			RuleWithNoConstructorReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6510,7 +6510,7 @@ export function GET() {
 			},
 			RuleWithNoControlCharactersInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6527,7 +6527,7 @@ export function GET() {
 			},
 			RuleWithNoDangerouslySetInnerHtmlOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6542,7 +6542,7 @@ export function GET() {
 			},
 			RuleWithNoDangerouslySetInnerHtmlWithChildrenOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6561,7 +6561,7 @@ export function GET() {
 			},
 			RuleWithNoDebuggerOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6580,7 +6580,7 @@ export function GET() {
 			},
 			RuleWithNoDefaultExportOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6595,7 +6595,7 @@ export function GET() {
 			},
 			RuleWithNoDeleteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6614,7 +6614,7 @@ export function GET() {
 			},
 			RuleWithNoDescendingSpecificityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6629,7 +6629,7 @@ export function GET() {
 			},
 			RuleWithNoDestructuredPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6644,7 +6644,7 @@ export function GET() {
 			},
 			RuleWithNoDistractingElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6663,7 +6663,7 @@ export function GET() {
 			},
 			RuleWithNoDocumentCookieOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6678,7 +6678,7 @@ export function GET() {
 			},
 			RuleWithNoDocumentImportInPageOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6693,7 +6693,7 @@ export function GET() {
 			},
 			RuleWithNoDoneCallbackOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6708,7 +6708,7 @@ export function GET() {
 			},
 			RuleWithNoDoubleEqualsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6727,7 +6727,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateAtImportRulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6742,7 +6742,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateCaseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6757,7 +6757,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateClassMembersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6772,7 +6772,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateCustomPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6789,7 +6789,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateElseIfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6804,7 +6804,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateFieldsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6819,7 +6819,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateFontNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6834,7 +6834,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateJsxPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6849,7 +6849,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateObjectKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6864,7 +6864,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateParametersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6879,7 +6879,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicatePropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6894,7 +6894,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateSelectorsKeyframeBlockOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6913,7 +6913,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateTestHooksOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6928,7 +6928,7 @@ export function GET() {
 			},
 			RuleWithNoDynamicNamespaceImportAccessOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6945,7 +6945,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyBlockOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6960,7 +6960,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyBlockStatementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6975,7 +6975,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyCharacterClassInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6992,7 +6992,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyInterfaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7011,7 +7011,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyPatternOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7026,7 +7026,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyTypeParametersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7041,7 +7041,7 @@ export function GET() {
 			},
 			RuleWithNoEnumOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7056,7 +7056,7 @@ export function GET() {
 			},
 			RuleWithNoEvolvingTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7071,7 +7071,7 @@ export function GET() {
 			},
 			RuleWithNoExcessiveCognitiveComplexityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7088,7 +7088,7 @@ export function GET() {
 			},
 			RuleWithNoExcessiveLinesPerFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7105,7 +7105,7 @@ export function GET() {
 			},
 			RuleWithNoExcessiveNestedTestSuitesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7122,7 +7122,7 @@ export function GET() {
 			},
 			RuleWithNoExplicitAnyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7137,7 +7137,7 @@ export function GET() {
 			},
 			RuleWithNoExportedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7152,7 +7152,7 @@ export function GET() {
 			},
 			RuleWithNoExportsInTestOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7167,7 +7167,7 @@ export function GET() {
 			},
 			RuleWithNoExtraBooleanCastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7186,7 +7186,7 @@ export function GET() {
 			},
 			RuleWithNoExtraNonNullAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7205,7 +7205,7 @@ export function GET() {
 			},
 			RuleWithNoFallthroughSwitchClauseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7220,7 +7220,7 @@ export function GET() {
 			},
 			RuleWithNoFlatMapIdentityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7239,7 +7239,7 @@ export function GET() {
 			},
 			RuleWithNoFloatingPromisesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7258,7 +7258,7 @@ export function GET() {
 			},
 			RuleWithNoFocusedTestsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7277,7 +7277,7 @@ export function GET() {
 			},
 			RuleWithNoForEachOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7292,7 +7292,7 @@ export function GET() {
 			},
 			RuleWithNoFunctionAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7307,7 +7307,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7322,7 +7322,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalDirnameFilenameOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7341,7 +7341,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalEvalOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7356,7 +7356,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalIsFiniteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7375,7 +7375,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalIsNanOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7394,7 +7394,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalObjectCallsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7409,7 +7409,7 @@ export function GET() {
 			},
 			RuleWithNoHeadElementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7424,7 +7424,7 @@ export function GET() {
 			},
 			RuleWithNoHeadImportInDocumentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7439,7 +7439,7 @@ export function GET() {
 			},
 			RuleWithNoHeaderScopeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7458,7 +7458,7 @@ export function GET() {
 			},
 			RuleWithNoImgElementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7473,7 +7473,7 @@ export function GET() {
 			},
 			RuleWithNoImplicitAnyLetOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7488,7 +7488,7 @@ export function GET() {
 			},
 			RuleWithNoImplicitBooleanOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7507,7 +7507,7 @@ export function GET() {
 			},
 			RuleWithNoImplicitCoercionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7526,7 +7526,7 @@ export function GET() {
 			},
 			RuleWithNoImportAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7541,7 +7541,7 @@ export function GET() {
 			},
 			RuleWithNoImportCyclesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7556,7 +7556,7 @@ export function GET() {
 			},
 			RuleWithNoImportantInKeyframeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7571,7 +7571,7 @@ export function GET() {
 			},
 			RuleWithNoImportantStylesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7590,7 +7590,7 @@ export function GET() {
 			},
 			RuleWithNoInferrableTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7609,7 +7609,7 @@ export function GET() {
 			},
 			RuleWithNoInnerDeclarationsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7624,7 +7624,7 @@ export function GET() {
 			},
 			RuleWithNoInteractiveElementToNoninteractiveRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7647,7 +7647,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidBuiltinInstantiationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7668,7 +7668,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidConstructorSuperOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7683,7 +7683,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidDirectionInLinearGradientOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7702,7 +7702,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidGridAreasOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7717,7 +7717,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidPositionAtImportRuleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7734,7 +7734,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidUseBeforeDeclarationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7751,7 +7751,7 @@ export function GET() {
 			},
 			RuleWithNoIrregularWhitespaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7766,7 +7766,7 @@ export function GET() {
 			},
 			RuleWithNoLabelVarOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7781,7 +7781,7 @@ export function GET() {
 			},
 			RuleWithNoLabelWithoutControlOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7796,7 +7796,7 @@ export function GET() {
 			},
 			RuleWithNoMagicNumbersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7811,7 +7811,7 @@ export function GET() {
 			},
 			RuleWithNoMisleadingCharacterClassOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7832,7 +7832,7 @@ export function GET() {
 			},
 			RuleWithNoMisleadingInstantiatorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7847,7 +7847,7 @@ export function GET() {
 			},
 			RuleWithNoMisplacedAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7862,7 +7862,7 @@ export function GET() {
 			},
 			RuleWithNoMisrefactoredShorthandAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7883,7 +7883,7 @@ export function GET() {
 			},
 			RuleWithNoMissingVarFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7898,7 +7898,7 @@ export function GET() {
 			},
 			RuleWithNoMisusedPromisesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7917,7 +7917,7 @@ export function GET() {
 			},
 			RuleWithNoNamespaceImportOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7932,7 +7932,7 @@ export function GET() {
 			},
 			RuleWithNoNamespaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7947,7 +7947,7 @@ export function GET() {
 			},
 			RuleWithNoNegationElseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7966,7 +7966,7 @@ export function GET() {
 			},
 			RuleWithNoNestedComponentDefinitionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7983,7 +7983,7 @@ export function GET() {
 			},
 			RuleWithNoNestedTernaryOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7998,7 +7998,7 @@ export function GET() {
 			},
 			RuleWithNoNodejsModulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8013,7 +8013,7 @@ export function GET() {
 			},
 			RuleWithNoNonNullAssertedOptionalChainOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8030,7 +8030,7 @@ export function GET() {
 			},
 			RuleWithNoNonNullAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8049,7 +8049,7 @@ export function GET() {
 			},
 			RuleWithNoNoninteractiveElementInteractionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8068,7 +8068,7 @@ export function GET() {
 			},
 			RuleWithNoNoninteractiveElementToInteractiveRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8091,7 +8091,7 @@ export function GET() {
 			},
 			RuleWithNoNoninteractiveTabindexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8110,7 +8110,7 @@ export function GET() {
 			},
 			RuleWithNoNonoctalDecimalEscapeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8129,7 +8129,7 @@ export function GET() {
 			},
 			RuleWithNoOctalEscapeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8148,7 +8148,7 @@ export function GET() {
 			},
 			RuleWithNoParameterAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8163,7 +8163,7 @@ export function GET() {
 			},
 			RuleWithNoParameterPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8178,7 +8178,7 @@ export function GET() {
 			},
 			RuleWithNoPositiveTabindexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8197,7 +8197,7 @@ export function GET() {
 			},
 			RuleWithNoPrecisionLossOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8212,7 +8212,7 @@ export function GET() {
 			},
 			RuleWithNoPrivateImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8227,7 +8227,7 @@ export function GET() {
 			},
 			RuleWithNoProcessEnvOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8242,7 +8242,7 @@ export function GET() {
 			},
 			RuleWithNoProcessGlobalOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8261,7 +8261,7 @@ export function GET() {
 			},
 			RuleWithNoPrototypeBuiltinsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8280,7 +8280,7 @@ export function GET() {
 			},
 			RuleWithNoQuickfixBiomeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8299,7 +8299,7 @@ export function GET() {
 			},
 			RuleWithNoQwikUseVisibleTaskOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8314,7 +8314,7 @@ export function GET() {
 			},
 			RuleWithNoReExportAllOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8329,7 +8329,7 @@ export function GET() {
 			},
 			RuleWithNoReactPropAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8344,7 +8344,7 @@ export function GET() {
 			},
 			RuleWithNoReactSpecificPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8363,7 +8363,7 @@ export function GET() {
 			},
 			RuleWithNoRedeclareOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8378,7 +8378,7 @@ export function GET() {
 			},
 			RuleWithNoRedundantAltOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8393,7 +8393,7 @@ export function GET() {
 			},
 			RuleWithNoRedundantRolesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8412,7 +8412,7 @@ export function GET() {
 			},
 			RuleWithNoRedundantUseStrictOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8431,7 +8431,7 @@ export function GET() {
 			},
 			RuleWithNoRenderReturnValueOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8446,7 +8446,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8461,7 +8461,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedGlobalsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8476,7 +8476,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8491,7 +8491,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8510,7 +8510,7 @@ export function GET() {
 			},
 			RuleWithNoSecretsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8525,7 +8525,7 @@ export function GET() {
 			},
 			RuleWithNoSelfAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8540,7 +8540,7 @@ export function GET() {
 			},
 			RuleWithNoSelfCompareOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8555,7 +8555,7 @@ export function GET() {
 			},
 			RuleWithNoSetterReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8570,7 +8570,7 @@ export function GET() {
 			},
 			RuleWithNoShadowOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8585,7 +8585,7 @@ export function GET() {
 			},
 			RuleWithNoShadowRestrictedNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8600,7 +8600,7 @@ export function GET() {
 			},
 			RuleWithNoShorthandPropertyOverridesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8617,7 +8617,7 @@ export function GET() {
 			},
 			RuleWithNoShoutyConstantsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8636,7 +8636,7 @@ export function GET() {
 			},
 			RuleWithNoSkippedTestsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8655,7 +8655,7 @@ export function GET() {
 			},
 			RuleWithNoSparseArrayOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8674,7 +8674,7 @@ export function GET() {
 			},
 			RuleWithNoStaticElementInteractionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8691,7 +8691,7 @@ export function GET() {
 			},
 			RuleWithNoStaticOnlyClassOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8706,7 +8706,7 @@ export function GET() {
 			},
 			RuleWithNoStringCaseMismatchOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8725,7 +8725,7 @@ export function GET() {
 			},
 			RuleWithNoSubstrOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8744,7 +8744,7 @@ export function GET() {
 			},
 			RuleWithNoSuspiciousSemicolonInJsxOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8761,7 +8761,7 @@ export function GET() {
 			},
 			RuleWithNoSvgWithoutTitleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8776,7 +8776,7 @@ export function GET() {
 			},
 			RuleWithNoSwitchDeclarationsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8795,7 +8795,7 @@ export function GET() {
 			},
 			RuleWithNoTemplateCurlyInStringOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8810,7 +8810,7 @@ export function GET() {
 			},
 			RuleWithNoThenPropertyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8825,7 +8825,7 @@ export function GET() {
 			},
 			RuleWithNoThisInStaticOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8844,7 +8844,7 @@ export function GET() {
 			},
 			RuleWithNoTsIgnoreOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8863,7 +8863,7 @@ export function GET() {
 			},
 			RuleWithNoUnassignedVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8878,7 +8878,7 @@ export function GET() {
 			},
 			RuleWithNoUndeclaredDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8893,7 +8893,7 @@ export function GET() {
 			},
 			RuleWithNoUndeclaredVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8908,7 +8908,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownAtRuleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8923,7 +8923,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8938,7 +8938,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownMediaFeatureNameOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8953,7 +8953,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownPropertyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8968,7 +8968,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownPseudoClassOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8983,7 +8983,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownPseudoElementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8998,7 +8998,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownTypeSelectorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9013,7 +9013,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownUnitOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9028,7 +9028,7 @@ export function GET() {
 			},
 			RuleWithNoUnmatchableAnbSelectorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9043,7 +9043,7 @@ export function GET() {
 			},
 			RuleWithNoUnnecessaryConditionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9058,7 +9058,7 @@ export function GET() {
 			},
 			RuleWithNoUnreachableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9073,7 +9073,7 @@ export function GET() {
 			},
 			RuleWithNoUnreachableSuperOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9088,7 +9088,7 @@ export function GET() {
 			},
 			RuleWithNoUnresolvedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9103,7 +9103,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeDeclarationMergingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9120,7 +9120,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeFinallyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9135,7 +9135,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeNegationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9154,7 +9154,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeOptionalChainingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9169,7 +9169,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedFunctionParametersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9190,7 +9190,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9209,7 +9209,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedLabelsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9228,7 +9228,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedPrivateClassMembersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9249,7 +9249,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedTemplateLiteralOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9268,7 +9268,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9287,7 +9287,7 @@ export function GET() {
 			},
 			RuleWithNoUnwantedPolyfillioOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9302,7 +9302,7 @@ export function GET() {
 			},
 			RuleWithNoUselessBackrefInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9317,7 +9317,7 @@ export function GET() {
 			},
 			RuleWithNoUselessCatchOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9336,7 +9336,7 @@ export function GET() {
 			},
 			RuleWithNoUselessConstructorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9355,7 +9355,7 @@ export function GET() {
 			},
 			RuleWithNoUselessContinueOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9374,7 +9374,7 @@ export function GET() {
 			},
 			RuleWithNoUselessElseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9393,7 +9393,7 @@ export function GET() {
 			},
 			RuleWithNoUselessEmptyExportOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9412,7 +9412,7 @@ export function GET() {
 			},
 			RuleWithNoUselessEscapeInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9431,7 +9431,7 @@ export function GET() {
 			},
 			RuleWithNoUselessEscapeInStringOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9450,7 +9450,7 @@ export function GET() {
 			},
 			RuleWithNoUselessFragmentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9469,7 +9469,7 @@ export function GET() {
 			},
 			RuleWithNoUselessLabelOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9488,7 +9488,7 @@ export function GET() {
 			},
 			RuleWithNoUselessLoneBlockStatementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9509,7 +9509,7 @@ export function GET() {
 			},
 			RuleWithNoUselessRenameOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9528,7 +9528,7 @@ export function GET() {
 			},
 			RuleWithNoUselessStringConcatOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9547,7 +9547,7 @@ export function GET() {
 			},
 			RuleWithNoUselessStringRawOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9562,7 +9562,7 @@ export function GET() {
 			},
 			RuleWithNoUselessSwitchCaseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9581,7 +9581,7 @@ export function GET() {
 			},
 			RuleWithNoUselessTernaryOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9600,7 +9600,7 @@ export function GET() {
 			},
 			RuleWithNoUselessThisAliasOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9619,7 +9619,7 @@ export function GET() {
 			},
 			RuleWithNoUselessTypeConstraintOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9638,7 +9638,7 @@ export function GET() {
 			},
 			RuleWithNoUselessUndefinedInitializationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9659,7 +9659,7 @@ export function GET() {
 			},
 			RuleWithNoUselessUndefinedOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9678,7 +9678,7 @@ export function GET() {
 			},
 			RuleWithNoValueAtRuleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9693,7 +9693,7 @@ export function GET() {
 			},
 			RuleWithNoVarOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9712,7 +9712,7 @@ export function GET() {
 			},
 			RuleWithNoVoidElementsWithChildrenOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9733,7 +9733,7 @@ export function GET() {
 			},
 			RuleWithNoVoidOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9748,7 +9748,7 @@ export function GET() {
 			},
 			RuleWithNoVoidTypeReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9763,7 +9763,7 @@ export function GET() {
 			},
 			RuleWithNoVueDataObjectDeclarationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9784,7 +9784,7 @@ export function GET() {
 			},
 			RuleWithNoVueReservedKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9799,7 +9799,7 @@ export function GET() {
 			},
 			RuleWithNoVueReservedPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9814,7 +9814,7 @@ export function GET() {
 			},
 			RuleWithNoWithOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9829,7 +9829,7 @@ export function GET() {
 			},
 			RuleWithNoYodaExpressionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9848,7 +9848,7 @@ export function GET() {
 			},
 			RuleWithUseAdjacentGetterSetterOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9863,7 +9863,7 @@ export function GET() {
 			},
 			RuleWithUseAdjacentOverloadSignaturesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9880,7 +9880,7 @@ export function GET() {
 			},
 			RuleWithUseAltTextOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9895,7 +9895,7 @@ export function GET() {
 			},
 			RuleWithUseAnchorContentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9914,7 +9914,7 @@ export function GET() {
 			},
 			RuleWithUseAnchorHrefOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9929,7 +9929,7 @@ export function GET() {
 			},
 			RuleWithUseAriaActivedescendantWithTabindexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9952,7 +9952,7 @@ export function GET() {
 			},
 			RuleWithUseAriaPropsForRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9967,7 +9967,7 @@ export function GET() {
 			},
 			RuleWithUseAriaPropsSupportedByRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9984,7 +9984,7 @@ export function GET() {
 			},
 			RuleWithUseArrayLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10003,7 +10003,7 @@ export function GET() {
 			},
 			RuleWithUseArrowFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10022,7 +10022,7 @@ export function GET() {
 			},
 			RuleWithUseAsConstAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10041,7 +10041,7 @@ export function GET() {
 			},
 			RuleWithUseAtIndexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10060,7 +10060,7 @@ export function GET() {
 			},
 			RuleWithUseAwaitOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10075,7 +10075,7 @@ export function GET() {
 			},
 			RuleWithUseBlockStatementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10094,7 +10094,7 @@ export function GET() {
 			},
 			RuleWithUseButtonTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10109,7 +10109,7 @@ export function GET() {
 			},
 			RuleWithUseCollapsedElseIfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10128,7 +10128,7 @@ export function GET() {
 			},
 			RuleWithUseCollapsedIfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10147,7 +10147,7 @@ export function GET() {
 			},
 			RuleWithUseComponentExportOnlyModulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10164,7 +10164,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentArrayTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10183,7 +10183,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentBuiltinInstantiationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10206,7 +10206,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentCurlyBracesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10225,7 +10225,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentMemberAccessibilityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10242,7 +10242,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentObjectDefinitionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10263,7 +10263,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentResponseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10282,7 +10282,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentTypeDefinitionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10303,7 +10303,7 @@ export function GET() {
 			},
 			RuleWithUseConstOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10322,7 +10322,7 @@ export function GET() {
 			},
 			RuleWithUseDateNowOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10341,7 +10341,7 @@ export function GET() {
 			},
 			RuleWithUseDefaultParameterLastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10360,7 +10360,7 @@ export function GET() {
 			},
 			RuleWithUseDefaultSwitchClauseLastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10377,7 +10377,7 @@ export function GET() {
 			},
 			RuleWithUseDefaultSwitchClauseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10392,7 +10392,7 @@ export function GET() {
 			},
 			RuleWithUseDeprecatedReasonOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10407,7 +10407,7 @@ export function GET() {
 			},
 			RuleWithUseEnumInitializersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10426,7 +10426,7 @@ export function GET() {
 			},
 			RuleWithUseErrorMessageOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10441,7 +10441,7 @@ export function GET() {
 			},
 			RuleWithUseExhaustiveDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10460,7 +10460,7 @@ export function GET() {
 			},
 			RuleWithUseExhaustiveSwitchCasesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10479,7 +10479,7 @@ export function GET() {
 			},
 			RuleWithUseExplicitLengthCheckOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10498,7 +10498,7 @@ export function GET() {
 			},
 			RuleWithUseExplicitTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10513,7 +10513,7 @@ export function GET() {
 			},
 			RuleWithUseExponentiationOperatorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10532,7 +10532,7 @@ export function GET() {
 			},
 			RuleWithUseExportTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10551,7 +10551,7 @@ export function GET() {
 			},
 			RuleWithUseExportsLastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10566,7 +10566,7 @@ export function GET() {
 			},
 			RuleWithUseFilenamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10581,7 +10581,7 @@ export function GET() {
 			},
 			RuleWithUseFlatMapOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10600,7 +10600,7 @@ export function GET() {
 			},
 			RuleWithUseFocusableInteractiveOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10615,7 +10615,7 @@ export function GET() {
 			},
 			RuleWithUseForComponentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10630,7 +10630,7 @@ export function GET() {
 			},
 			RuleWithUseForOfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10645,7 +10645,7 @@ export function GET() {
 			},
 			RuleWithUseFragmentSyntaxOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10664,7 +10664,7 @@ export function GET() {
 			},
 			RuleWithUseGenericFontNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10679,7 +10679,7 @@ export function GET() {
 			},
 			RuleWithUseGetterReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10694,7 +10694,7 @@ export function GET() {
 			},
 			RuleWithUseGoogleFontDisplayOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10709,7 +10709,7 @@ export function GET() {
 			},
 			RuleWithUseGoogleFontPreconnectOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10728,7 +10728,7 @@ export function GET() {
 			},
 			RuleWithUseGuardForInOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10743,7 +10743,7 @@ export function GET() {
 			},
 			RuleWithUseHeadingContentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10758,7 +10758,7 @@ export function GET() {
 			},
 			RuleWithUseHookAtTopLevelOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10773,7 +10773,7 @@ export function GET() {
 			},
 			RuleWithUseHtmlLangOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10788,7 +10788,7 @@ export function GET() {
 			},
 			RuleWithUseIframeTitleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10803,7 +10803,7 @@ export function GET() {
 			},
 			RuleWithUseImageSizeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10818,7 +10818,7 @@ export function GET() {
 			},
 			RuleWithUseImportExtensionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10837,7 +10837,7 @@ export function GET() {
 			},
 			RuleWithUseImportTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10856,7 +10856,7 @@ export function GET() {
 			},
 			RuleWithUseIndexOfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10875,7 +10875,7 @@ export function GET() {
 			},
 			RuleWithUseIsArrayOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10894,7 +10894,7 @@ export function GET() {
 			},
 			RuleWithUseIsNanOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10913,7 +10913,7 @@ export function GET() {
 			},
 			RuleWithUseIterableCallbackReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10928,7 +10928,7 @@ export function GET() {
 			},
 			RuleWithUseJsonImportAttributeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10947,7 +10947,7 @@ export function GET() {
 			},
 			RuleWithUseJsxKeyInIterableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10962,7 +10962,7 @@ export function GET() {
 			},
 			RuleWithUseKeyWithClickEventsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10977,7 +10977,7 @@ export function GET() {
 			},
 			RuleWithUseKeyWithMouseEventsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10992,7 +10992,7 @@ export function GET() {
 			},
 			RuleWithUseLiteralEnumMembersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11007,7 +11007,7 @@ export function GET() {
 			},
 			RuleWithUseLiteralKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11026,7 +11026,7 @@ export function GET() {
 			},
 			RuleWithUseMediaCaptionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11041,7 +11041,7 @@ export function GET() {
 			},
 			RuleWithUseNamedOperationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11060,7 +11060,7 @@ export function GET() {
 			},
 			RuleWithUseNamespaceKeywordOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11079,7 +11079,7 @@ export function GET() {
 			},
 			RuleWithUseNamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11094,7 +11094,7 @@ export function GET() {
 			},
 			RuleWithUseNodeAssertStrictOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11113,7 +11113,7 @@ export function GET() {
 			},
 			RuleWithUseNodejsImportProtocolOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11132,7 +11132,7 @@ export function GET() {
 			},
 			RuleWithUseNumberNamespaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11151,7 +11151,7 @@ export function GET() {
 			},
 			RuleWithUseNumberToFixedDigitsArgumentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11172,7 +11172,7 @@ export function GET() {
 			},
 			RuleWithUseNumericLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11191,7 +11191,7 @@ export function GET() {
 			},
 			RuleWithUseNumericSeparatorsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11210,7 +11210,7 @@ export function GET() {
 			},
 			RuleWithUseObjectSpreadOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11229,7 +11229,7 @@ export function GET() {
 			},
 			RuleWithUseOptionalChainOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11248,7 +11248,7 @@ export function GET() {
 			},
 			RuleWithUseParseIntRadixOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11267,7 +11267,7 @@ export function GET() {
 			},
 			RuleWithUseQwikClasslistOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11282,7 +11282,7 @@ export function GET() {
 			},
 			RuleWithUseReactFunctionComponentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11299,7 +11299,7 @@ export function GET() {
 			},
 			RuleWithUseReadonlyClassPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11320,7 +11320,7 @@ export function GET() {
 			},
 			RuleWithUseRegexLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11339,7 +11339,7 @@ export function GET() {
 			},
 			RuleWithUseSelfClosingElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11358,7 +11358,7 @@ export function GET() {
 			},
 			RuleWithUseSemanticElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11373,7 +11373,7 @@ export function GET() {
 			},
 			RuleWithUseShorthandAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11392,7 +11392,7 @@ export function GET() {
 			},
 			RuleWithUseShorthandFunctionTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11411,7 +11411,7 @@ export function GET() {
 			},
 			RuleWithUseSimpleNumberKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11430,7 +11430,7 @@ export function GET() {
 			},
 			RuleWithUseSimplifiedLogicExpressionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11451,7 +11451,7 @@ export function GET() {
 			},
 			RuleWithUseSingleJsDocAsteriskOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11470,7 +11470,7 @@ export function GET() {
 			},
 			RuleWithUseSingleVarDeclaratorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11489,7 +11489,7 @@ export function GET() {
 			},
 			RuleWithUseSortedClassesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11508,7 +11508,7 @@ export function GET() {
 			},
 			RuleWithUseStrictModeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11527,7 +11527,7 @@ export function GET() {
 			},
 			RuleWithUseSymbolDescriptionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11542,7 +11542,7 @@ export function GET() {
 			},
 			RuleWithUseTemplateOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11561,7 +11561,7 @@ export function GET() {
 			},
 			RuleWithUseThrowNewErrorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11580,7 +11580,7 @@ export function GET() {
 			},
 			RuleWithUseThrowOnlyErrorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11595,7 +11595,7 @@ export function GET() {
 			},
 			RuleWithUseTopLevelRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11610,7 +11610,7 @@ export function GET() {
 			},
 			RuleWithUseTrimStartEndOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11629,7 +11629,7 @@ export function GET() {
 			},
 			RuleWithUseUnifiedTypeSignatureOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11648,7 +11648,7 @@ export function GET() {
 			},
 			RuleWithUseUniqueElementIdsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11663,7 +11663,7 @@ export function GET() {
 			},
 			RuleWithUseValidAnchorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11678,7 +11678,7 @@ export function GET() {
 			},
 			RuleWithUseValidAriaPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11697,7 +11697,7 @@ export function GET() {
 			},
 			RuleWithUseValidAriaRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11716,7 +11716,7 @@ export function GET() {
 			},
 			RuleWithUseValidAriaValuesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11731,7 +11731,7 @@ export function GET() {
 			},
 			RuleWithUseValidAutocompleteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11746,7 +11746,7 @@ export function GET() {
 			},
 			RuleWithUseValidForDirectionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11761,7 +11761,7 @@ export function GET() {
 			},
 			RuleWithUseValidLangOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11776,7 +11776,7 @@ export function GET() {
 			},
 			RuleWithUseValidTypeofOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11795,7 +11795,7 @@ export function GET() {
 			},
 			RuleWithUseWhileOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11814,7 +11814,7 @@ export function GET() {
 			},
 			RuleWithUseYieldOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",

--- a/src/pages/schemas/2.2.0/schema.json.js
+++ b/src/pages/schemas/2.2.0/schema.json.js
@@ -5742,7 +5742,7 @@ export function GET() {
 			RuleAssistPlainConfiguration: { type: "string", enum: ["off", "on"] },
 			RuleAssistWithOptions_for_OrganizeImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5757,7 +5757,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_UseSortedAttributesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5772,7 +5772,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_UseSortedKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5787,7 +5787,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_UseSortedPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5898,7 +5898,7 @@ export function GET() {
 			},
 			RuleWithNoAccessKeyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -5917,7 +5917,7 @@ export function GET() {
 			},
 			RuleWithNoAccumulatingSpreadOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5932,7 +5932,7 @@ export function GET() {
 			},
 			RuleWithNoAdjacentSpacesInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -5951,7 +5951,7 @@ export function GET() {
 			},
 			RuleWithNoAlertOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5966,7 +5966,7 @@ export function GET() {
 			},
 			RuleWithNoApproximativeNumericConstantOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -5987,7 +5987,7 @@ export function GET() {
 			},
 			RuleWithNoArgumentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6002,7 +6002,7 @@ export function GET() {
 			},
 			RuleWithNoAriaHiddenOnFocusableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6021,7 +6021,7 @@ export function GET() {
 			},
 			RuleWithNoAriaUnsupportedElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6040,7 +6040,7 @@ export function GET() {
 			},
 			RuleWithNoArrayIndexKeyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6055,7 +6055,7 @@ export function GET() {
 			},
 			RuleWithNoAssignInExpressionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6070,7 +6070,7 @@ export function GET() {
 			},
 			RuleWithNoAsyncPromiseExecutorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6085,7 +6085,7 @@ export function GET() {
 			},
 			RuleWithNoAutofocusOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6104,7 +6104,7 @@ export function GET() {
 			},
 			RuleWithNoAwaitInLoopsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6119,7 +6119,7 @@ export function GET() {
 			},
 			RuleWithNoBannedTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6138,7 +6138,7 @@ export function GET() {
 			},
 			RuleWithNoBarrelFileOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6153,7 +6153,7 @@ export function GET() {
 			},
 			RuleWithNoBiomeFirstExceptionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6172,7 +6172,7 @@ export function GET() {
 			},
 			RuleWithNoBitwiseOperatorsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6187,7 +6187,7 @@ export function GET() {
 			},
 			RuleWithNoBlankTargetOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6206,7 +6206,7 @@ export function GET() {
 			},
 			RuleWithNoCatchAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6221,7 +6221,7 @@ export function GET() {
 			},
 			RuleWithNoChildrenPropOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6236,7 +6236,7 @@ export function GET() {
 			},
 			RuleWithNoClassAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6251,7 +6251,7 @@ export function GET() {
 			},
 			RuleWithNoCommaOperatorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6266,7 +6266,7 @@ export function GET() {
 			},
 			RuleWithNoCommentTextOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6285,7 +6285,7 @@ export function GET() {
 			},
 			RuleWithNoCommonJsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6300,7 +6300,7 @@ export function GET() {
 			},
 			RuleWithNoCompareNegZeroOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6319,7 +6319,7 @@ export function GET() {
 			},
 			RuleWithNoConfusingLabelsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6334,7 +6334,7 @@ export function GET() {
 			},
 			RuleWithNoConfusingVoidTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6353,7 +6353,7 @@ export function GET() {
 			},
 			RuleWithNoConsoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6372,7 +6372,7 @@ export function GET() {
 			},
 			RuleWithNoConstAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6391,7 +6391,7 @@ export function GET() {
 			},
 			RuleWithNoConstEnumOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6410,7 +6410,7 @@ export function GET() {
 			},
 			RuleWithNoConstantBinaryExpressionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6427,7 +6427,7 @@ export function GET() {
 			},
 			RuleWithNoConstantConditionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6442,7 +6442,7 @@ export function GET() {
 			},
 			RuleWithNoConstantMathMinMaxClampOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6461,7 +6461,7 @@ export function GET() {
 			},
 			RuleWithNoConstructorReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6476,7 +6476,7 @@ export function GET() {
 			},
 			RuleWithNoControlCharactersInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6493,7 +6493,7 @@ export function GET() {
 			},
 			RuleWithNoDangerouslySetInnerHtmlOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6508,7 +6508,7 @@ export function GET() {
 			},
 			RuleWithNoDangerouslySetInnerHtmlWithChildrenOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6527,7 +6527,7 @@ export function GET() {
 			},
 			RuleWithNoDebuggerOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6546,7 +6546,7 @@ export function GET() {
 			},
 			RuleWithNoDefaultExportOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6561,7 +6561,7 @@ export function GET() {
 			},
 			RuleWithNoDeleteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6580,7 +6580,7 @@ export function GET() {
 			},
 			RuleWithNoDescendingSpecificityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6595,7 +6595,7 @@ export function GET() {
 			},
 			RuleWithNoDistractingElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6614,7 +6614,7 @@ export function GET() {
 			},
 			RuleWithNoDocumentCookieOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6629,7 +6629,7 @@ export function GET() {
 			},
 			RuleWithNoDocumentImportInPageOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6644,7 +6644,7 @@ export function GET() {
 			},
 			RuleWithNoDoneCallbackOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6659,7 +6659,7 @@ export function GET() {
 			},
 			RuleWithNoDoubleEqualsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6678,7 +6678,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateAtImportRulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6693,7 +6693,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateCaseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6708,7 +6708,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateClassMembersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6723,7 +6723,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateCustomPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6740,7 +6740,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateElseIfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6755,7 +6755,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateFieldsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6770,7 +6770,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateFontNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6785,7 +6785,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateJsxPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6800,7 +6800,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateObjectKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6815,7 +6815,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateParametersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6830,7 +6830,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicatePropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6845,7 +6845,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateSelectorsKeyframeBlockOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6864,7 +6864,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateTestHooksOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6879,7 +6879,7 @@ export function GET() {
 			},
 			RuleWithNoDynamicNamespaceImportAccessOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6896,7 +6896,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyBlockOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6911,7 +6911,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyBlockStatementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6926,7 +6926,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyCharacterClassInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6943,7 +6943,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyInterfaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6962,7 +6962,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyPatternOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6977,7 +6977,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyTypeParametersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6992,7 +6992,7 @@ export function GET() {
 			},
 			RuleWithNoEnumOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7007,7 +7007,7 @@ export function GET() {
 			},
 			RuleWithNoEvolvingTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7022,7 +7022,7 @@ export function GET() {
 			},
 			RuleWithNoExcessiveCognitiveComplexityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7039,7 +7039,7 @@ export function GET() {
 			},
 			RuleWithNoExcessiveLinesPerFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7056,7 +7056,7 @@ export function GET() {
 			},
 			RuleWithNoExcessiveNestedTestSuitesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7073,7 +7073,7 @@ export function GET() {
 			},
 			RuleWithNoExplicitAnyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7088,7 +7088,7 @@ export function GET() {
 			},
 			RuleWithNoExportedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7103,7 +7103,7 @@ export function GET() {
 			},
 			RuleWithNoExportsInTestOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7118,7 +7118,7 @@ export function GET() {
 			},
 			RuleWithNoExtraBooleanCastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7137,7 +7137,7 @@ export function GET() {
 			},
 			RuleWithNoExtraNonNullAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7156,7 +7156,7 @@ export function GET() {
 			},
 			RuleWithNoFallthroughSwitchClauseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7171,7 +7171,7 @@ export function GET() {
 			},
 			RuleWithNoFlatMapIdentityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7190,7 +7190,7 @@ export function GET() {
 			},
 			RuleWithNoFloatingPromisesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7209,7 +7209,7 @@ export function GET() {
 			},
 			RuleWithNoFocusedTestsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7228,7 +7228,7 @@ export function GET() {
 			},
 			RuleWithNoForEachOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7243,7 +7243,7 @@ export function GET() {
 			},
 			RuleWithNoFunctionAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7258,7 +7258,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7273,7 +7273,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalDirnameFilenameOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7292,7 +7292,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalEvalOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7307,7 +7307,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalIsFiniteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7326,7 +7326,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalIsNanOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7345,7 +7345,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalObjectCallsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7360,7 +7360,7 @@ export function GET() {
 			},
 			RuleWithNoHeadElementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7375,7 +7375,7 @@ export function GET() {
 			},
 			RuleWithNoHeadImportInDocumentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7390,7 +7390,7 @@ export function GET() {
 			},
 			RuleWithNoHeaderScopeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7409,7 +7409,7 @@ export function GET() {
 			},
 			RuleWithNoImgElementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7424,7 +7424,7 @@ export function GET() {
 			},
 			RuleWithNoImplicitAnyLetOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7439,7 +7439,7 @@ export function GET() {
 			},
 			RuleWithNoImplicitBooleanOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7458,7 +7458,7 @@ export function GET() {
 			},
 			RuleWithNoImplicitCoercionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7477,7 +7477,7 @@ export function GET() {
 			},
 			RuleWithNoImportAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7492,7 +7492,7 @@ export function GET() {
 			},
 			RuleWithNoImportCyclesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7507,7 +7507,7 @@ export function GET() {
 			},
 			RuleWithNoImportantInKeyframeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7522,7 +7522,7 @@ export function GET() {
 			},
 			RuleWithNoImportantStylesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7541,7 +7541,7 @@ export function GET() {
 			},
 			RuleWithNoInferrableTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7560,7 +7560,7 @@ export function GET() {
 			},
 			RuleWithNoInnerDeclarationsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7575,7 +7575,7 @@ export function GET() {
 			},
 			RuleWithNoInteractiveElementToNoninteractiveRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7598,7 +7598,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidBuiltinInstantiationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7619,7 +7619,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidConstructorSuperOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7634,7 +7634,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidDirectionInLinearGradientOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7653,7 +7653,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidGridAreasOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7668,7 +7668,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidPositionAtImportRuleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7685,7 +7685,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidUseBeforeDeclarationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7702,7 +7702,7 @@ export function GET() {
 			},
 			RuleWithNoIrregularWhitespaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7717,7 +7717,7 @@ export function GET() {
 			},
 			RuleWithNoLabelVarOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7732,7 +7732,7 @@ export function GET() {
 			},
 			RuleWithNoLabelWithoutControlOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7747,7 +7747,7 @@ export function GET() {
 			},
 			RuleWithNoMagicNumbersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7762,7 +7762,7 @@ export function GET() {
 			},
 			RuleWithNoMisleadingCharacterClassOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7783,7 +7783,7 @@ export function GET() {
 			},
 			RuleWithNoMisleadingInstantiatorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7798,7 +7798,7 @@ export function GET() {
 			},
 			RuleWithNoMisplacedAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7813,7 +7813,7 @@ export function GET() {
 			},
 			RuleWithNoMisrefactoredShorthandAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7834,7 +7834,7 @@ export function GET() {
 			},
 			RuleWithNoMissingVarFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7849,7 +7849,7 @@ export function GET() {
 			},
 			RuleWithNoMisusedPromisesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7868,7 +7868,7 @@ export function GET() {
 			},
 			RuleWithNoNamespaceImportOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7883,7 +7883,7 @@ export function GET() {
 			},
 			RuleWithNoNamespaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7898,7 +7898,7 @@ export function GET() {
 			},
 			RuleWithNoNegationElseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7917,7 +7917,7 @@ export function GET() {
 			},
 			RuleWithNoNestedComponentDefinitionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7934,7 +7934,7 @@ export function GET() {
 			},
 			RuleWithNoNestedTernaryOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7949,7 +7949,7 @@ export function GET() {
 			},
 			RuleWithNoNextAsyncClientComponentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7966,7 +7966,7 @@ export function GET() {
 			},
 			RuleWithNoNodejsModulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7981,7 +7981,7 @@ export function GET() {
 			},
 			RuleWithNoNonNullAssertedOptionalChainOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7998,7 +7998,7 @@ export function GET() {
 			},
 			RuleWithNoNonNullAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8017,7 +8017,7 @@ export function GET() {
 			},
 			RuleWithNoNoninteractiveElementInteractionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8036,7 +8036,7 @@ export function GET() {
 			},
 			RuleWithNoNoninteractiveElementToInteractiveRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8059,7 +8059,7 @@ export function GET() {
 			},
 			RuleWithNoNoninteractiveTabindexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8078,7 +8078,7 @@ export function GET() {
 			},
 			RuleWithNoNonoctalDecimalEscapeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8097,7 +8097,7 @@ export function GET() {
 			},
 			RuleWithNoOctalEscapeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8116,7 +8116,7 @@ export function GET() {
 			},
 			RuleWithNoParameterAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8131,7 +8131,7 @@ export function GET() {
 			},
 			RuleWithNoParameterPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8146,7 +8146,7 @@ export function GET() {
 			},
 			RuleWithNoPositiveTabindexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8165,7 +8165,7 @@ export function GET() {
 			},
 			RuleWithNoPrecisionLossOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8180,7 +8180,7 @@ export function GET() {
 			},
 			RuleWithNoPrivateImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8195,7 +8195,7 @@ export function GET() {
 			},
 			RuleWithNoProcessEnvOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8210,7 +8210,7 @@ export function GET() {
 			},
 			RuleWithNoProcessGlobalOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8229,7 +8229,7 @@ export function GET() {
 			},
 			RuleWithNoPrototypeBuiltinsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8248,7 +8248,7 @@ export function GET() {
 			},
 			RuleWithNoQuickfixBiomeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8267,7 +8267,7 @@ export function GET() {
 			},
 			RuleWithNoQwikUseVisibleTaskOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8282,7 +8282,7 @@ export function GET() {
 			},
 			RuleWithNoReExportAllOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8297,7 +8297,7 @@ export function GET() {
 			},
 			RuleWithNoReactPropAssignmentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8312,7 +8312,7 @@ export function GET() {
 			},
 			RuleWithNoReactSpecificPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8331,7 +8331,7 @@ export function GET() {
 			},
 			RuleWithNoRedeclareOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8346,7 +8346,7 @@ export function GET() {
 			},
 			RuleWithNoRedundantAltOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8361,7 +8361,7 @@ export function GET() {
 			},
 			RuleWithNoRedundantRolesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8380,7 +8380,7 @@ export function GET() {
 			},
 			RuleWithNoRedundantUseStrictOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8399,7 +8399,7 @@ export function GET() {
 			},
 			RuleWithNoRenderReturnValueOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8414,7 +8414,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8429,7 +8429,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedGlobalsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8444,7 +8444,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8459,7 +8459,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8478,7 +8478,7 @@ export function GET() {
 			},
 			RuleWithNoSecretsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8493,7 +8493,7 @@ export function GET() {
 			},
 			RuleWithNoSelfAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8508,7 +8508,7 @@ export function GET() {
 			},
 			RuleWithNoSelfCompareOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8523,7 +8523,7 @@ export function GET() {
 			},
 			RuleWithNoSetterReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8538,7 +8538,7 @@ export function GET() {
 			},
 			RuleWithNoShadowOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8553,7 +8553,7 @@ export function GET() {
 			},
 			RuleWithNoShadowRestrictedNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8568,7 +8568,7 @@ export function GET() {
 			},
 			RuleWithNoShorthandPropertyOverridesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8585,7 +8585,7 @@ export function GET() {
 			},
 			RuleWithNoShoutyConstantsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8604,7 +8604,7 @@ export function GET() {
 			},
 			RuleWithNoSkippedTestsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8623,7 +8623,7 @@ export function GET() {
 			},
 			RuleWithNoSolidDestructuredPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8638,7 +8638,7 @@ export function GET() {
 			},
 			RuleWithNoSparseArrayOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8657,7 +8657,7 @@ export function GET() {
 			},
 			RuleWithNoStaticElementInteractionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8674,7 +8674,7 @@ export function GET() {
 			},
 			RuleWithNoStaticOnlyClassOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8689,7 +8689,7 @@ export function GET() {
 			},
 			RuleWithNoStringCaseMismatchOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8708,7 +8708,7 @@ export function GET() {
 			},
 			RuleWithNoSubstrOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8727,7 +8727,7 @@ export function GET() {
 			},
 			RuleWithNoSuspiciousSemicolonInJsxOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8744,7 +8744,7 @@ export function GET() {
 			},
 			RuleWithNoSvgWithoutTitleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8759,7 +8759,7 @@ export function GET() {
 			},
 			RuleWithNoSwitchDeclarationsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8778,7 +8778,7 @@ export function GET() {
 			},
 			RuleWithNoTemplateCurlyInStringOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8793,7 +8793,7 @@ export function GET() {
 			},
 			RuleWithNoThenPropertyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8808,7 +8808,7 @@ export function GET() {
 			},
 			RuleWithNoThisInStaticOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8827,7 +8827,7 @@ export function GET() {
 			},
 			RuleWithNoTsIgnoreOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8846,7 +8846,7 @@ export function GET() {
 			},
 			RuleWithNoUnassignedVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8861,7 +8861,7 @@ export function GET() {
 			},
 			RuleWithNoUndeclaredDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8876,7 +8876,7 @@ export function GET() {
 			},
 			RuleWithNoUndeclaredVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8891,7 +8891,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownAtRulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8906,7 +8906,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8921,7 +8921,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownMediaFeatureNameOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8936,7 +8936,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownPropertyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8951,7 +8951,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownPseudoClassOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8966,7 +8966,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownPseudoElementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8981,7 +8981,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownTypeSelectorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8996,7 +8996,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownUnitOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9011,7 +9011,7 @@ export function GET() {
 			},
 			RuleWithNoUnmatchableAnbSelectorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9026,7 +9026,7 @@ export function GET() {
 			},
 			RuleWithNoUnnecessaryConditionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9041,7 +9041,7 @@ export function GET() {
 			},
 			RuleWithNoUnreachableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9056,7 +9056,7 @@ export function GET() {
 			},
 			RuleWithNoUnreachableSuperOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9071,7 +9071,7 @@ export function GET() {
 			},
 			RuleWithNoUnresolvedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9086,7 +9086,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeDeclarationMergingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9103,7 +9103,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeFinallyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9118,7 +9118,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeNegationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9137,7 +9137,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeOptionalChainingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9152,7 +9152,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedFunctionParametersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9173,7 +9173,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9192,7 +9192,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedLabelsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9211,7 +9211,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedPrivateClassMembersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9232,7 +9232,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedTemplateLiteralOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9251,7 +9251,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9270,7 +9270,7 @@ export function GET() {
 			},
 			RuleWithNoUnwantedPolyfillioOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9285,7 +9285,7 @@ export function GET() {
 			},
 			RuleWithNoUselessCatchOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9304,7 +9304,7 @@ export function GET() {
 			},
 			RuleWithNoUselessConstructorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9323,7 +9323,7 @@ export function GET() {
 			},
 			RuleWithNoUselessContinueOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9342,7 +9342,7 @@ export function GET() {
 			},
 			RuleWithNoUselessElseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9361,7 +9361,7 @@ export function GET() {
 			},
 			RuleWithNoUselessEmptyExportOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9380,7 +9380,7 @@ export function GET() {
 			},
 			RuleWithNoUselessEscapeInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9399,7 +9399,7 @@ export function GET() {
 			},
 			RuleWithNoUselessEscapeInStringOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9418,7 +9418,7 @@ export function GET() {
 			},
 			RuleWithNoUselessFragmentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9437,7 +9437,7 @@ export function GET() {
 			},
 			RuleWithNoUselessLabelOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9456,7 +9456,7 @@ export function GET() {
 			},
 			RuleWithNoUselessLoneBlockStatementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9477,7 +9477,7 @@ export function GET() {
 			},
 			RuleWithNoUselessRegexBackrefsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9492,7 +9492,7 @@ export function GET() {
 			},
 			RuleWithNoUselessRenameOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9511,7 +9511,7 @@ export function GET() {
 			},
 			RuleWithNoUselessStringConcatOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9530,7 +9530,7 @@ export function GET() {
 			},
 			RuleWithNoUselessStringRawOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9545,7 +9545,7 @@ export function GET() {
 			},
 			RuleWithNoUselessSwitchCaseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9564,7 +9564,7 @@ export function GET() {
 			},
 			RuleWithNoUselessTernaryOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9583,7 +9583,7 @@ export function GET() {
 			},
 			RuleWithNoUselessThisAliasOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9602,7 +9602,7 @@ export function GET() {
 			},
 			RuleWithNoUselessTypeConstraintOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9621,7 +9621,7 @@ export function GET() {
 			},
 			RuleWithNoUselessUndefinedInitializationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9642,7 +9642,7 @@ export function GET() {
 			},
 			RuleWithNoUselessUndefinedOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9661,7 +9661,7 @@ export function GET() {
 			},
 			RuleWithNoValueAtRuleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9676,7 +9676,7 @@ export function GET() {
 			},
 			RuleWithNoVarOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9695,7 +9695,7 @@ export function GET() {
 			},
 			RuleWithNoVoidElementsWithChildrenOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9716,7 +9716,7 @@ export function GET() {
 			},
 			RuleWithNoVoidOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9731,7 +9731,7 @@ export function GET() {
 			},
 			RuleWithNoVoidTypeReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9746,7 +9746,7 @@ export function GET() {
 			},
 			RuleWithNoVueDataObjectDeclarationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9767,7 +9767,7 @@ export function GET() {
 			},
 			RuleWithNoVueReservedKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9782,7 +9782,7 @@ export function GET() {
 			},
 			RuleWithNoVueReservedPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9797,7 +9797,7 @@ export function GET() {
 			},
 			RuleWithNoWithOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9812,7 +9812,7 @@ export function GET() {
 			},
 			RuleWithNoYodaExpressionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9831,7 +9831,7 @@ export function GET() {
 			},
 			RuleWithUseAdjacentOverloadSignaturesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9848,7 +9848,7 @@ export function GET() {
 			},
 			RuleWithUseAltTextOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9863,7 +9863,7 @@ export function GET() {
 			},
 			RuleWithUseAnchorContentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9882,7 +9882,7 @@ export function GET() {
 			},
 			RuleWithUseAnchorHrefOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9897,7 +9897,7 @@ export function GET() {
 			},
 			RuleWithUseAriaActivedescendantWithTabindexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9920,7 +9920,7 @@ export function GET() {
 			},
 			RuleWithUseAriaPropsForRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9935,7 +9935,7 @@ export function GET() {
 			},
 			RuleWithUseAriaPropsSupportedByRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9952,7 +9952,7 @@ export function GET() {
 			},
 			RuleWithUseArrayLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9971,7 +9971,7 @@ export function GET() {
 			},
 			RuleWithUseArrowFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9990,7 +9990,7 @@ export function GET() {
 			},
 			RuleWithUseAsConstAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10009,7 +10009,7 @@ export function GET() {
 			},
 			RuleWithUseAtIndexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10028,7 +10028,7 @@ export function GET() {
 			},
 			RuleWithUseAwaitOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10043,7 +10043,7 @@ export function GET() {
 			},
 			RuleWithUseBiomeIgnoreFolderOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10062,7 +10062,7 @@ export function GET() {
 			},
 			RuleWithUseBlockStatementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10081,7 +10081,7 @@ export function GET() {
 			},
 			RuleWithUseButtonTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10096,7 +10096,7 @@ export function GET() {
 			},
 			RuleWithUseCollapsedElseIfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10115,7 +10115,7 @@ export function GET() {
 			},
 			RuleWithUseCollapsedIfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10134,7 +10134,7 @@ export function GET() {
 			},
 			RuleWithUseComponentExportOnlyModulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10151,7 +10151,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentArrayTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10170,7 +10170,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentBuiltinInstantiationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10193,7 +10193,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentCurlyBracesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10212,7 +10212,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentMemberAccessibilityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10229,7 +10229,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentObjectDefinitionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10250,7 +10250,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentTypeDefinitionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10271,7 +10271,7 @@ export function GET() {
 			},
 			RuleWithUseConstOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10290,7 +10290,7 @@ export function GET() {
 			},
 			RuleWithUseDateNowOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10309,7 +10309,7 @@ export function GET() {
 			},
 			RuleWithUseDefaultParameterLastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10328,7 +10328,7 @@ export function GET() {
 			},
 			RuleWithUseDefaultSwitchClauseLastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10345,7 +10345,7 @@ export function GET() {
 			},
 			RuleWithUseDefaultSwitchClauseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10360,7 +10360,7 @@ export function GET() {
 			},
 			RuleWithUseDeprecatedReasonOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10375,7 +10375,7 @@ export function GET() {
 			},
 			RuleWithUseEnumInitializersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10394,7 +10394,7 @@ export function GET() {
 			},
 			RuleWithUseErrorMessageOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10409,7 +10409,7 @@ export function GET() {
 			},
 			RuleWithUseExhaustiveDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10428,7 +10428,7 @@ export function GET() {
 			},
 			RuleWithUseExhaustiveSwitchCasesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10447,7 +10447,7 @@ export function GET() {
 			},
 			RuleWithUseExplicitLengthCheckOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10466,7 +10466,7 @@ export function GET() {
 			},
 			RuleWithUseExplicitTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10481,7 +10481,7 @@ export function GET() {
 			},
 			RuleWithUseExponentiationOperatorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10500,7 +10500,7 @@ export function GET() {
 			},
 			RuleWithUseExportTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10519,7 +10519,7 @@ export function GET() {
 			},
 			RuleWithUseExportsLastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10534,7 +10534,7 @@ export function GET() {
 			},
 			RuleWithUseFilenamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10549,7 +10549,7 @@ export function GET() {
 			},
 			RuleWithUseFlatMapOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10568,7 +10568,7 @@ export function GET() {
 			},
 			RuleWithUseFocusableInteractiveOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10583,7 +10583,7 @@ export function GET() {
 			},
 			RuleWithUseForOfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10598,7 +10598,7 @@ export function GET() {
 			},
 			RuleWithUseFragmentSyntaxOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10617,7 +10617,7 @@ export function GET() {
 			},
 			RuleWithUseGenericFontNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10632,7 +10632,7 @@ export function GET() {
 			},
 			RuleWithUseGetterReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10647,7 +10647,7 @@ export function GET() {
 			},
 			RuleWithUseGoogleFontDisplayOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10662,7 +10662,7 @@ export function GET() {
 			},
 			RuleWithUseGoogleFontPreconnectOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10681,7 +10681,7 @@ export function GET() {
 			},
 			RuleWithUseGraphqlNamedOperationsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10700,7 +10700,7 @@ export function GET() {
 			},
 			RuleWithUseGraphqlNamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10717,7 +10717,7 @@ export function GET() {
 			},
 			RuleWithUseGroupedAccessorPairsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10732,7 +10732,7 @@ export function GET() {
 			},
 			RuleWithUseGuardForInOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10747,7 +10747,7 @@ export function GET() {
 			},
 			RuleWithUseHeadingContentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10762,7 +10762,7 @@ export function GET() {
 			},
 			RuleWithUseHookAtTopLevelOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10777,7 +10777,7 @@ export function GET() {
 			},
 			RuleWithUseHtmlLangOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10792,7 +10792,7 @@ export function GET() {
 			},
 			RuleWithUseIframeTitleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10807,7 +10807,7 @@ export function GET() {
 			},
 			RuleWithUseImageSizeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10822,7 +10822,7 @@ export function GET() {
 			},
 			RuleWithUseImportExtensionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10841,7 +10841,7 @@ export function GET() {
 			},
 			RuleWithUseImportTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10860,7 +10860,7 @@ export function GET() {
 			},
 			RuleWithUseIndexOfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10879,7 +10879,7 @@ export function GET() {
 			},
 			RuleWithUseIsArrayOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10898,7 +10898,7 @@ export function GET() {
 			},
 			RuleWithUseIsNanOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10917,7 +10917,7 @@ export function GET() {
 			},
 			RuleWithUseIterableCallbackReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10932,7 +10932,7 @@ export function GET() {
 			},
 			RuleWithUseJsonImportAttributesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10951,7 +10951,7 @@ export function GET() {
 			},
 			RuleWithUseJsxKeyInIterableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10966,7 +10966,7 @@ export function GET() {
 			},
 			RuleWithUseKeyWithClickEventsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10981,7 +10981,7 @@ export function GET() {
 			},
 			RuleWithUseKeyWithMouseEventsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10996,7 +10996,7 @@ export function GET() {
 			},
 			RuleWithUseLiteralEnumMembersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11011,7 +11011,7 @@ export function GET() {
 			},
 			RuleWithUseLiteralKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11030,7 +11030,7 @@ export function GET() {
 			},
 			RuleWithUseMaxParamsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11045,7 +11045,7 @@ export function GET() {
 			},
 			RuleWithUseMediaCaptionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11060,7 +11060,7 @@ export function GET() {
 			},
 			RuleWithUseNamespaceKeywordOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11079,7 +11079,7 @@ export function GET() {
 			},
 			RuleWithUseNamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11098,7 +11098,7 @@ export function GET() {
 			},
 			RuleWithUseNodeAssertStrictOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11117,7 +11117,7 @@ export function GET() {
 			},
 			RuleWithUseNodejsImportProtocolOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11136,7 +11136,7 @@ export function GET() {
 			},
 			RuleWithUseNumberNamespaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11155,7 +11155,7 @@ export function GET() {
 			},
 			RuleWithUseNumberToFixedDigitsArgumentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11176,7 +11176,7 @@ export function GET() {
 			},
 			RuleWithUseNumericLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11195,7 +11195,7 @@ export function GET() {
 			},
 			RuleWithUseNumericSeparatorsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11214,7 +11214,7 @@ export function GET() {
 			},
 			RuleWithUseObjectSpreadOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11233,7 +11233,7 @@ export function GET() {
 			},
 			RuleWithUseOptionalChainOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11252,7 +11252,7 @@ export function GET() {
 			},
 			RuleWithUseParseIntRadixOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11271,7 +11271,7 @@ export function GET() {
 			},
 			RuleWithUseQwikClasslistOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11286,7 +11286,7 @@ export function GET() {
 			},
 			RuleWithUseReactFunctionComponentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11303,7 +11303,7 @@ export function GET() {
 			},
 			RuleWithUseReadonlyClassPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11324,7 +11324,7 @@ export function GET() {
 			},
 			RuleWithUseRegexLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11343,7 +11343,7 @@ export function GET() {
 			},
 			RuleWithUseSelfClosingElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11362,7 +11362,7 @@ export function GET() {
 			},
 			RuleWithUseSemanticElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11377,7 +11377,7 @@ export function GET() {
 			},
 			RuleWithUseShorthandAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11396,7 +11396,7 @@ export function GET() {
 			},
 			RuleWithUseShorthandFunctionTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11415,7 +11415,7 @@ export function GET() {
 			},
 			RuleWithUseSimpleNumberKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11434,7 +11434,7 @@ export function GET() {
 			},
 			RuleWithUseSimplifiedLogicExpressionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11455,7 +11455,7 @@ export function GET() {
 			},
 			RuleWithUseSingleJsDocAsteriskOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11474,7 +11474,7 @@ export function GET() {
 			},
 			RuleWithUseSingleVarDeclaratorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11493,7 +11493,7 @@ export function GET() {
 			},
 			RuleWithUseSolidForComponentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11508,7 +11508,7 @@ export function GET() {
 			},
 			RuleWithUseSortedClassesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11527,7 +11527,7 @@ export function GET() {
 			},
 			RuleWithUseStaticResponseMethodsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11546,7 +11546,7 @@ export function GET() {
 			},
 			RuleWithUseStrictModeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11565,7 +11565,7 @@ export function GET() {
 			},
 			RuleWithUseSymbolDescriptionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11580,7 +11580,7 @@ export function GET() {
 			},
 			RuleWithUseTemplateOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11599,7 +11599,7 @@ export function GET() {
 			},
 			RuleWithUseThrowNewErrorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11618,7 +11618,7 @@ export function GET() {
 			},
 			RuleWithUseThrowOnlyErrorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11633,7 +11633,7 @@ export function GET() {
 			},
 			RuleWithUseTopLevelRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11648,7 +11648,7 @@ export function GET() {
 			},
 			RuleWithUseTrimStartEndOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11667,7 +11667,7 @@ export function GET() {
 			},
 			RuleWithUseUnifiedTypeSignaturesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11686,7 +11686,7 @@ export function GET() {
 			},
 			RuleWithUseUniqueElementIdsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11701,7 +11701,7 @@ export function GET() {
 			},
 			RuleWithUseValidAnchorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11716,7 +11716,7 @@ export function GET() {
 			},
 			RuleWithUseValidAriaPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11735,7 +11735,7 @@ export function GET() {
 			},
 			RuleWithUseValidAriaRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11754,7 +11754,7 @@ export function GET() {
 			},
 			RuleWithUseValidAriaValuesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11769,7 +11769,7 @@ export function GET() {
 			},
 			RuleWithUseValidAutocompleteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11784,7 +11784,7 @@ export function GET() {
 			},
 			RuleWithUseValidForDirectionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11799,7 +11799,7 @@ export function GET() {
 			},
 			RuleWithUseValidLangOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11814,7 +11814,7 @@ export function GET() {
 			},
 			RuleWithUseValidTypeofOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11833,7 +11833,7 @@ export function GET() {
 			},
 			RuleWithUseWhileOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11852,7 +11852,7 @@ export function GET() {
 			},
 			RuleWithUseYieldOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",

--- a/src/pages/schemas/2.2.2/schema.json.js
+++ b/src/pages/schemas/2.2.2/schema.json.js
@@ -5742,7 +5742,7 @@ export function GET() {
 			RuleAssistPlainConfiguration: { type: "string", enum: ["off", "on"] },
 			RuleAssistWithOptions_for_OrganizeImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5757,7 +5757,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_UseSortedAttributesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5772,7 +5772,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_UseSortedKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5787,7 +5787,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_UseSortedPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5898,7 +5898,7 @@ export function GET() {
 			},
 			RuleWithNoAccessKeyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -5917,7 +5917,7 @@ export function GET() {
 			},
 			RuleWithNoAccumulatingSpreadOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5932,7 +5932,7 @@ export function GET() {
 			},
 			RuleWithNoAdjacentSpacesInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -5951,7 +5951,7 @@ export function GET() {
 			},
 			RuleWithNoAlertOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5966,7 +5966,7 @@ export function GET() {
 			},
 			RuleWithNoApproximativeNumericConstantOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -5987,7 +5987,7 @@ export function GET() {
 			},
 			RuleWithNoArgumentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6002,7 +6002,7 @@ export function GET() {
 			},
 			RuleWithNoAriaHiddenOnFocusableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6021,7 +6021,7 @@ export function GET() {
 			},
 			RuleWithNoAriaUnsupportedElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6040,7 +6040,7 @@ export function GET() {
 			},
 			RuleWithNoArrayIndexKeyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6055,7 +6055,7 @@ export function GET() {
 			},
 			RuleWithNoAssignInExpressionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6070,7 +6070,7 @@ export function GET() {
 			},
 			RuleWithNoAsyncPromiseExecutorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6085,7 +6085,7 @@ export function GET() {
 			},
 			RuleWithNoAutofocusOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6104,7 +6104,7 @@ export function GET() {
 			},
 			RuleWithNoAwaitInLoopsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6119,7 +6119,7 @@ export function GET() {
 			},
 			RuleWithNoBannedTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6138,7 +6138,7 @@ export function GET() {
 			},
 			RuleWithNoBarrelFileOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6153,7 +6153,7 @@ export function GET() {
 			},
 			RuleWithNoBiomeFirstExceptionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6172,7 +6172,7 @@ export function GET() {
 			},
 			RuleWithNoBitwiseOperatorsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6187,7 +6187,7 @@ export function GET() {
 			},
 			RuleWithNoBlankTargetOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6206,7 +6206,7 @@ export function GET() {
 			},
 			RuleWithNoCatchAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6221,7 +6221,7 @@ export function GET() {
 			},
 			RuleWithNoChildrenPropOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6236,7 +6236,7 @@ export function GET() {
 			},
 			RuleWithNoClassAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6251,7 +6251,7 @@ export function GET() {
 			},
 			RuleWithNoCommaOperatorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6266,7 +6266,7 @@ export function GET() {
 			},
 			RuleWithNoCommentTextOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6285,7 +6285,7 @@ export function GET() {
 			},
 			RuleWithNoCommonJsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6300,7 +6300,7 @@ export function GET() {
 			},
 			RuleWithNoCompareNegZeroOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6319,7 +6319,7 @@ export function GET() {
 			},
 			RuleWithNoConfusingLabelsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6334,7 +6334,7 @@ export function GET() {
 			},
 			RuleWithNoConfusingVoidTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6353,7 +6353,7 @@ export function GET() {
 			},
 			RuleWithNoConsoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6372,7 +6372,7 @@ export function GET() {
 			},
 			RuleWithNoConstAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6391,7 +6391,7 @@ export function GET() {
 			},
 			RuleWithNoConstEnumOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6410,7 +6410,7 @@ export function GET() {
 			},
 			RuleWithNoConstantBinaryExpressionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6427,7 +6427,7 @@ export function GET() {
 			},
 			RuleWithNoConstantConditionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6442,7 +6442,7 @@ export function GET() {
 			},
 			RuleWithNoConstantMathMinMaxClampOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6461,7 +6461,7 @@ export function GET() {
 			},
 			RuleWithNoConstructorReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6476,7 +6476,7 @@ export function GET() {
 			},
 			RuleWithNoControlCharactersInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6493,7 +6493,7 @@ export function GET() {
 			},
 			RuleWithNoDangerouslySetInnerHtmlOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6508,7 +6508,7 @@ export function GET() {
 			},
 			RuleWithNoDangerouslySetInnerHtmlWithChildrenOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6527,7 +6527,7 @@ export function GET() {
 			},
 			RuleWithNoDebuggerOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6546,7 +6546,7 @@ export function GET() {
 			},
 			RuleWithNoDefaultExportOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6561,7 +6561,7 @@ export function GET() {
 			},
 			RuleWithNoDeleteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6580,7 +6580,7 @@ export function GET() {
 			},
 			RuleWithNoDescendingSpecificityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6595,7 +6595,7 @@ export function GET() {
 			},
 			RuleWithNoDistractingElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6614,7 +6614,7 @@ export function GET() {
 			},
 			RuleWithNoDocumentCookieOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6629,7 +6629,7 @@ export function GET() {
 			},
 			RuleWithNoDocumentImportInPageOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6644,7 +6644,7 @@ export function GET() {
 			},
 			RuleWithNoDoneCallbackOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6659,7 +6659,7 @@ export function GET() {
 			},
 			RuleWithNoDoubleEqualsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6678,7 +6678,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateAtImportRulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6693,7 +6693,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateCaseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6708,7 +6708,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateClassMembersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6723,7 +6723,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateCustomPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6740,7 +6740,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateElseIfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6755,7 +6755,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateFieldsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6770,7 +6770,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateFontNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6785,7 +6785,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateJsxPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6800,7 +6800,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateObjectKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6815,7 +6815,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateParametersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6830,7 +6830,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicatePropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6845,7 +6845,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateSelectorsKeyframeBlockOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6864,7 +6864,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateTestHooksOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6879,7 +6879,7 @@ export function GET() {
 			},
 			RuleWithNoDynamicNamespaceImportAccessOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6896,7 +6896,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyBlockOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6911,7 +6911,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyBlockStatementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6926,7 +6926,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyCharacterClassInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6943,7 +6943,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyInterfaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6962,7 +6962,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyPatternOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6977,7 +6977,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyTypeParametersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6992,7 +6992,7 @@ export function GET() {
 			},
 			RuleWithNoEnumOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7007,7 +7007,7 @@ export function GET() {
 			},
 			RuleWithNoEvolvingTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7022,7 +7022,7 @@ export function GET() {
 			},
 			RuleWithNoExcessiveCognitiveComplexityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7039,7 +7039,7 @@ export function GET() {
 			},
 			RuleWithNoExcessiveLinesPerFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7056,7 +7056,7 @@ export function GET() {
 			},
 			RuleWithNoExcessiveNestedTestSuitesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7073,7 +7073,7 @@ export function GET() {
 			},
 			RuleWithNoExplicitAnyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7088,7 +7088,7 @@ export function GET() {
 			},
 			RuleWithNoExportedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7103,7 +7103,7 @@ export function GET() {
 			},
 			RuleWithNoExportsInTestOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7118,7 +7118,7 @@ export function GET() {
 			},
 			RuleWithNoExtraBooleanCastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7137,7 +7137,7 @@ export function GET() {
 			},
 			RuleWithNoExtraNonNullAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7156,7 +7156,7 @@ export function GET() {
 			},
 			RuleWithNoFallthroughSwitchClauseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7171,7 +7171,7 @@ export function GET() {
 			},
 			RuleWithNoFlatMapIdentityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7190,7 +7190,7 @@ export function GET() {
 			},
 			RuleWithNoFloatingPromisesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7209,7 +7209,7 @@ export function GET() {
 			},
 			RuleWithNoFocusedTestsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7228,7 +7228,7 @@ export function GET() {
 			},
 			RuleWithNoForEachOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7243,7 +7243,7 @@ export function GET() {
 			},
 			RuleWithNoFunctionAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7258,7 +7258,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7273,7 +7273,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalDirnameFilenameOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7292,7 +7292,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalEvalOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7307,7 +7307,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalIsFiniteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7326,7 +7326,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalIsNanOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7345,7 +7345,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalObjectCallsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7360,7 +7360,7 @@ export function GET() {
 			},
 			RuleWithNoHeadElementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7375,7 +7375,7 @@ export function GET() {
 			},
 			RuleWithNoHeadImportInDocumentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7390,7 +7390,7 @@ export function GET() {
 			},
 			RuleWithNoHeaderScopeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7409,7 +7409,7 @@ export function GET() {
 			},
 			RuleWithNoImgElementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7424,7 +7424,7 @@ export function GET() {
 			},
 			RuleWithNoImplicitAnyLetOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7439,7 +7439,7 @@ export function GET() {
 			},
 			RuleWithNoImplicitBooleanOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7458,7 +7458,7 @@ export function GET() {
 			},
 			RuleWithNoImplicitCoercionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7477,7 +7477,7 @@ export function GET() {
 			},
 			RuleWithNoImportAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7492,7 +7492,7 @@ export function GET() {
 			},
 			RuleWithNoImportCyclesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7507,7 +7507,7 @@ export function GET() {
 			},
 			RuleWithNoImportantInKeyframeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7522,7 +7522,7 @@ export function GET() {
 			},
 			RuleWithNoImportantStylesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7541,7 +7541,7 @@ export function GET() {
 			},
 			RuleWithNoInferrableTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7560,7 +7560,7 @@ export function GET() {
 			},
 			RuleWithNoInnerDeclarationsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7575,7 +7575,7 @@ export function GET() {
 			},
 			RuleWithNoInteractiveElementToNoninteractiveRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7598,7 +7598,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidBuiltinInstantiationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7619,7 +7619,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidConstructorSuperOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7634,7 +7634,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidDirectionInLinearGradientOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7653,7 +7653,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidGridAreasOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7668,7 +7668,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidPositionAtImportRuleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7685,7 +7685,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidUseBeforeDeclarationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7702,7 +7702,7 @@ export function GET() {
 			},
 			RuleWithNoIrregularWhitespaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7717,7 +7717,7 @@ export function GET() {
 			},
 			RuleWithNoLabelVarOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7732,7 +7732,7 @@ export function GET() {
 			},
 			RuleWithNoLabelWithoutControlOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7747,7 +7747,7 @@ export function GET() {
 			},
 			RuleWithNoMagicNumbersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7762,7 +7762,7 @@ export function GET() {
 			},
 			RuleWithNoMisleadingCharacterClassOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7783,7 +7783,7 @@ export function GET() {
 			},
 			RuleWithNoMisleadingInstantiatorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7798,7 +7798,7 @@ export function GET() {
 			},
 			RuleWithNoMisplacedAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7813,7 +7813,7 @@ export function GET() {
 			},
 			RuleWithNoMisrefactoredShorthandAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7834,7 +7834,7 @@ export function GET() {
 			},
 			RuleWithNoMissingVarFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7849,7 +7849,7 @@ export function GET() {
 			},
 			RuleWithNoMisusedPromisesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7868,7 +7868,7 @@ export function GET() {
 			},
 			RuleWithNoNamespaceImportOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7883,7 +7883,7 @@ export function GET() {
 			},
 			RuleWithNoNamespaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7898,7 +7898,7 @@ export function GET() {
 			},
 			RuleWithNoNegationElseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7917,7 +7917,7 @@ export function GET() {
 			},
 			RuleWithNoNestedComponentDefinitionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7934,7 +7934,7 @@ export function GET() {
 			},
 			RuleWithNoNestedTernaryOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7949,7 +7949,7 @@ export function GET() {
 			},
 			RuleWithNoNextAsyncClientComponentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7966,7 +7966,7 @@ export function GET() {
 			},
 			RuleWithNoNodejsModulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7981,7 +7981,7 @@ export function GET() {
 			},
 			RuleWithNoNonNullAssertedOptionalChainOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7998,7 +7998,7 @@ export function GET() {
 			},
 			RuleWithNoNonNullAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8017,7 +8017,7 @@ export function GET() {
 			},
 			RuleWithNoNoninteractiveElementInteractionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8036,7 +8036,7 @@ export function GET() {
 			},
 			RuleWithNoNoninteractiveElementToInteractiveRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8059,7 +8059,7 @@ export function GET() {
 			},
 			RuleWithNoNoninteractiveTabindexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8078,7 +8078,7 @@ export function GET() {
 			},
 			RuleWithNoNonoctalDecimalEscapeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8097,7 +8097,7 @@ export function GET() {
 			},
 			RuleWithNoOctalEscapeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8116,7 +8116,7 @@ export function GET() {
 			},
 			RuleWithNoParameterAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8131,7 +8131,7 @@ export function GET() {
 			},
 			RuleWithNoParameterPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8146,7 +8146,7 @@ export function GET() {
 			},
 			RuleWithNoPositiveTabindexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8165,7 +8165,7 @@ export function GET() {
 			},
 			RuleWithNoPrecisionLossOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8180,7 +8180,7 @@ export function GET() {
 			},
 			RuleWithNoPrivateImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8195,7 +8195,7 @@ export function GET() {
 			},
 			RuleWithNoProcessEnvOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8210,7 +8210,7 @@ export function GET() {
 			},
 			RuleWithNoProcessGlobalOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8229,7 +8229,7 @@ export function GET() {
 			},
 			RuleWithNoPrototypeBuiltinsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8248,7 +8248,7 @@ export function GET() {
 			},
 			RuleWithNoQuickfixBiomeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8267,7 +8267,7 @@ export function GET() {
 			},
 			RuleWithNoQwikUseVisibleTaskOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8282,7 +8282,7 @@ export function GET() {
 			},
 			RuleWithNoReExportAllOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8297,7 +8297,7 @@ export function GET() {
 			},
 			RuleWithNoReactPropAssignmentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8312,7 +8312,7 @@ export function GET() {
 			},
 			RuleWithNoReactSpecificPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8331,7 +8331,7 @@ export function GET() {
 			},
 			RuleWithNoRedeclareOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8346,7 +8346,7 @@ export function GET() {
 			},
 			RuleWithNoRedundantAltOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8361,7 +8361,7 @@ export function GET() {
 			},
 			RuleWithNoRedundantRolesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8380,7 +8380,7 @@ export function GET() {
 			},
 			RuleWithNoRedundantUseStrictOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8399,7 +8399,7 @@ export function GET() {
 			},
 			RuleWithNoRenderReturnValueOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8414,7 +8414,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8429,7 +8429,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedGlobalsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8444,7 +8444,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8459,7 +8459,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8478,7 +8478,7 @@ export function GET() {
 			},
 			RuleWithNoSecretsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8493,7 +8493,7 @@ export function GET() {
 			},
 			RuleWithNoSelfAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8508,7 +8508,7 @@ export function GET() {
 			},
 			RuleWithNoSelfCompareOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8523,7 +8523,7 @@ export function GET() {
 			},
 			RuleWithNoSetterReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8538,7 +8538,7 @@ export function GET() {
 			},
 			RuleWithNoShadowOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8553,7 +8553,7 @@ export function GET() {
 			},
 			RuleWithNoShadowRestrictedNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8568,7 +8568,7 @@ export function GET() {
 			},
 			RuleWithNoShorthandPropertyOverridesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8585,7 +8585,7 @@ export function GET() {
 			},
 			RuleWithNoShoutyConstantsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8604,7 +8604,7 @@ export function GET() {
 			},
 			RuleWithNoSkippedTestsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8623,7 +8623,7 @@ export function GET() {
 			},
 			RuleWithNoSolidDestructuredPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8638,7 +8638,7 @@ export function GET() {
 			},
 			RuleWithNoSparseArrayOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8657,7 +8657,7 @@ export function GET() {
 			},
 			RuleWithNoStaticElementInteractionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8674,7 +8674,7 @@ export function GET() {
 			},
 			RuleWithNoStaticOnlyClassOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8689,7 +8689,7 @@ export function GET() {
 			},
 			RuleWithNoStringCaseMismatchOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8708,7 +8708,7 @@ export function GET() {
 			},
 			RuleWithNoSubstrOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8727,7 +8727,7 @@ export function GET() {
 			},
 			RuleWithNoSuspiciousSemicolonInJsxOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8744,7 +8744,7 @@ export function GET() {
 			},
 			RuleWithNoSvgWithoutTitleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8759,7 +8759,7 @@ export function GET() {
 			},
 			RuleWithNoSwitchDeclarationsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8778,7 +8778,7 @@ export function GET() {
 			},
 			RuleWithNoTemplateCurlyInStringOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8793,7 +8793,7 @@ export function GET() {
 			},
 			RuleWithNoThenPropertyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8808,7 +8808,7 @@ export function GET() {
 			},
 			RuleWithNoThisInStaticOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8827,7 +8827,7 @@ export function GET() {
 			},
 			RuleWithNoTsIgnoreOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8846,7 +8846,7 @@ export function GET() {
 			},
 			RuleWithNoUnassignedVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8861,7 +8861,7 @@ export function GET() {
 			},
 			RuleWithNoUndeclaredDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8876,7 +8876,7 @@ export function GET() {
 			},
 			RuleWithNoUndeclaredVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8891,7 +8891,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownAtRulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8906,7 +8906,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8921,7 +8921,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownMediaFeatureNameOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8936,7 +8936,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownPropertyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8951,7 +8951,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownPseudoClassOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8966,7 +8966,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownPseudoElementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8981,7 +8981,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownTypeSelectorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8996,7 +8996,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownUnitOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9011,7 +9011,7 @@ export function GET() {
 			},
 			RuleWithNoUnmatchableAnbSelectorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9026,7 +9026,7 @@ export function GET() {
 			},
 			RuleWithNoUnnecessaryConditionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9041,7 +9041,7 @@ export function GET() {
 			},
 			RuleWithNoUnreachableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9056,7 +9056,7 @@ export function GET() {
 			},
 			RuleWithNoUnreachableSuperOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9071,7 +9071,7 @@ export function GET() {
 			},
 			RuleWithNoUnresolvedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9086,7 +9086,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeDeclarationMergingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9103,7 +9103,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeFinallyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9118,7 +9118,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeNegationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9137,7 +9137,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeOptionalChainingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9152,7 +9152,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedFunctionParametersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9173,7 +9173,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9192,7 +9192,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedLabelsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9211,7 +9211,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedPrivateClassMembersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9232,7 +9232,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedTemplateLiteralOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9251,7 +9251,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9270,7 +9270,7 @@ export function GET() {
 			},
 			RuleWithNoUnwantedPolyfillioOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9285,7 +9285,7 @@ export function GET() {
 			},
 			RuleWithNoUselessCatchOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9304,7 +9304,7 @@ export function GET() {
 			},
 			RuleWithNoUselessConstructorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9323,7 +9323,7 @@ export function GET() {
 			},
 			RuleWithNoUselessContinueOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9342,7 +9342,7 @@ export function GET() {
 			},
 			RuleWithNoUselessElseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9361,7 +9361,7 @@ export function GET() {
 			},
 			RuleWithNoUselessEmptyExportOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9380,7 +9380,7 @@ export function GET() {
 			},
 			RuleWithNoUselessEscapeInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9399,7 +9399,7 @@ export function GET() {
 			},
 			RuleWithNoUselessEscapeInStringOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9418,7 +9418,7 @@ export function GET() {
 			},
 			RuleWithNoUselessFragmentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9437,7 +9437,7 @@ export function GET() {
 			},
 			RuleWithNoUselessLabelOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9456,7 +9456,7 @@ export function GET() {
 			},
 			RuleWithNoUselessLoneBlockStatementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9477,7 +9477,7 @@ export function GET() {
 			},
 			RuleWithNoUselessRegexBackrefsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9492,7 +9492,7 @@ export function GET() {
 			},
 			RuleWithNoUselessRenameOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9511,7 +9511,7 @@ export function GET() {
 			},
 			RuleWithNoUselessStringConcatOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9530,7 +9530,7 @@ export function GET() {
 			},
 			RuleWithNoUselessStringRawOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9545,7 +9545,7 @@ export function GET() {
 			},
 			RuleWithNoUselessSwitchCaseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9564,7 +9564,7 @@ export function GET() {
 			},
 			RuleWithNoUselessTernaryOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9583,7 +9583,7 @@ export function GET() {
 			},
 			RuleWithNoUselessThisAliasOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9602,7 +9602,7 @@ export function GET() {
 			},
 			RuleWithNoUselessTypeConstraintOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9621,7 +9621,7 @@ export function GET() {
 			},
 			RuleWithNoUselessUndefinedInitializationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9642,7 +9642,7 @@ export function GET() {
 			},
 			RuleWithNoUselessUndefinedOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9661,7 +9661,7 @@ export function GET() {
 			},
 			RuleWithNoValueAtRuleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9676,7 +9676,7 @@ export function GET() {
 			},
 			RuleWithNoVarOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9695,7 +9695,7 @@ export function GET() {
 			},
 			RuleWithNoVoidElementsWithChildrenOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9716,7 +9716,7 @@ export function GET() {
 			},
 			RuleWithNoVoidOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9731,7 +9731,7 @@ export function GET() {
 			},
 			RuleWithNoVoidTypeReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9746,7 +9746,7 @@ export function GET() {
 			},
 			RuleWithNoVueDataObjectDeclarationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9767,7 +9767,7 @@ export function GET() {
 			},
 			RuleWithNoVueReservedKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9782,7 +9782,7 @@ export function GET() {
 			},
 			RuleWithNoVueReservedPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9797,7 +9797,7 @@ export function GET() {
 			},
 			RuleWithNoWithOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9812,7 +9812,7 @@ export function GET() {
 			},
 			RuleWithNoYodaExpressionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9831,7 +9831,7 @@ export function GET() {
 			},
 			RuleWithUseAdjacentOverloadSignaturesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9848,7 +9848,7 @@ export function GET() {
 			},
 			RuleWithUseAltTextOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9863,7 +9863,7 @@ export function GET() {
 			},
 			RuleWithUseAnchorContentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9882,7 +9882,7 @@ export function GET() {
 			},
 			RuleWithUseAnchorHrefOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9897,7 +9897,7 @@ export function GET() {
 			},
 			RuleWithUseAriaActivedescendantWithTabindexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9920,7 +9920,7 @@ export function GET() {
 			},
 			RuleWithUseAriaPropsForRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9935,7 +9935,7 @@ export function GET() {
 			},
 			RuleWithUseAriaPropsSupportedByRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9952,7 +9952,7 @@ export function GET() {
 			},
 			RuleWithUseArrayLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9971,7 +9971,7 @@ export function GET() {
 			},
 			RuleWithUseArrowFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9990,7 +9990,7 @@ export function GET() {
 			},
 			RuleWithUseAsConstAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10009,7 +10009,7 @@ export function GET() {
 			},
 			RuleWithUseAtIndexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10028,7 +10028,7 @@ export function GET() {
 			},
 			RuleWithUseAwaitOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10043,7 +10043,7 @@ export function GET() {
 			},
 			RuleWithUseBiomeIgnoreFolderOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10062,7 +10062,7 @@ export function GET() {
 			},
 			RuleWithUseBlockStatementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10081,7 +10081,7 @@ export function GET() {
 			},
 			RuleWithUseButtonTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10096,7 +10096,7 @@ export function GET() {
 			},
 			RuleWithUseCollapsedElseIfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10115,7 +10115,7 @@ export function GET() {
 			},
 			RuleWithUseCollapsedIfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10134,7 +10134,7 @@ export function GET() {
 			},
 			RuleWithUseComponentExportOnlyModulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10151,7 +10151,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentArrayTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10170,7 +10170,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentBuiltinInstantiationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10193,7 +10193,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentCurlyBracesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10212,7 +10212,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentMemberAccessibilityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10229,7 +10229,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentObjectDefinitionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10250,7 +10250,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentTypeDefinitionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10271,7 +10271,7 @@ export function GET() {
 			},
 			RuleWithUseConstOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10290,7 +10290,7 @@ export function GET() {
 			},
 			RuleWithUseDateNowOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10309,7 +10309,7 @@ export function GET() {
 			},
 			RuleWithUseDefaultParameterLastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10328,7 +10328,7 @@ export function GET() {
 			},
 			RuleWithUseDefaultSwitchClauseLastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10345,7 +10345,7 @@ export function GET() {
 			},
 			RuleWithUseDefaultSwitchClauseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10360,7 +10360,7 @@ export function GET() {
 			},
 			RuleWithUseDeprecatedReasonOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10375,7 +10375,7 @@ export function GET() {
 			},
 			RuleWithUseEnumInitializersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10394,7 +10394,7 @@ export function GET() {
 			},
 			RuleWithUseErrorMessageOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10409,7 +10409,7 @@ export function GET() {
 			},
 			RuleWithUseExhaustiveDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10428,7 +10428,7 @@ export function GET() {
 			},
 			RuleWithUseExhaustiveSwitchCasesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10447,7 +10447,7 @@ export function GET() {
 			},
 			RuleWithUseExplicitLengthCheckOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10466,7 +10466,7 @@ export function GET() {
 			},
 			RuleWithUseExplicitTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10481,7 +10481,7 @@ export function GET() {
 			},
 			RuleWithUseExponentiationOperatorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10500,7 +10500,7 @@ export function GET() {
 			},
 			RuleWithUseExportTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10519,7 +10519,7 @@ export function GET() {
 			},
 			RuleWithUseExportsLastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10534,7 +10534,7 @@ export function GET() {
 			},
 			RuleWithUseFilenamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10549,7 +10549,7 @@ export function GET() {
 			},
 			RuleWithUseFlatMapOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10568,7 +10568,7 @@ export function GET() {
 			},
 			RuleWithUseFocusableInteractiveOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10583,7 +10583,7 @@ export function GET() {
 			},
 			RuleWithUseForOfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10598,7 +10598,7 @@ export function GET() {
 			},
 			RuleWithUseFragmentSyntaxOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10617,7 +10617,7 @@ export function GET() {
 			},
 			RuleWithUseGenericFontNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10632,7 +10632,7 @@ export function GET() {
 			},
 			RuleWithUseGetterReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10647,7 +10647,7 @@ export function GET() {
 			},
 			RuleWithUseGoogleFontDisplayOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10662,7 +10662,7 @@ export function GET() {
 			},
 			RuleWithUseGoogleFontPreconnectOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10681,7 +10681,7 @@ export function GET() {
 			},
 			RuleWithUseGraphqlNamedOperationsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10700,7 +10700,7 @@ export function GET() {
 			},
 			RuleWithUseGraphqlNamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10717,7 +10717,7 @@ export function GET() {
 			},
 			RuleWithUseGroupedAccessorPairsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10732,7 +10732,7 @@ export function GET() {
 			},
 			RuleWithUseGuardForInOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10747,7 +10747,7 @@ export function GET() {
 			},
 			RuleWithUseHeadingContentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10762,7 +10762,7 @@ export function GET() {
 			},
 			RuleWithUseHookAtTopLevelOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10777,7 +10777,7 @@ export function GET() {
 			},
 			RuleWithUseHtmlLangOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10792,7 +10792,7 @@ export function GET() {
 			},
 			RuleWithUseIframeTitleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10807,7 +10807,7 @@ export function GET() {
 			},
 			RuleWithUseImageSizeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10822,7 +10822,7 @@ export function GET() {
 			},
 			RuleWithUseImportExtensionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10841,7 +10841,7 @@ export function GET() {
 			},
 			RuleWithUseImportTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10860,7 +10860,7 @@ export function GET() {
 			},
 			RuleWithUseIndexOfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10879,7 +10879,7 @@ export function GET() {
 			},
 			RuleWithUseIsArrayOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10898,7 +10898,7 @@ export function GET() {
 			},
 			RuleWithUseIsNanOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10917,7 +10917,7 @@ export function GET() {
 			},
 			RuleWithUseIterableCallbackReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10932,7 +10932,7 @@ export function GET() {
 			},
 			RuleWithUseJsonImportAttributesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10951,7 +10951,7 @@ export function GET() {
 			},
 			RuleWithUseJsxKeyInIterableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10966,7 +10966,7 @@ export function GET() {
 			},
 			RuleWithUseKeyWithClickEventsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10981,7 +10981,7 @@ export function GET() {
 			},
 			RuleWithUseKeyWithMouseEventsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10996,7 +10996,7 @@ export function GET() {
 			},
 			RuleWithUseLiteralEnumMembersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11011,7 +11011,7 @@ export function GET() {
 			},
 			RuleWithUseLiteralKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11030,7 +11030,7 @@ export function GET() {
 			},
 			RuleWithUseMaxParamsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11045,7 +11045,7 @@ export function GET() {
 			},
 			RuleWithUseMediaCaptionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11060,7 +11060,7 @@ export function GET() {
 			},
 			RuleWithUseNamespaceKeywordOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11079,7 +11079,7 @@ export function GET() {
 			},
 			RuleWithUseNamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11098,7 +11098,7 @@ export function GET() {
 			},
 			RuleWithUseNodeAssertStrictOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11117,7 +11117,7 @@ export function GET() {
 			},
 			RuleWithUseNodejsImportProtocolOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11136,7 +11136,7 @@ export function GET() {
 			},
 			RuleWithUseNumberNamespaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11155,7 +11155,7 @@ export function GET() {
 			},
 			RuleWithUseNumberToFixedDigitsArgumentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11176,7 +11176,7 @@ export function GET() {
 			},
 			RuleWithUseNumericLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11195,7 +11195,7 @@ export function GET() {
 			},
 			RuleWithUseNumericSeparatorsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11214,7 +11214,7 @@ export function GET() {
 			},
 			RuleWithUseObjectSpreadOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11233,7 +11233,7 @@ export function GET() {
 			},
 			RuleWithUseOptionalChainOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11252,7 +11252,7 @@ export function GET() {
 			},
 			RuleWithUseParseIntRadixOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11271,7 +11271,7 @@ export function GET() {
 			},
 			RuleWithUseQwikClasslistOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11286,7 +11286,7 @@ export function GET() {
 			},
 			RuleWithUseReactFunctionComponentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11303,7 +11303,7 @@ export function GET() {
 			},
 			RuleWithUseReadonlyClassPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11324,7 +11324,7 @@ export function GET() {
 			},
 			RuleWithUseRegexLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11343,7 +11343,7 @@ export function GET() {
 			},
 			RuleWithUseSelfClosingElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11362,7 +11362,7 @@ export function GET() {
 			},
 			RuleWithUseSemanticElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11377,7 +11377,7 @@ export function GET() {
 			},
 			RuleWithUseShorthandAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11396,7 +11396,7 @@ export function GET() {
 			},
 			RuleWithUseShorthandFunctionTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11415,7 +11415,7 @@ export function GET() {
 			},
 			RuleWithUseSimpleNumberKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11434,7 +11434,7 @@ export function GET() {
 			},
 			RuleWithUseSimplifiedLogicExpressionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11455,7 +11455,7 @@ export function GET() {
 			},
 			RuleWithUseSingleJsDocAsteriskOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11474,7 +11474,7 @@ export function GET() {
 			},
 			RuleWithUseSingleVarDeclaratorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11493,7 +11493,7 @@ export function GET() {
 			},
 			RuleWithUseSolidForComponentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11508,7 +11508,7 @@ export function GET() {
 			},
 			RuleWithUseSortedClassesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11527,7 +11527,7 @@ export function GET() {
 			},
 			RuleWithUseStaticResponseMethodsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11546,7 +11546,7 @@ export function GET() {
 			},
 			RuleWithUseStrictModeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11565,7 +11565,7 @@ export function GET() {
 			},
 			RuleWithUseSymbolDescriptionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11580,7 +11580,7 @@ export function GET() {
 			},
 			RuleWithUseTemplateOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11599,7 +11599,7 @@ export function GET() {
 			},
 			RuleWithUseThrowNewErrorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11618,7 +11618,7 @@ export function GET() {
 			},
 			RuleWithUseThrowOnlyErrorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11633,7 +11633,7 @@ export function GET() {
 			},
 			RuleWithUseTopLevelRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11648,7 +11648,7 @@ export function GET() {
 			},
 			RuleWithUseTrimStartEndOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11667,7 +11667,7 @@ export function GET() {
 			},
 			RuleWithUseUnifiedTypeSignaturesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11686,7 +11686,7 @@ export function GET() {
 			},
 			RuleWithUseUniqueElementIdsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11701,7 +11701,7 @@ export function GET() {
 			},
 			RuleWithUseValidAnchorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11716,7 +11716,7 @@ export function GET() {
 			},
 			RuleWithUseValidAriaPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11735,7 +11735,7 @@ export function GET() {
 			},
 			RuleWithUseValidAriaRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11754,7 +11754,7 @@ export function GET() {
 			},
 			RuleWithUseValidAriaValuesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11769,7 +11769,7 @@ export function GET() {
 			},
 			RuleWithUseValidAutocompleteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11784,7 +11784,7 @@ export function GET() {
 			},
 			RuleWithUseValidForDirectionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11799,7 +11799,7 @@ export function GET() {
 			},
 			RuleWithUseValidLangOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11814,7 +11814,7 @@ export function GET() {
 			},
 			RuleWithUseValidTypeofOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11833,7 +11833,7 @@ export function GET() {
 			},
 			RuleWithUseWhileOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11852,7 +11852,7 @@ export function GET() {
 			},
 			RuleWithUseYieldOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",

--- a/src/pages/schemas/2.2.3/schema.json.js
+++ b/src/pages/schemas/2.2.3/schema.json.js
@@ -5778,7 +5778,7 @@ export function GET() {
 			RuleAssistPlainConfiguration: { type: "string", enum: ["off", "on"] },
 			RuleAssistWithOptions_for_OrganizeImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5793,7 +5793,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_UseSortedAttributesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5808,7 +5808,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_UseSortedKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5823,7 +5823,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_UseSortedPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5933,7 +5933,7 @@ export function GET() {
 			},
 			RuleWithNoAccessKeyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -5952,7 +5952,7 @@ export function GET() {
 			},
 			RuleWithNoAccumulatingSpreadOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5967,7 +5967,7 @@ export function GET() {
 			},
 			RuleWithNoAdjacentSpacesInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -5986,7 +5986,7 @@ export function GET() {
 			},
 			RuleWithNoAlertOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6001,7 +6001,7 @@ export function GET() {
 			},
 			RuleWithNoApproximativeNumericConstantOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6022,7 +6022,7 @@ export function GET() {
 			},
 			RuleWithNoArgumentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6037,7 +6037,7 @@ export function GET() {
 			},
 			RuleWithNoAriaHiddenOnFocusableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6056,7 +6056,7 @@ export function GET() {
 			},
 			RuleWithNoAriaUnsupportedElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6075,7 +6075,7 @@ export function GET() {
 			},
 			RuleWithNoArrayIndexKeyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6090,7 +6090,7 @@ export function GET() {
 			},
 			RuleWithNoAssignInExpressionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6105,7 +6105,7 @@ export function GET() {
 			},
 			RuleWithNoAsyncPromiseExecutorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6120,7 +6120,7 @@ export function GET() {
 			},
 			RuleWithNoAutofocusOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6139,7 +6139,7 @@ export function GET() {
 			},
 			RuleWithNoAwaitInLoopsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6154,7 +6154,7 @@ export function GET() {
 			},
 			RuleWithNoBannedTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6173,7 +6173,7 @@ export function GET() {
 			},
 			RuleWithNoBarrelFileOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6188,7 +6188,7 @@ export function GET() {
 			},
 			RuleWithNoBiomeFirstExceptionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6207,7 +6207,7 @@ export function GET() {
 			},
 			RuleWithNoBitwiseOperatorsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6222,7 +6222,7 @@ export function GET() {
 			},
 			RuleWithNoBlankTargetOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6241,7 +6241,7 @@ export function GET() {
 			},
 			RuleWithNoCatchAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6256,7 +6256,7 @@ export function GET() {
 			},
 			RuleWithNoChildrenPropOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6271,7 +6271,7 @@ export function GET() {
 			},
 			RuleWithNoClassAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6286,7 +6286,7 @@ export function GET() {
 			},
 			RuleWithNoCommaOperatorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6301,7 +6301,7 @@ export function GET() {
 			},
 			RuleWithNoCommentTextOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6320,7 +6320,7 @@ export function GET() {
 			},
 			RuleWithNoCommonJsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6335,7 +6335,7 @@ export function GET() {
 			},
 			RuleWithNoCompareNegZeroOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6354,7 +6354,7 @@ export function GET() {
 			},
 			RuleWithNoConfusingLabelsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6369,7 +6369,7 @@ export function GET() {
 			},
 			RuleWithNoConfusingVoidTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6388,7 +6388,7 @@ export function GET() {
 			},
 			RuleWithNoConsoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6407,7 +6407,7 @@ export function GET() {
 			},
 			RuleWithNoConstAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6426,7 +6426,7 @@ export function GET() {
 			},
 			RuleWithNoConstEnumOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6445,7 +6445,7 @@ export function GET() {
 			},
 			RuleWithNoConstantBinaryExpressionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6462,7 +6462,7 @@ export function GET() {
 			},
 			RuleWithNoConstantConditionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6477,7 +6477,7 @@ export function GET() {
 			},
 			RuleWithNoConstantMathMinMaxClampOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6496,7 +6496,7 @@ export function GET() {
 			},
 			RuleWithNoConstructorReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6511,7 +6511,7 @@ export function GET() {
 			},
 			RuleWithNoControlCharactersInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6528,7 +6528,7 @@ export function GET() {
 			},
 			RuleWithNoDangerouslySetInnerHtmlOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6543,7 +6543,7 @@ export function GET() {
 			},
 			RuleWithNoDangerouslySetInnerHtmlWithChildrenOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6562,7 +6562,7 @@ export function GET() {
 			},
 			RuleWithNoDebuggerOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6581,7 +6581,7 @@ export function GET() {
 			},
 			RuleWithNoDefaultExportOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6596,7 +6596,7 @@ export function GET() {
 			},
 			RuleWithNoDeleteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6615,7 +6615,7 @@ export function GET() {
 			},
 			RuleWithNoDescendingSpecificityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6630,7 +6630,7 @@ export function GET() {
 			},
 			RuleWithNoDistractingElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6649,7 +6649,7 @@ export function GET() {
 			},
 			RuleWithNoDocumentCookieOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6664,7 +6664,7 @@ export function GET() {
 			},
 			RuleWithNoDocumentImportInPageOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6679,7 +6679,7 @@ export function GET() {
 			},
 			RuleWithNoDoneCallbackOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6694,7 +6694,7 @@ export function GET() {
 			},
 			RuleWithNoDoubleEqualsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6713,7 +6713,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateAtImportRulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6728,7 +6728,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateCaseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6743,7 +6743,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateClassMembersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6758,7 +6758,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateCustomPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6775,7 +6775,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateElseIfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6790,7 +6790,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateFieldsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6805,7 +6805,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateFontNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6820,7 +6820,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateJsxPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6835,7 +6835,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateObjectKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6850,7 +6850,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateParametersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6865,7 +6865,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicatePropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6880,7 +6880,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateSelectorsKeyframeBlockOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6899,7 +6899,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateTestHooksOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6914,7 +6914,7 @@ export function GET() {
 			},
 			RuleWithNoDynamicNamespaceImportAccessOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6931,7 +6931,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyBlockOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6946,7 +6946,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyBlockStatementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6961,7 +6961,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyCharacterClassInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6978,7 +6978,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyInterfaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6997,7 +6997,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyPatternOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7012,7 +7012,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyTypeParametersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7027,7 +7027,7 @@ export function GET() {
 			},
 			RuleWithNoEnumOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7042,7 +7042,7 @@ export function GET() {
 			},
 			RuleWithNoEvolvingTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7057,7 +7057,7 @@ export function GET() {
 			},
 			RuleWithNoExcessiveCognitiveComplexityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7074,7 +7074,7 @@ export function GET() {
 			},
 			RuleWithNoExcessiveLinesPerFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7091,7 +7091,7 @@ export function GET() {
 			},
 			RuleWithNoExcessiveNestedTestSuitesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7108,7 +7108,7 @@ export function GET() {
 			},
 			RuleWithNoExplicitAnyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7123,7 +7123,7 @@ export function GET() {
 			},
 			RuleWithNoExportedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7138,7 +7138,7 @@ export function GET() {
 			},
 			RuleWithNoExportsInTestOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7153,7 +7153,7 @@ export function GET() {
 			},
 			RuleWithNoExtraBooleanCastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7172,7 +7172,7 @@ export function GET() {
 			},
 			RuleWithNoExtraNonNullAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7191,7 +7191,7 @@ export function GET() {
 			},
 			RuleWithNoFallthroughSwitchClauseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7206,7 +7206,7 @@ export function GET() {
 			},
 			RuleWithNoFlatMapIdentityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7225,7 +7225,7 @@ export function GET() {
 			},
 			RuleWithNoFloatingPromisesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7244,7 +7244,7 @@ export function GET() {
 			},
 			RuleWithNoFocusedTestsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7263,7 +7263,7 @@ export function GET() {
 			},
 			RuleWithNoForEachOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7278,7 +7278,7 @@ export function GET() {
 			},
 			RuleWithNoFunctionAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7293,7 +7293,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7308,7 +7308,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalDirnameFilenameOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7327,7 +7327,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalEvalOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7342,7 +7342,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalIsFiniteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7361,7 +7361,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalIsNanOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7380,7 +7380,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalObjectCallsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7395,7 +7395,7 @@ export function GET() {
 			},
 			RuleWithNoHeadElementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7410,7 +7410,7 @@ export function GET() {
 			},
 			RuleWithNoHeadImportInDocumentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7425,7 +7425,7 @@ export function GET() {
 			},
 			RuleWithNoHeaderScopeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7444,7 +7444,7 @@ export function GET() {
 			},
 			RuleWithNoImgElementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7459,7 +7459,7 @@ export function GET() {
 			},
 			RuleWithNoImplicitAnyLetOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7474,7 +7474,7 @@ export function GET() {
 			},
 			RuleWithNoImplicitBooleanOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7493,7 +7493,7 @@ export function GET() {
 			},
 			RuleWithNoImplicitCoercionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7512,7 +7512,7 @@ export function GET() {
 			},
 			RuleWithNoImportAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7527,7 +7527,7 @@ export function GET() {
 			},
 			RuleWithNoImportCyclesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7542,7 +7542,7 @@ export function GET() {
 			},
 			RuleWithNoImportantInKeyframeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7557,7 +7557,7 @@ export function GET() {
 			},
 			RuleWithNoImportantStylesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7576,7 +7576,7 @@ export function GET() {
 			},
 			RuleWithNoInferrableTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7595,7 +7595,7 @@ export function GET() {
 			},
 			RuleWithNoInnerDeclarationsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7610,7 +7610,7 @@ export function GET() {
 			},
 			RuleWithNoInteractiveElementToNoninteractiveRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7633,7 +7633,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidBuiltinInstantiationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7654,7 +7654,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidConstructorSuperOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7669,7 +7669,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidDirectionInLinearGradientOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7688,7 +7688,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidGridAreasOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7703,7 +7703,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidPositionAtImportRuleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7720,7 +7720,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidUseBeforeDeclarationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7737,7 +7737,7 @@ export function GET() {
 			},
 			RuleWithNoIrregularWhitespaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7752,7 +7752,7 @@ export function GET() {
 			},
 			RuleWithNoLabelVarOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7767,7 +7767,7 @@ export function GET() {
 			},
 			RuleWithNoLabelWithoutControlOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7782,7 +7782,7 @@ export function GET() {
 			},
 			RuleWithNoMagicNumbersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7797,7 +7797,7 @@ export function GET() {
 			},
 			RuleWithNoMisleadingCharacterClassOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7818,7 +7818,7 @@ export function GET() {
 			},
 			RuleWithNoMisleadingInstantiatorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7833,7 +7833,7 @@ export function GET() {
 			},
 			RuleWithNoMisplacedAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7848,7 +7848,7 @@ export function GET() {
 			},
 			RuleWithNoMisrefactoredShorthandAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7869,7 +7869,7 @@ export function GET() {
 			},
 			RuleWithNoMissingVarFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7884,7 +7884,7 @@ export function GET() {
 			},
 			RuleWithNoMisusedPromisesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7903,7 +7903,7 @@ export function GET() {
 			},
 			RuleWithNoNamespaceImportOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7918,7 +7918,7 @@ export function GET() {
 			},
 			RuleWithNoNamespaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7933,7 +7933,7 @@ export function GET() {
 			},
 			RuleWithNoNegationElseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7952,7 +7952,7 @@ export function GET() {
 			},
 			RuleWithNoNestedComponentDefinitionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7969,7 +7969,7 @@ export function GET() {
 			},
 			RuleWithNoNestedTernaryOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7984,7 +7984,7 @@ export function GET() {
 			},
 			RuleWithNoNextAsyncClientComponentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8001,7 +8001,7 @@ export function GET() {
 			},
 			RuleWithNoNodejsModulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8016,7 +8016,7 @@ export function GET() {
 			},
 			RuleWithNoNonNullAssertedOptionalChainOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8033,7 +8033,7 @@ export function GET() {
 			},
 			RuleWithNoNonNullAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8052,7 +8052,7 @@ export function GET() {
 			},
 			RuleWithNoNoninteractiveElementInteractionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8071,7 +8071,7 @@ export function GET() {
 			},
 			RuleWithNoNoninteractiveElementToInteractiveRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8094,7 +8094,7 @@ export function GET() {
 			},
 			RuleWithNoNoninteractiveTabindexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8113,7 +8113,7 @@ export function GET() {
 			},
 			RuleWithNoNonoctalDecimalEscapeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8132,7 +8132,7 @@ export function GET() {
 			},
 			RuleWithNoOctalEscapeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8151,7 +8151,7 @@ export function GET() {
 			},
 			RuleWithNoParameterAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8166,7 +8166,7 @@ export function GET() {
 			},
 			RuleWithNoParameterPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8181,7 +8181,7 @@ export function GET() {
 			},
 			RuleWithNoPositiveTabindexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8200,7 +8200,7 @@ export function GET() {
 			},
 			RuleWithNoPrecisionLossOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8215,7 +8215,7 @@ export function GET() {
 			},
 			RuleWithNoPrivateImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8230,7 +8230,7 @@ export function GET() {
 			},
 			RuleWithNoProcessEnvOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8245,7 +8245,7 @@ export function GET() {
 			},
 			RuleWithNoProcessGlobalOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8264,7 +8264,7 @@ export function GET() {
 			},
 			RuleWithNoPrototypeBuiltinsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8283,7 +8283,7 @@ export function GET() {
 			},
 			RuleWithNoQuickfixBiomeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8302,7 +8302,7 @@ export function GET() {
 			},
 			RuleWithNoQwikUseVisibleTaskOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8317,7 +8317,7 @@ export function GET() {
 			},
 			RuleWithNoReExportAllOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8332,7 +8332,7 @@ export function GET() {
 			},
 			RuleWithNoReactPropAssignmentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8347,7 +8347,7 @@ export function GET() {
 			},
 			RuleWithNoReactSpecificPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8366,7 +8366,7 @@ export function GET() {
 			},
 			RuleWithNoRedeclareOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8381,7 +8381,7 @@ export function GET() {
 			},
 			RuleWithNoRedundantAltOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8396,7 +8396,7 @@ export function GET() {
 			},
 			RuleWithNoRedundantRolesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8415,7 +8415,7 @@ export function GET() {
 			},
 			RuleWithNoRedundantUseStrictOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8434,7 +8434,7 @@ export function GET() {
 			},
 			RuleWithNoRenderReturnValueOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8449,7 +8449,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8464,7 +8464,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedGlobalsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8479,7 +8479,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8494,7 +8494,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8513,7 +8513,7 @@ export function GET() {
 			},
 			RuleWithNoSecretsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8528,7 +8528,7 @@ export function GET() {
 			},
 			RuleWithNoSelfAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8543,7 +8543,7 @@ export function GET() {
 			},
 			RuleWithNoSelfCompareOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8558,7 +8558,7 @@ export function GET() {
 			},
 			RuleWithNoSetterReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8573,7 +8573,7 @@ export function GET() {
 			},
 			RuleWithNoShadowOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8588,7 +8588,7 @@ export function GET() {
 			},
 			RuleWithNoShadowRestrictedNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8603,7 +8603,7 @@ export function GET() {
 			},
 			RuleWithNoShorthandPropertyOverridesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8620,7 +8620,7 @@ export function GET() {
 			},
 			RuleWithNoShoutyConstantsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8639,7 +8639,7 @@ export function GET() {
 			},
 			RuleWithNoSkippedTestsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8658,7 +8658,7 @@ export function GET() {
 			},
 			RuleWithNoSolidDestructuredPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8673,7 +8673,7 @@ export function GET() {
 			},
 			RuleWithNoSparseArrayOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8692,7 +8692,7 @@ export function GET() {
 			},
 			RuleWithNoStaticElementInteractionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8709,7 +8709,7 @@ export function GET() {
 			},
 			RuleWithNoStaticOnlyClassOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8724,7 +8724,7 @@ export function GET() {
 			},
 			RuleWithNoStringCaseMismatchOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8743,7 +8743,7 @@ export function GET() {
 			},
 			RuleWithNoSubstrOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8762,7 +8762,7 @@ export function GET() {
 			},
 			RuleWithNoSuspiciousSemicolonInJsxOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8779,7 +8779,7 @@ export function GET() {
 			},
 			RuleWithNoSvgWithoutTitleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8794,7 +8794,7 @@ export function GET() {
 			},
 			RuleWithNoSwitchDeclarationsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8813,7 +8813,7 @@ export function GET() {
 			},
 			RuleWithNoTemplateCurlyInStringOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8828,7 +8828,7 @@ export function GET() {
 			},
 			RuleWithNoThenPropertyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8843,7 +8843,7 @@ export function GET() {
 			},
 			RuleWithNoThisInStaticOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8862,7 +8862,7 @@ export function GET() {
 			},
 			RuleWithNoTsIgnoreOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8881,7 +8881,7 @@ export function GET() {
 			},
 			RuleWithNoUnassignedVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8896,7 +8896,7 @@ export function GET() {
 			},
 			RuleWithNoUndeclaredDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8911,7 +8911,7 @@ export function GET() {
 			},
 			RuleWithNoUndeclaredVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8926,7 +8926,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownAtRulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8941,7 +8941,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8956,7 +8956,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownMediaFeatureNameOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8971,7 +8971,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownPropertyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8986,7 +8986,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownPseudoClassOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9001,7 +9001,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownPseudoElementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9016,7 +9016,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownTypeSelectorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9031,7 +9031,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownUnitOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9046,7 +9046,7 @@ export function GET() {
 			},
 			RuleWithNoUnmatchableAnbSelectorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9061,7 +9061,7 @@ export function GET() {
 			},
 			RuleWithNoUnnecessaryConditionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9076,7 +9076,7 @@ export function GET() {
 			},
 			RuleWithNoUnreachableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9091,7 +9091,7 @@ export function GET() {
 			},
 			RuleWithNoUnreachableSuperOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9106,7 +9106,7 @@ export function GET() {
 			},
 			RuleWithNoUnresolvedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9121,7 +9121,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeDeclarationMergingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9138,7 +9138,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeFinallyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9153,7 +9153,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeNegationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9172,7 +9172,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeOptionalChainingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9187,7 +9187,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedFunctionParametersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9208,7 +9208,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9227,7 +9227,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedLabelsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9246,7 +9246,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedPrivateClassMembersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9267,7 +9267,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedTemplateLiteralOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9286,7 +9286,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9305,7 +9305,7 @@ export function GET() {
 			},
 			RuleWithNoUnwantedPolyfillioOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9320,7 +9320,7 @@ export function GET() {
 			},
 			RuleWithNoUselessCatchBindingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9339,7 +9339,7 @@ export function GET() {
 			},
 			RuleWithNoUselessCatchOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9358,7 +9358,7 @@ export function GET() {
 			},
 			RuleWithNoUselessConstructorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9377,7 +9377,7 @@ export function GET() {
 			},
 			RuleWithNoUselessContinueOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9396,7 +9396,7 @@ export function GET() {
 			},
 			RuleWithNoUselessElseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9415,7 +9415,7 @@ export function GET() {
 			},
 			RuleWithNoUselessEmptyExportOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9434,7 +9434,7 @@ export function GET() {
 			},
 			RuleWithNoUselessEscapeInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9453,7 +9453,7 @@ export function GET() {
 			},
 			RuleWithNoUselessEscapeInStringOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9472,7 +9472,7 @@ export function GET() {
 			},
 			RuleWithNoUselessFragmentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9491,7 +9491,7 @@ export function GET() {
 			},
 			RuleWithNoUselessLabelOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9510,7 +9510,7 @@ export function GET() {
 			},
 			RuleWithNoUselessLoneBlockStatementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9531,7 +9531,7 @@ export function GET() {
 			},
 			RuleWithNoUselessRegexBackrefsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9546,7 +9546,7 @@ export function GET() {
 			},
 			RuleWithNoUselessRenameOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9565,7 +9565,7 @@ export function GET() {
 			},
 			RuleWithNoUselessStringConcatOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9584,7 +9584,7 @@ export function GET() {
 			},
 			RuleWithNoUselessStringRawOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9599,7 +9599,7 @@ export function GET() {
 			},
 			RuleWithNoUselessSwitchCaseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9618,7 +9618,7 @@ export function GET() {
 			},
 			RuleWithNoUselessTernaryOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9637,7 +9637,7 @@ export function GET() {
 			},
 			RuleWithNoUselessThisAliasOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9656,7 +9656,7 @@ export function GET() {
 			},
 			RuleWithNoUselessTypeConstraintOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9675,7 +9675,7 @@ export function GET() {
 			},
 			RuleWithNoUselessUndefinedInitializationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9696,7 +9696,7 @@ export function GET() {
 			},
 			RuleWithNoUselessUndefinedOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9715,7 +9715,7 @@ export function GET() {
 			},
 			RuleWithNoValueAtRuleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9730,7 +9730,7 @@ export function GET() {
 			},
 			RuleWithNoVarOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9749,7 +9749,7 @@ export function GET() {
 			},
 			RuleWithNoVoidElementsWithChildrenOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9770,7 +9770,7 @@ export function GET() {
 			},
 			RuleWithNoVoidOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9785,7 +9785,7 @@ export function GET() {
 			},
 			RuleWithNoVoidTypeReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9800,7 +9800,7 @@ export function GET() {
 			},
 			RuleWithNoVueDataObjectDeclarationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9821,7 +9821,7 @@ export function GET() {
 			},
 			RuleWithNoVueReservedKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9836,7 +9836,7 @@ export function GET() {
 			},
 			RuleWithNoVueReservedPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9851,7 +9851,7 @@ export function GET() {
 			},
 			RuleWithNoWithOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9866,7 +9866,7 @@ export function GET() {
 			},
 			RuleWithNoYodaExpressionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9885,7 +9885,7 @@ export function GET() {
 			},
 			RuleWithUseAdjacentOverloadSignaturesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9902,7 +9902,7 @@ export function GET() {
 			},
 			RuleWithUseAltTextOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9917,7 +9917,7 @@ export function GET() {
 			},
 			RuleWithUseAnchorContentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9936,7 +9936,7 @@ export function GET() {
 			},
 			RuleWithUseAnchorHrefOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9951,7 +9951,7 @@ export function GET() {
 			},
 			RuleWithUseAriaActivedescendantWithTabindexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9974,7 +9974,7 @@ export function GET() {
 			},
 			RuleWithUseAriaPropsForRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9989,7 +9989,7 @@ export function GET() {
 			},
 			RuleWithUseAriaPropsSupportedByRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10006,7 +10006,7 @@ export function GET() {
 			},
 			RuleWithUseArrayLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10025,7 +10025,7 @@ export function GET() {
 			},
 			RuleWithUseArrowFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10044,7 +10044,7 @@ export function GET() {
 			},
 			RuleWithUseAsConstAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10063,7 +10063,7 @@ export function GET() {
 			},
 			RuleWithUseAtIndexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10082,7 +10082,7 @@ export function GET() {
 			},
 			RuleWithUseAwaitOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10097,7 +10097,7 @@ export function GET() {
 			},
 			RuleWithUseBiomeIgnoreFolderOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10116,7 +10116,7 @@ export function GET() {
 			},
 			RuleWithUseBlockStatementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10135,7 +10135,7 @@ export function GET() {
 			},
 			RuleWithUseButtonTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10150,7 +10150,7 @@ export function GET() {
 			},
 			RuleWithUseCollapsedElseIfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10169,7 +10169,7 @@ export function GET() {
 			},
 			RuleWithUseCollapsedIfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10188,7 +10188,7 @@ export function GET() {
 			},
 			RuleWithUseComponentExportOnlyModulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10205,7 +10205,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentArrayTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10224,7 +10224,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentArrowReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10243,7 +10243,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentBuiltinInstantiationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10266,7 +10266,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentCurlyBracesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10285,7 +10285,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentMemberAccessibilityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10302,7 +10302,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentObjectDefinitionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10323,7 +10323,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentTypeDefinitionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10344,7 +10344,7 @@ export function GET() {
 			},
 			RuleWithUseConstOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10363,7 +10363,7 @@ export function GET() {
 			},
 			RuleWithUseDateNowOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10382,7 +10382,7 @@ export function GET() {
 			},
 			RuleWithUseDefaultParameterLastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10401,7 +10401,7 @@ export function GET() {
 			},
 			RuleWithUseDefaultSwitchClauseLastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10418,7 +10418,7 @@ export function GET() {
 			},
 			RuleWithUseDefaultSwitchClauseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10433,7 +10433,7 @@ export function GET() {
 			},
 			RuleWithUseDeprecatedReasonOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10448,7 +10448,7 @@ export function GET() {
 			},
 			RuleWithUseEnumInitializersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10467,7 +10467,7 @@ export function GET() {
 			},
 			RuleWithUseErrorMessageOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10482,7 +10482,7 @@ export function GET() {
 			},
 			RuleWithUseExhaustiveDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10501,7 +10501,7 @@ export function GET() {
 			},
 			RuleWithUseExhaustiveSwitchCasesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10520,7 +10520,7 @@ export function GET() {
 			},
 			RuleWithUseExplicitLengthCheckOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10539,7 +10539,7 @@ export function GET() {
 			},
 			RuleWithUseExplicitTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10554,7 +10554,7 @@ export function GET() {
 			},
 			RuleWithUseExponentiationOperatorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10573,7 +10573,7 @@ export function GET() {
 			},
 			RuleWithUseExportTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10592,7 +10592,7 @@ export function GET() {
 			},
 			RuleWithUseExportsLastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10607,7 +10607,7 @@ export function GET() {
 			},
 			RuleWithUseFilenamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10622,7 +10622,7 @@ export function GET() {
 			},
 			RuleWithUseFlatMapOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10641,7 +10641,7 @@ export function GET() {
 			},
 			RuleWithUseFocusableInteractiveOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10656,7 +10656,7 @@ export function GET() {
 			},
 			RuleWithUseForOfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10671,7 +10671,7 @@ export function GET() {
 			},
 			RuleWithUseFragmentSyntaxOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10690,7 +10690,7 @@ export function GET() {
 			},
 			RuleWithUseGenericFontNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10705,7 +10705,7 @@ export function GET() {
 			},
 			RuleWithUseGetterReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10720,7 +10720,7 @@ export function GET() {
 			},
 			RuleWithUseGoogleFontDisplayOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10735,7 +10735,7 @@ export function GET() {
 			},
 			RuleWithUseGoogleFontPreconnectOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10754,7 +10754,7 @@ export function GET() {
 			},
 			RuleWithUseGraphqlNamedOperationsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10773,7 +10773,7 @@ export function GET() {
 			},
 			RuleWithUseGraphqlNamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10790,7 +10790,7 @@ export function GET() {
 			},
 			RuleWithUseGroupedAccessorPairsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10805,7 +10805,7 @@ export function GET() {
 			},
 			RuleWithUseGuardForInOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10820,7 +10820,7 @@ export function GET() {
 			},
 			RuleWithUseHeadingContentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10835,7 +10835,7 @@ export function GET() {
 			},
 			RuleWithUseHookAtTopLevelOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10850,7 +10850,7 @@ export function GET() {
 			},
 			RuleWithUseHtmlLangOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10865,7 +10865,7 @@ export function GET() {
 			},
 			RuleWithUseIframeTitleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10880,7 +10880,7 @@ export function GET() {
 			},
 			RuleWithUseImageSizeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10895,7 +10895,7 @@ export function GET() {
 			},
 			RuleWithUseImportExtensionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10914,7 +10914,7 @@ export function GET() {
 			},
 			RuleWithUseImportTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10933,7 +10933,7 @@ export function GET() {
 			},
 			RuleWithUseIndexOfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10952,7 +10952,7 @@ export function GET() {
 			},
 			RuleWithUseIsArrayOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10971,7 +10971,7 @@ export function GET() {
 			},
 			RuleWithUseIsNanOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10990,7 +10990,7 @@ export function GET() {
 			},
 			RuleWithUseIterableCallbackReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11005,7 +11005,7 @@ export function GET() {
 			},
 			RuleWithUseJsonImportAttributesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11024,7 +11024,7 @@ export function GET() {
 			},
 			RuleWithUseJsxKeyInIterableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11039,7 +11039,7 @@ export function GET() {
 			},
 			RuleWithUseKeyWithClickEventsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11054,7 +11054,7 @@ export function GET() {
 			},
 			RuleWithUseKeyWithMouseEventsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11069,7 +11069,7 @@ export function GET() {
 			},
 			RuleWithUseLiteralEnumMembersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11084,7 +11084,7 @@ export function GET() {
 			},
 			RuleWithUseLiteralKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11103,7 +11103,7 @@ export function GET() {
 			},
 			RuleWithUseMaxParamsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11118,7 +11118,7 @@ export function GET() {
 			},
 			RuleWithUseMediaCaptionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11133,7 +11133,7 @@ export function GET() {
 			},
 			RuleWithUseNamespaceKeywordOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11152,7 +11152,7 @@ export function GET() {
 			},
 			RuleWithUseNamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11171,7 +11171,7 @@ export function GET() {
 			},
 			RuleWithUseNodeAssertStrictOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11190,7 +11190,7 @@ export function GET() {
 			},
 			RuleWithUseNodejsImportProtocolOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11209,7 +11209,7 @@ export function GET() {
 			},
 			RuleWithUseNumberNamespaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11228,7 +11228,7 @@ export function GET() {
 			},
 			RuleWithUseNumberToFixedDigitsArgumentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11249,7 +11249,7 @@ export function GET() {
 			},
 			RuleWithUseNumericLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11268,7 +11268,7 @@ export function GET() {
 			},
 			RuleWithUseNumericSeparatorsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11287,7 +11287,7 @@ export function GET() {
 			},
 			RuleWithUseObjectSpreadOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11306,7 +11306,7 @@ export function GET() {
 			},
 			RuleWithUseOptionalChainOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11325,7 +11325,7 @@ export function GET() {
 			},
 			RuleWithUseParseIntRadixOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11344,7 +11344,7 @@ export function GET() {
 			},
 			RuleWithUseQwikClasslistOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11359,7 +11359,7 @@ export function GET() {
 			},
 			RuleWithUseReactFunctionComponentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11376,7 +11376,7 @@ export function GET() {
 			},
 			RuleWithUseReadonlyClassPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11397,7 +11397,7 @@ export function GET() {
 			},
 			RuleWithUseRegexLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11416,7 +11416,7 @@ export function GET() {
 			},
 			RuleWithUseSelfClosingElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11435,7 +11435,7 @@ export function GET() {
 			},
 			RuleWithUseSemanticElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11450,7 +11450,7 @@ export function GET() {
 			},
 			RuleWithUseShorthandAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11469,7 +11469,7 @@ export function GET() {
 			},
 			RuleWithUseShorthandFunctionTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11488,7 +11488,7 @@ export function GET() {
 			},
 			RuleWithUseSimpleNumberKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11507,7 +11507,7 @@ export function GET() {
 			},
 			RuleWithUseSimplifiedLogicExpressionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11528,7 +11528,7 @@ export function GET() {
 			},
 			RuleWithUseSingleJsDocAsteriskOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11547,7 +11547,7 @@ export function GET() {
 			},
 			RuleWithUseSingleVarDeclaratorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11566,7 +11566,7 @@ export function GET() {
 			},
 			RuleWithUseSolidForComponentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11581,7 +11581,7 @@ export function GET() {
 			},
 			RuleWithUseSortedClassesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11600,7 +11600,7 @@ export function GET() {
 			},
 			RuleWithUseStaticResponseMethodsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11619,7 +11619,7 @@ export function GET() {
 			},
 			RuleWithUseStrictModeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11638,7 +11638,7 @@ export function GET() {
 			},
 			RuleWithUseSymbolDescriptionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11653,7 +11653,7 @@ export function GET() {
 			},
 			RuleWithUseTemplateOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11672,7 +11672,7 @@ export function GET() {
 			},
 			RuleWithUseThrowNewErrorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11691,7 +11691,7 @@ export function GET() {
 			},
 			RuleWithUseThrowOnlyErrorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11706,7 +11706,7 @@ export function GET() {
 			},
 			RuleWithUseTopLevelRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11721,7 +11721,7 @@ export function GET() {
 			},
 			RuleWithUseTrimStartEndOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11740,7 +11740,7 @@ export function GET() {
 			},
 			RuleWithUseUnifiedTypeSignaturesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11759,7 +11759,7 @@ export function GET() {
 			},
 			RuleWithUseUniqueElementIdsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11774,7 +11774,7 @@ export function GET() {
 			},
 			RuleWithUseValidAnchorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11789,7 +11789,7 @@ export function GET() {
 			},
 			RuleWithUseValidAriaPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11808,7 +11808,7 @@ export function GET() {
 			},
 			RuleWithUseValidAriaRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11827,7 +11827,7 @@ export function GET() {
 			},
 			RuleWithUseValidAriaValuesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11842,7 +11842,7 @@ export function GET() {
 			},
 			RuleWithUseValidAutocompleteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11857,7 +11857,7 @@ export function GET() {
 			},
 			RuleWithUseValidForDirectionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11872,7 +11872,7 @@ export function GET() {
 			},
 			RuleWithUseValidLangOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11887,7 +11887,7 @@ export function GET() {
 			},
 			RuleWithUseValidTypeofOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11906,7 +11906,7 @@ export function GET() {
 			},
 			RuleWithUseVueMultiWordComponentNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11923,7 +11923,7 @@ export function GET() {
 			},
 			RuleWithUseWhileOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11942,7 +11942,7 @@ export function GET() {
 			},
 			RuleWithUseYieldOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",

--- a/src/pages/schemas/2.2.4/schema.json.js
+++ b/src/pages/schemas/2.2.4/schema.json.js
@@ -5834,7 +5834,7 @@ export function GET() {
 			RuleAssistPlainConfiguration: { type: "string", enum: ["off", "on"] },
 			RuleAssistWithOptions_for_OrganizeImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5849,7 +5849,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_UseSortedAttributesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5864,7 +5864,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_UseSortedKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5879,7 +5879,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_UseSortedPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5989,7 +5989,7 @@ export function GET() {
 			},
 			RuleWithNoAccessKeyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6008,7 +6008,7 @@ export function GET() {
 			},
 			RuleWithNoAccumulatingSpreadOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6023,7 +6023,7 @@ export function GET() {
 			},
 			RuleWithNoAdjacentSpacesInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6042,7 +6042,7 @@ export function GET() {
 			},
 			RuleWithNoAlertOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6057,7 +6057,7 @@ export function GET() {
 			},
 			RuleWithNoApproximativeNumericConstantOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6078,7 +6078,7 @@ export function GET() {
 			},
 			RuleWithNoArgumentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6093,7 +6093,7 @@ export function GET() {
 			},
 			RuleWithNoAriaHiddenOnFocusableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6112,7 +6112,7 @@ export function GET() {
 			},
 			RuleWithNoAriaUnsupportedElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6131,7 +6131,7 @@ export function GET() {
 			},
 			RuleWithNoArrayIndexKeyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6146,7 +6146,7 @@ export function GET() {
 			},
 			RuleWithNoAssignInExpressionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6161,7 +6161,7 @@ export function GET() {
 			},
 			RuleWithNoAsyncPromiseExecutorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6176,7 +6176,7 @@ export function GET() {
 			},
 			RuleWithNoAutofocusOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6195,7 +6195,7 @@ export function GET() {
 			},
 			RuleWithNoAwaitInLoopsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6210,7 +6210,7 @@ export function GET() {
 			},
 			RuleWithNoBannedTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6229,7 +6229,7 @@ export function GET() {
 			},
 			RuleWithNoBarrelFileOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6244,7 +6244,7 @@ export function GET() {
 			},
 			RuleWithNoBiomeFirstExceptionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6263,7 +6263,7 @@ export function GET() {
 			},
 			RuleWithNoBitwiseOperatorsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6278,7 +6278,7 @@ export function GET() {
 			},
 			RuleWithNoBlankTargetOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6297,7 +6297,7 @@ export function GET() {
 			},
 			RuleWithNoCatchAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6312,7 +6312,7 @@ export function GET() {
 			},
 			RuleWithNoChildrenPropOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6327,7 +6327,7 @@ export function GET() {
 			},
 			RuleWithNoClassAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6342,7 +6342,7 @@ export function GET() {
 			},
 			RuleWithNoCommaOperatorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6357,7 +6357,7 @@ export function GET() {
 			},
 			RuleWithNoCommentTextOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6376,7 +6376,7 @@ export function GET() {
 			},
 			RuleWithNoCommonJsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6391,7 +6391,7 @@ export function GET() {
 			},
 			RuleWithNoCompareNegZeroOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6410,7 +6410,7 @@ export function GET() {
 			},
 			RuleWithNoConfusingLabelsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6425,7 +6425,7 @@ export function GET() {
 			},
 			RuleWithNoConfusingVoidTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6444,7 +6444,7 @@ export function GET() {
 			},
 			RuleWithNoConsoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6463,7 +6463,7 @@ export function GET() {
 			},
 			RuleWithNoConstAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6482,7 +6482,7 @@ export function GET() {
 			},
 			RuleWithNoConstEnumOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6501,7 +6501,7 @@ export function GET() {
 			},
 			RuleWithNoConstantBinaryExpressionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6518,7 +6518,7 @@ export function GET() {
 			},
 			RuleWithNoConstantConditionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6533,7 +6533,7 @@ export function GET() {
 			},
 			RuleWithNoConstantMathMinMaxClampOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6552,7 +6552,7 @@ export function GET() {
 			},
 			RuleWithNoConstructorReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6567,7 +6567,7 @@ export function GET() {
 			},
 			RuleWithNoControlCharactersInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6584,7 +6584,7 @@ export function GET() {
 			},
 			RuleWithNoDangerouslySetInnerHtmlOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6599,7 +6599,7 @@ export function GET() {
 			},
 			RuleWithNoDangerouslySetInnerHtmlWithChildrenOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6618,7 +6618,7 @@ export function GET() {
 			},
 			RuleWithNoDebuggerOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6637,7 +6637,7 @@ export function GET() {
 			},
 			RuleWithNoDefaultExportOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6652,7 +6652,7 @@ export function GET() {
 			},
 			RuleWithNoDeleteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6671,7 +6671,7 @@ export function GET() {
 			},
 			RuleWithNoDescendingSpecificityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6686,7 +6686,7 @@ export function GET() {
 			},
 			RuleWithNoDistractingElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6705,7 +6705,7 @@ export function GET() {
 			},
 			RuleWithNoDocumentCookieOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6720,7 +6720,7 @@ export function GET() {
 			},
 			RuleWithNoDocumentImportInPageOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6735,7 +6735,7 @@ export function GET() {
 			},
 			RuleWithNoDoneCallbackOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6750,7 +6750,7 @@ export function GET() {
 			},
 			RuleWithNoDoubleEqualsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6769,7 +6769,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateAtImportRulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6784,7 +6784,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateCaseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6799,7 +6799,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateClassMembersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6814,7 +6814,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateCustomPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6831,7 +6831,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6846,7 +6846,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateElseIfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6861,7 +6861,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateFieldsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6876,7 +6876,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateFontNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6891,7 +6891,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateJsxPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6906,7 +6906,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateObjectKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6921,7 +6921,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateParametersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6936,7 +6936,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicatePropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6951,7 +6951,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateSelectorsKeyframeBlockOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6970,7 +6970,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateTestHooksOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6985,7 +6985,7 @@ export function GET() {
 			},
 			RuleWithNoDynamicNamespaceImportAccessOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7002,7 +7002,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyBlockOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7017,7 +7017,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyBlockStatementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7032,7 +7032,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyCharacterClassInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7049,7 +7049,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyInterfaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7068,7 +7068,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyPatternOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7083,7 +7083,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyTypeParametersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7098,7 +7098,7 @@ export function GET() {
 			},
 			RuleWithNoEnumOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7113,7 +7113,7 @@ export function GET() {
 			},
 			RuleWithNoEvolvingTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7128,7 +7128,7 @@ export function GET() {
 			},
 			RuleWithNoExcessiveCognitiveComplexityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7145,7 +7145,7 @@ export function GET() {
 			},
 			RuleWithNoExcessiveLinesPerFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7162,7 +7162,7 @@ export function GET() {
 			},
 			RuleWithNoExcessiveNestedTestSuitesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7179,7 +7179,7 @@ export function GET() {
 			},
 			RuleWithNoExplicitAnyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7194,7 +7194,7 @@ export function GET() {
 			},
 			RuleWithNoExportedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7209,7 +7209,7 @@ export function GET() {
 			},
 			RuleWithNoExportsInTestOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7224,7 +7224,7 @@ export function GET() {
 			},
 			RuleWithNoExtraBooleanCastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7243,7 +7243,7 @@ export function GET() {
 			},
 			RuleWithNoExtraNonNullAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7262,7 +7262,7 @@ export function GET() {
 			},
 			RuleWithNoFallthroughSwitchClauseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7277,7 +7277,7 @@ export function GET() {
 			},
 			RuleWithNoFlatMapIdentityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7296,7 +7296,7 @@ export function GET() {
 			},
 			RuleWithNoFloatingPromisesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7315,7 +7315,7 @@ export function GET() {
 			},
 			RuleWithNoFocusedTestsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7334,7 +7334,7 @@ export function GET() {
 			},
 			RuleWithNoForEachOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7349,7 +7349,7 @@ export function GET() {
 			},
 			RuleWithNoFunctionAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7364,7 +7364,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7379,7 +7379,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalDirnameFilenameOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7398,7 +7398,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalEvalOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7413,7 +7413,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalIsFiniteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7432,7 +7432,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalIsNanOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7451,7 +7451,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalObjectCallsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7466,7 +7466,7 @@ export function GET() {
 			},
 			RuleWithNoHeadElementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7481,7 +7481,7 @@ export function GET() {
 			},
 			RuleWithNoHeadImportInDocumentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7496,7 +7496,7 @@ export function GET() {
 			},
 			RuleWithNoHeaderScopeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7515,7 +7515,7 @@ export function GET() {
 			},
 			RuleWithNoImgElementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7530,7 +7530,7 @@ export function GET() {
 			},
 			RuleWithNoImplicitAnyLetOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7545,7 +7545,7 @@ export function GET() {
 			},
 			RuleWithNoImplicitBooleanOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7564,7 +7564,7 @@ export function GET() {
 			},
 			RuleWithNoImplicitCoercionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7583,7 +7583,7 @@ export function GET() {
 			},
 			RuleWithNoImportAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7598,7 +7598,7 @@ export function GET() {
 			},
 			RuleWithNoImportCyclesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7613,7 +7613,7 @@ export function GET() {
 			},
 			RuleWithNoImportantInKeyframeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7628,7 +7628,7 @@ export function GET() {
 			},
 			RuleWithNoImportantStylesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7647,7 +7647,7 @@ export function GET() {
 			},
 			RuleWithNoInferrableTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7666,7 +7666,7 @@ export function GET() {
 			},
 			RuleWithNoInnerDeclarationsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7681,7 +7681,7 @@ export function GET() {
 			},
 			RuleWithNoInteractiveElementToNoninteractiveRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7704,7 +7704,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidBuiltinInstantiationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7725,7 +7725,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidConstructorSuperOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7740,7 +7740,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidDirectionInLinearGradientOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7759,7 +7759,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidGridAreasOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7774,7 +7774,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidPositionAtImportRuleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7791,7 +7791,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidUseBeforeDeclarationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7808,7 +7808,7 @@ export function GET() {
 			},
 			RuleWithNoIrregularWhitespaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7823,7 +7823,7 @@ export function GET() {
 			},
 			RuleWithNoJsxLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7838,7 +7838,7 @@ export function GET() {
 			},
 			RuleWithNoLabelVarOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7853,7 +7853,7 @@ export function GET() {
 			},
 			RuleWithNoLabelWithoutControlOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7868,7 +7868,7 @@ export function GET() {
 			},
 			RuleWithNoMagicNumbersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7883,7 +7883,7 @@ export function GET() {
 			},
 			RuleWithNoMisleadingCharacterClassOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7904,7 +7904,7 @@ export function GET() {
 			},
 			RuleWithNoMisleadingInstantiatorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7919,7 +7919,7 @@ export function GET() {
 			},
 			RuleWithNoMisplacedAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7934,7 +7934,7 @@ export function GET() {
 			},
 			RuleWithNoMisrefactoredShorthandAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7955,7 +7955,7 @@ export function GET() {
 			},
 			RuleWithNoMissingVarFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7970,7 +7970,7 @@ export function GET() {
 			},
 			RuleWithNoMisusedPromisesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7989,7 +7989,7 @@ export function GET() {
 			},
 			RuleWithNoNamespaceImportOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8004,7 +8004,7 @@ export function GET() {
 			},
 			RuleWithNoNamespaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8019,7 +8019,7 @@ export function GET() {
 			},
 			RuleWithNoNegationElseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8038,7 +8038,7 @@ export function GET() {
 			},
 			RuleWithNoNestedComponentDefinitionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8055,7 +8055,7 @@ export function GET() {
 			},
 			RuleWithNoNestedTernaryOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8070,7 +8070,7 @@ export function GET() {
 			},
 			RuleWithNoNextAsyncClientComponentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8087,7 +8087,7 @@ export function GET() {
 			},
 			RuleWithNoNodejsModulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8102,7 +8102,7 @@ export function GET() {
 			},
 			RuleWithNoNonNullAssertedOptionalChainOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8119,7 +8119,7 @@ export function GET() {
 			},
 			RuleWithNoNonNullAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8138,7 +8138,7 @@ export function GET() {
 			},
 			RuleWithNoNoninteractiveElementInteractionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8157,7 +8157,7 @@ export function GET() {
 			},
 			RuleWithNoNoninteractiveElementToInteractiveRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8180,7 +8180,7 @@ export function GET() {
 			},
 			RuleWithNoNoninteractiveTabindexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8199,7 +8199,7 @@ export function GET() {
 			},
 			RuleWithNoNonoctalDecimalEscapeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8218,7 +8218,7 @@ export function GET() {
 			},
 			RuleWithNoOctalEscapeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8237,7 +8237,7 @@ export function GET() {
 			},
 			RuleWithNoParameterAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8252,7 +8252,7 @@ export function GET() {
 			},
 			RuleWithNoParameterPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8267,7 +8267,7 @@ export function GET() {
 			},
 			RuleWithNoPositiveTabindexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8286,7 +8286,7 @@ export function GET() {
 			},
 			RuleWithNoPrecisionLossOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8301,7 +8301,7 @@ export function GET() {
 			},
 			RuleWithNoPrivateImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8316,7 +8316,7 @@ export function GET() {
 			},
 			RuleWithNoProcessEnvOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8331,7 +8331,7 @@ export function GET() {
 			},
 			RuleWithNoProcessGlobalOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8350,7 +8350,7 @@ export function GET() {
 			},
 			RuleWithNoPrototypeBuiltinsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8369,7 +8369,7 @@ export function GET() {
 			},
 			RuleWithNoQuickfixBiomeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8388,7 +8388,7 @@ export function GET() {
 			},
 			RuleWithNoQwikUseVisibleTaskOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8403,7 +8403,7 @@ export function GET() {
 			},
 			RuleWithNoReExportAllOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8418,7 +8418,7 @@ export function GET() {
 			},
 			RuleWithNoReactPropAssignmentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8433,7 +8433,7 @@ export function GET() {
 			},
 			RuleWithNoReactSpecificPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8452,7 +8452,7 @@ export function GET() {
 			},
 			RuleWithNoRedeclareOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8467,7 +8467,7 @@ export function GET() {
 			},
 			RuleWithNoRedundantAltOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8482,7 +8482,7 @@ export function GET() {
 			},
 			RuleWithNoRedundantRolesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8501,7 +8501,7 @@ export function GET() {
 			},
 			RuleWithNoRedundantUseStrictOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8520,7 +8520,7 @@ export function GET() {
 			},
 			RuleWithNoRenderReturnValueOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8535,7 +8535,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8550,7 +8550,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedGlobalsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8565,7 +8565,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8580,7 +8580,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8599,7 +8599,7 @@ export function GET() {
 			},
 			RuleWithNoSecretsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8614,7 +8614,7 @@ export function GET() {
 			},
 			RuleWithNoSelfAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8629,7 +8629,7 @@ export function GET() {
 			},
 			RuleWithNoSelfCompareOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8644,7 +8644,7 @@ export function GET() {
 			},
 			RuleWithNoSetterReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8659,7 +8659,7 @@ export function GET() {
 			},
 			RuleWithNoShadowOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8674,7 +8674,7 @@ export function GET() {
 			},
 			RuleWithNoShadowRestrictedNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8689,7 +8689,7 @@ export function GET() {
 			},
 			RuleWithNoShorthandPropertyOverridesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8706,7 +8706,7 @@ export function GET() {
 			},
 			RuleWithNoShoutyConstantsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8725,7 +8725,7 @@ export function GET() {
 			},
 			RuleWithNoSkippedTestsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8744,7 +8744,7 @@ export function GET() {
 			},
 			RuleWithNoSolidDestructuredPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8759,7 +8759,7 @@ export function GET() {
 			},
 			RuleWithNoSparseArrayOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8778,7 +8778,7 @@ export function GET() {
 			},
 			RuleWithNoStaticElementInteractionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8795,7 +8795,7 @@ export function GET() {
 			},
 			RuleWithNoStaticOnlyClassOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8810,7 +8810,7 @@ export function GET() {
 			},
 			RuleWithNoStringCaseMismatchOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8829,7 +8829,7 @@ export function GET() {
 			},
 			RuleWithNoSubstrOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8848,7 +8848,7 @@ export function GET() {
 			},
 			RuleWithNoSuspiciousSemicolonInJsxOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8865,7 +8865,7 @@ export function GET() {
 			},
 			RuleWithNoSvgWithoutTitleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8880,7 +8880,7 @@ export function GET() {
 			},
 			RuleWithNoSwitchDeclarationsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8899,7 +8899,7 @@ export function GET() {
 			},
 			RuleWithNoTemplateCurlyInStringOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8914,7 +8914,7 @@ export function GET() {
 			},
 			RuleWithNoThenPropertyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8929,7 +8929,7 @@ export function GET() {
 			},
 			RuleWithNoThisInStaticOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8948,7 +8948,7 @@ export function GET() {
 			},
 			RuleWithNoTsIgnoreOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8967,7 +8967,7 @@ export function GET() {
 			},
 			RuleWithNoUnassignedVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8982,7 +8982,7 @@ export function GET() {
 			},
 			RuleWithNoUndeclaredDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8997,7 +8997,7 @@ export function GET() {
 			},
 			RuleWithNoUndeclaredVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9012,7 +9012,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownAtRulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9027,7 +9027,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9042,7 +9042,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownMediaFeatureNameOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9057,7 +9057,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownPropertyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9072,7 +9072,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownPseudoClassOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9087,7 +9087,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownPseudoElementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9102,7 +9102,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownTypeSelectorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9117,7 +9117,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownUnitOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9132,7 +9132,7 @@ export function GET() {
 			},
 			RuleWithNoUnmatchableAnbSelectorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9147,7 +9147,7 @@ export function GET() {
 			},
 			RuleWithNoUnnecessaryConditionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9162,7 +9162,7 @@ export function GET() {
 			},
 			RuleWithNoUnreachableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9177,7 +9177,7 @@ export function GET() {
 			},
 			RuleWithNoUnreachableSuperOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9192,7 +9192,7 @@ export function GET() {
 			},
 			RuleWithNoUnresolvedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9207,7 +9207,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeDeclarationMergingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9224,7 +9224,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeFinallyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9239,7 +9239,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeNegationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9258,7 +9258,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeOptionalChainingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9273,7 +9273,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedFunctionParametersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9294,7 +9294,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9313,7 +9313,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedLabelsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9332,7 +9332,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedPrivateClassMembersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9353,7 +9353,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedTemplateLiteralOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9372,7 +9372,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9391,7 +9391,7 @@ export function GET() {
 			},
 			RuleWithNoUnwantedPolyfillioOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9406,7 +9406,7 @@ export function GET() {
 			},
 			RuleWithNoUselessCatchBindingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9425,7 +9425,7 @@ export function GET() {
 			},
 			RuleWithNoUselessCatchOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9444,7 +9444,7 @@ export function GET() {
 			},
 			RuleWithNoUselessConstructorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9463,7 +9463,7 @@ export function GET() {
 			},
 			RuleWithNoUselessContinueOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9482,7 +9482,7 @@ export function GET() {
 			},
 			RuleWithNoUselessElseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9501,7 +9501,7 @@ export function GET() {
 			},
 			RuleWithNoUselessEmptyExportOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9520,7 +9520,7 @@ export function GET() {
 			},
 			RuleWithNoUselessEscapeInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9539,7 +9539,7 @@ export function GET() {
 			},
 			RuleWithNoUselessEscapeInStringOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9558,7 +9558,7 @@ export function GET() {
 			},
 			RuleWithNoUselessFragmentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9577,7 +9577,7 @@ export function GET() {
 			},
 			RuleWithNoUselessLabelOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9596,7 +9596,7 @@ export function GET() {
 			},
 			RuleWithNoUselessLoneBlockStatementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9617,7 +9617,7 @@ export function GET() {
 			},
 			RuleWithNoUselessRegexBackrefsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9632,7 +9632,7 @@ export function GET() {
 			},
 			RuleWithNoUselessRenameOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9651,7 +9651,7 @@ export function GET() {
 			},
 			RuleWithNoUselessStringConcatOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9670,7 +9670,7 @@ export function GET() {
 			},
 			RuleWithNoUselessStringRawOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9685,7 +9685,7 @@ export function GET() {
 			},
 			RuleWithNoUselessSwitchCaseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9704,7 +9704,7 @@ export function GET() {
 			},
 			RuleWithNoUselessTernaryOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9723,7 +9723,7 @@ export function GET() {
 			},
 			RuleWithNoUselessThisAliasOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9742,7 +9742,7 @@ export function GET() {
 			},
 			RuleWithNoUselessTypeConstraintOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9761,7 +9761,7 @@ export function GET() {
 			},
 			RuleWithNoUselessUndefinedInitializationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9782,7 +9782,7 @@ export function GET() {
 			},
 			RuleWithNoUselessUndefinedOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9801,7 +9801,7 @@ export function GET() {
 			},
 			RuleWithNoValueAtRuleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9816,7 +9816,7 @@ export function GET() {
 			},
 			RuleWithNoVarOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9835,7 +9835,7 @@ export function GET() {
 			},
 			RuleWithNoVoidElementsWithChildrenOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9856,7 +9856,7 @@ export function GET() {
 			},
 			RuleWithNoVoidOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9871,7 +9871,7 @@ export function GET() {
 			},
 			RuleWithNoVoidTypeReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9886,7 +9886,7 @@ export function GET() {
 			},
 			RuleWithNoVueDataObjectDeclarationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9907,7 +9907,7 @@ export function GET() {
 			},
 			RuleWithNoVueReservedKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9922,7 +9922,7 @@ export function GET() {
 			},
 			RuleWithNoVueReservedPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9937,7 +9937,7 @@ export function GET() {
 			},
 			RuleWithNoWithOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9952,7 +9952,7 @@ export function GET() {
 			},
 			RuleWithNoYodaExpressionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9971,7 +9971,7 @@ export function GET() {
 			},
 			RuleWithUseAdjacentOverloadSignaturesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9988,7 +9988,7 @@ export function GET() {
 			},
 			RuleWithUseAltTextOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10003,7 +10003,7 @@ export function GET() {
 			},
 			RuleWithUseAnchorContentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10022,7 +10022,7 @@ export function GET() {
 			},
 			RuleWithUseAnchorHrefOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10037,7 +10037,7 @@ export function GET() {
 			},
 			RuleWithUseAriaActivedescendantWithTabindexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10060,7 +10060,7 @@ export function GET() {
 			},
 			RuleWithUseAriaPropsForRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10075,7 +10075,7 @@ export function GET() {
 			},
 			RuleWithUseAriaPropsSupportedByRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10092,7 +10092,7 @@ export function GET() {
 			},
 			RuleWithUseArrayLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10111,7 +10111,7 @@ export function GET() {
 			},
 			RuleWithUseArrowFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10130,7 +10130,7 @@ export function GET() {
 			},
 			RuleWithUseAsConstAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10149,7 +10149,7 @@ export function GET() {
 			},
 			RuleWithUseAtIndexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10168,7 +10168,7 @@ export function GET() {
 			},
 			RuleWithUseAwaitOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10183,7 +10183,7 @@ export function GET() {
 			},
 			RuleWithUseBiomeIgnoreFolderOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10202,7 +10202,7 @@ export function GET() {
 			},
 			RuleWithUseBlockStatementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10221,7 +10221,7 @@ export function GET() {
 			},
 			RuleWithUseButtonTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10236,7 +10236,7 @@ export function GET() {
 			},
 			RuleWithUseCollapsedElseIfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10255,7 +10255,7 @@ export function GET() {
 			},
 			RuleWithUseCollapsedIfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10274,7 +10274,7 @@ export function GET() {
 			},
 			RuleWithUseComponentExportOnlyModulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10291,7 +10291,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentArrayTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10310,7 +10310,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentArrowReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10329,7 +10329,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentBuiltinInstantiationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10352,7 +10352,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentCurlyBracesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10371,7 +10371,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentMemberAccessibilityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10388,7 +10388,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentObjectDefinitionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10409,7 +10409,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentTypeDefinitionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10430,7 +10430,7 @@ export function GET() {
 			},
 			RuleWithUseConstOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10449,7 +10449,7 @@ export function GET() {
 			},
 			RuleWithUseDateNowOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10468,7 +10468,7 @@ export function GET() {
 			},
 			RuleWithUseDefaultParameterLastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10487,7 +10487,7 @@ export function GET() {
 			},
 			RuleWithUseDefaultSwitchClauseLastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10504,7 +10504,7 @@ export function GET() {
 			},
 			RuleWithUseDefaultSwitchClauseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10519,7 +10519,7 @@ export function GET() {
 			},
 			RuleWithUseDeprecatedReasonOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10534,7 +10534,7 @@ export function GET() {
 			},
 			RuleWithUseEnumInitializersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10553,7 +10553,7 @@ export function GET() {
 			},
 			RuleWithUseErrorMessageOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10568,7 +10568,7 @@ export function GET() {
 			},
 			RuleWithUseExhaustiveDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10587,7 +10587,7 @@ export function GET() {
 			},
 			RuleWithUseExhaustiveSwitchCasesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10606,7 +10606,7 @@ export function GET() {
 			},
 			RuleWithUseExplicitLengthCheckOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10625,7 +10625,7 @@ export function GET() {
 			},
 			RuleWithUseExplicitTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10640,7 +10640,7 @@ export function GET() {
 			},
 			RuleWithUseExponentiationOperatorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10659,7 +10659,7 @@ export function GET() {
 			},
 			RuleWithUseExportTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10678,7 +10678,7 @@ export function GET() {
 			},
 			RuleWithUseExportsLastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10693,7 +10693,7 @@ export function GET() {
 			},
 			RuleWithUseFilenamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10708,7 +10708,7 @@ export function GET() {
 			},
 			RuleWithUseFlatMapOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10727,7 +10727,7 @@ export function GET() {
 			},
 			RuleWithUseFocusableInteractiveOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10742,7 +10742,7 @@ export function GET() {
 			},
 			RuleWithUseForOfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10757,7 +10757,7 @@ export function GET() {
 			},
 			RuleWithUseFragmentSyntaxOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10776,7 +10776,7 @@ export function GET() {
 			},
 			RuleWithUseGenericFontNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10791,7 +10791,7 @@ export function GET() {
 			},
 			RuleWithUseGetterReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10806,7 +10806,7 @@ export function GET() {
 			},
 			RuleWithUseGoogleFontDisplayOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10821,7 +10821,7 @@ export function GET() {
 			},
 			RuleWithUseGoogleFontPreconnectOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10840,7 +10840,7 @@ export function GET() {
 			},
 			RuleWithUseGraphqlNamedOperationsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10859,7 +10859,7 @@ export function GET() {
 			},
 			RuleWithUseGraphqlNamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10876,7 +10876,7 @@ export function GET() {
 			},
 			RuleWithUseGroupedAccessorPairsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10891,7 +10891,7 @@ export function GET() {
 			},
 			RuleWithUseGuardForInOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10906,7 +10906,7 @@ export function GET() {
 			},
 			RuleWithUseHeadingContentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10921,7 +10921,7 @@ export function GET() {
 			},
 			RuleWithUseHookAtTopLevelOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10936,7 +10936,7 @@ export function GET() {
 			},
 			RuleWithUseHtmlLangOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10951,7 +10951,7 @@ export function GET() {
 			},
 			RuleWithUseIframeTitleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10966,7 +10966,7 @@ export function GET() {
 			},
 			RuleWithUseImageSizeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10981,7 +10981,7 @@ export function GET() {
 			},
 			RuleWithUseImportExtensionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11000,7 +11000,7 @@ export function GET() {
 			},
 			RuleWithUseImportTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11019,7 +11019,7 @@ export function GET() {
 			},
 			RuleWithUseIndexOfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11038,7 +11038,7 @@ export function GET() {
 			},
 			RuleWithUseIsArrayOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11057,7 +11057,7 @@ export function GET() {
 			},
 			RuleWithUseIsNanOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11076,7 +11076,7 @@ export function GET() {
 			},
 			RuleWithUseIterableCallbackReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11091,7 +11091,7 @@ export function GET() {
 			},
 			RuleWithUseJsonImportAttributesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11110,7 +11110,7 @@ export function GET() {
 			},
 			RuleWithUseJsxKeyInIterableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11125,7 +11125,7 @@ export function GET() {
 			},
 			RuleWithUseKeyWithClickEventsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11140,7 +11140,7 @@ export function GET() {
 			},
 			RuleWithUseKeyWithMouseEventsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11155,7 +11155,7 @@ export function GET() {
 			},
 			RuleWithUseLiteralEnumMembersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11170,7 +11170,7 @@ export function GET() {
 			},
 			RuleWithUseLiteralKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11189,7 +11189,7 @@ export function GET() {
 			},
 			RuleWithUseMaxParamsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11204,7 +11204,7 @@ export function GET() {
 			},
 			RuleWithUseMediaCaptionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11219,7 +11219,7 @@ export function GET() {
 			},
 			RuleWithUseNamespaceKeywordOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11238,7 +11238,7 @@ export function GET() {
 			},
 			RuleWithUseNamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11257,7 +11257,7 @@ export function GET() {
 			},
 			RuleWithUseNodeAssertStrictOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11276,7 +11276,7 @@ export function GET() {
 			},
 			RuleWithUseNodejsImportProtocolOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11295,7 +11295,7 @@ export function GET() {
 			},
 			RuleWithUseNumberNamespaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11314,7 +11314,7 @@ export function GET() {
 			},
 			RuleWithUseNumberToFixedDigitsArgumentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11335,7 +11335,7 @@ export function GET() {
 			},
 			RuleWithUseNumericLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11354,7 +11354,7 @@ export function GET() {
 			},
 			RuleWithUseNumericSeparatorsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11373,7 +11373,7 @@ export function GET() {
 			},
 			RuleWithUseObjectSpreadOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11392,7 +11392,7 @@ export function GET() {
 			},
 			RuleWithUseOptionalChainOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11411,7 +11411,7 @@ export function GET() {
 			},
 			RuleWithUseParseIntRadixOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11430,7 +11430,7 @@ export function GET() {
 			},
 			RuleWithUseQwikClasslistOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11445,7 +11445,7 @@ export function GET() {
 			},
 			RuleWithUseReactFunctionComponentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11462,7 +11462,7 @@ export function GET() {
 			},
 			RuleWithUseReadonlyClassPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11483,7 +11483,7 @@ export function GET() {
 			},
 			RuleWithUseRegexLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11502,7 +11502,7 @@ export function GET() {
 			},
 			RuleWithUseSelfClosingElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11521,7 +11521,7 @@ export function GET() {
 			},
 			RuleWithUseSemanticElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11536,7 +11536,7 @@ export function GET() {
 			},
 			RuleWithUseShorthandAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11555,7 +11555,7 @@ export function GET() {
 			},
 			RuleWithUseShorthandFunctionTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11574,7 +11574,7 @@ export function GET() {
 			},
 			RuleWithUseSimpleNumberKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11593,7 +11593,7 @@ export function GET() {
 			},
 			RuleWithUseSimplifiedLogicExpressionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11614,7 +11614,7 @@ export function GET() {
 			},
 			RuleWithUseSingleJsDocAsteriskOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11633,7 +11633,7 @@ export function GET() {
 			},
 			RuleWithUseSingleVarDeclaratorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11652,7 +11652,7 @@ export function GET() {
 			},
 			RuleWithUseSolidForComponentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11667,7 +11667,7 @@ export function GET() {
 			},
 			RuleWithUseSortedClassesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11686,7 +11686,7 @@ export function GET() {
 			},
 			RuleWithUseStaticResponseMethodsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11705,7 +11705,7 @@ export function GET() {
 			},
 			RuleWithUseStrictModeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11724,7 +11724,7 @@ export function GET() {
 			},
 			RuleWithUseSymbolDescriptionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11739,7 +11739,7 @@ export function GET() {
 			},
 			RuleWithUseTemplateOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11758,7 +11758,7 @@ export function GET() {
 			},
 			RuleWithUseThrowNewErrorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11777,7 +11777,7 @@ export function GET() {
 			},
 			RuleWithUseThrowOnlyErrorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11792,7 +11792,7 @@ export function GET() {
 			},
 			RuleWithUseTopLevelRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11807,7 +11807,7 @@ export function GET() {
 			},
 			RuleWithUseTrimStartEndOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11826,7 +11826,7 @@ export function GET() {
 			},
 			RuleWithUseUnifiedTypeSignaturesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11845,7 +11845,7 @@ export function GET() {
 			},
 			RuleWithUseUniqueElementIdsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11860,7 +11860,7 @@ export function GET() {
 			},
 			RuleWithUseValidAnchorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11875,7 +11875,7 @@ export function GET() {
 			},
 			RuleWithUseValidAriaPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11894,7 +11894,7 @@ export function GET() {
 			},
 			RuleWithUseValidAriaRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11913,7 +11913,7 @@ export function GET() {
 			},
 			RuleWithUseValidAriaValuesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11928,7 +11928,7 @@ export function GET() {
 			},
 			RuleWithUseValidAutocompleteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11943,7 +11943,7 @@ export function GET() {
 			},
 			RuleWithUseValidForDirectionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11958,7 +11958,7 @@ export function GET() {
 			},
 			RuleWithUseValidLangOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11973,7 +11973,7 @@ export function GET() {
 			},
 			RuleWithUseValidTypeofOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11992,7 +11992,7 @@ export function GET() {
 			},
 			RuleWithUseVueMultiWordComponentNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12009,7 +12009,7 @@ export function GET() {
 			},
 			RuleWithUseWhileOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12028,7 +12028,7 @@ export function GET() {
 			},
 			RuleWithUseYieldOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",

--- a/src/pages/schemas/2.2.5/schema.json.js
+++ b/src/pages/schemas/2.2.5/schema.json.js
@@ -5905,7 +5905,7 @@ export function GET() {
 			RuleAssistPlainConfiguration: { type: "string", enum: ["off", "on"] },
 			RuleAssistWithOptions_for_OrganizeImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5920,7 +5920,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_UseSortedAttributesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5935,7 +5935,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_UseSortedKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5950,7 +5950,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_UseSortedPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6060,7 +6060,7 @@ export function GET() {
 			},
 			RuleWithNoAccessKeyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6079,7 +6079,7 @@ export function GET() {
 			},
 			RuleWithNoAccumulatingSpreadOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6094,7 +6094,7 @@ export function GET() {
 			},
 			RuleWithNoAdjacentSpacesInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6113,7 +6113,7 @@ export function GET() {
 			},
 			RuleWithNoAlertOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6128,7 +6128,7 @@ export function GET() {
 			},
 			RuleWithNoApproximativeNumericConstantOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6149,7 +6149,7 @@ export function GET() {
 			},
 			RuleWithNoArgumentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6164,7 +6164,7 @@ export function GET() {
 			},
 			RuleWithNoAriaHiddenOnFocusableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6183,7 +6183,7 @@ export function GET() {
 			},
 			RuleWithNoAriaUnsupportedElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6202,7 +6202,7 @@ export function GET() {
 			},
 			RuleWithNoArrayIndexKeyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6217,7 +6217,7 @@ export function GET() {
 			},
 			RuleWithNoAssignInExpressionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6232,7 +6232,7 @@ export function GET() {
 			},
 			RuleWithNoAsyncPromiseExecutorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6247,7 +6247,7 @@ export function GET() {
 			},
 			RuleWithNoAutofocusOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6266,7 +6266,7 @@ export function GET() {
 			},
 			RuleWithNoAwaitInLoopsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6281,7 +6281,7 @@ export function GET() {
 			},
 			RuleWithNoBannedTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6300,7 +6300,7 @@ export function GET() {
 			},
 			RuleWithNoBarrelFileOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6315,7 +6315,7 @@ export function GET() {
 			},
 			RuleWithNoBiomeFirstExceptionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6334,7 +6334,7 @@ export function GET() {
 			},
 			RuleWithNoBitwiseOperatorsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6349,7 +6349,7 @@ export function GET() {
 			},
 			RuleWithNoBlankTargetOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6368,7 +6368,7 @@ export function GET() {
 			},
 			RuleWithNoCatchAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6383,7 +6383,7 @@ export function GET() {
 			},
 			RuleWithNoChildrenPropOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6398,7 +6398,7 @@ export function GET() {
 			},
 			RuleWithNoClassAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6413,7 +6413,7 @@ export function GET() {
 			},
 			RuleWithNoCommaOperatorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6428,7 +6428,7 @@ export function GET() {
 			},
 			RuleWithNoCommentTextOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6447,7 +6447,7 @@ export function GET() {
 			},
 			RuleWithNoCommonJsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6462,7 +6462,7 @@ export function GET() {
 			},
 			RuleWithNoCompareNegZeroOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6481,7 +6481,7 @@ export function GET() {
 			},
 			RuleWithNoConfusingLabelsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6496,7 +6496,7 @@ export function GET() {
 			},
 			RuleWithNoConfusingVoidTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6515,7 +6515,7 @@ export function GET() {
 			},
 			RuleWithNoConsoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6534,7 +6534,7 @@ export function GET() {
 			},
 			RuleWithNoConstAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6553,7 +6553,7 @@ export function GET() {
 			},
 			RuleWithNoConstEnumOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6572,7 +6572,7 @@ export function GET() {
 			},
 			RuleWithNoConstantBinaryExpressionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6589,7 +6589,7 @@ export function GET() {
 			},
 			RuleWithNoConstantConditionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6604,7 +6604,7 @@ export function GET() {
 			},
 			RuleWithNoConstantMathMinMaxClampOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6623,7 +6623,7 @@ export function GET() {
 			},
 			RuleWithNoConstructorReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6638,7 +6638,7 @@ export function GET() {
 			},
 			RuleWithNoControlCharactersInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6655,7 +6655,7 @@ export function GET() {
 			},
 			RuleWithNoDangerouslySetInnerHtmlOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6670,7 +6670,7 @@ export function GET() {
 			},
 			RuleWithNoDangerouslySetInnerHtmlWithChildrenOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6689,7 +6689,7 @@ export function GET() {
 			},
 			RuleWithNoDebuggerOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6708,7 +6708,7 @@ export function GET() {
 			},
 			RuleWithNoDefaultExportOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6723,7 +6723,7 @@ export function GET() {
 			},
 			RuleWithNoDeleteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6742,7 +6742,7 @@ export function GET() {
 			},
 			RuleWithNoDeprecatedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6757,7 +6757,7 @@ export function GET() {
 			},
 			RuleWithNoDescendingSpecificityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6772,7 +6772,7 @@ export function GET() {
 			},
 			RuleWithNoDistractingElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6791,7 +6791,7 @@ export function GET() {
 			},
 			RuleWithNoDocumentCookieOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6806,7 +6806,7 @@ export function GET() {
 			},
 			RuleWithNoDocumentImportInPageOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6821,7 +6821,7 @@ export function GET() {
 			},
 			RuleWithNoDoneCallbackOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6836,7 +6836,7 @@ export function GET() {
 			},
 			RuleWithNoDoubleEqualsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6855,7 +6855,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateAtImportRulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6870,7 +6870,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateCaseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6885,7 +6885,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateClassMembersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6900,7 +6900,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateCustomPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6917,7 +6917,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6932,7 +6932,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateElseIfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6947,7 +6947,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateFieldsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6962,7 +6962,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateFontNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6977,7 +6977,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateJsxPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6992,7 +6992,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateObjectKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7007,7 +7007,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateParametersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7022,7 +7022,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicatePropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7037,7 +7037,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateSelectorsKeyframeBlockOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7056,7 +7056,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateTestHooksOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7071,7 +7071,7 @@ export function GET() {
 			},
 			RuleWithNoDynamicNamespaceImportAccessOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7088,7 +7088,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyBlockOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7103,7 +7103,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyBlockStatementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7118,7 +7118,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyCharacterClassInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7135,7 +7135,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyInterfaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7154,7 +7154,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyPatternOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7169,7 +7169,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyTypeParametersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7184,7 +7184,7 @@ export function GET() {
 			},
 			RuleWithNoEnumOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7199,7 +7199,7 @@ export function GET() {
 			},
 			RuleWithNoEvolvingTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7214,7 +7214,7 @@ export function GET() {
 			},
 			RuleWithNoExcessiveCognitiveComplexityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7231,7 +7231,7 @@ export function GET() {
 			},
 			RuleWithNoExcessiveLinesPerFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7248,7 +7248,7 @@ export function GET() {
 			},
 			RuleWithNoExcessiveNestedTestSuitesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7265,7 +7265,7 @@ export function GET() {
 			},
 			RuleWithNoExplicitAnyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7280,7 +7280,7 @@ export function GET() {
 			},
 			RuleWithNoExportedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7295,7 +7295,7 @@ export function GET() {
 			},
 			RuleWithNoExportsInTestOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7310,7 +7310,7 @@ export function GET() {
 			},
 			RuleWithNoExtraBooleanCastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7329,7 +7329,7 @@ export function GET() {
 			},
 			RuleWithNoExtraNonNullAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7348,7 +7348,7 @@ export function GET() {
 			},
 			RuleWithNoFallthroughSwitchClauseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7363,7 +7363,7 @@ export function GET() {
 			},
 			RuleWithNoFlatMapIdentityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7382,7 +7382,7 @@ export function GET() {
 			},
 			RuleWithNoFloatingPromisesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7401,7 +7401,7 @@ export function GET() {
 			},
 			RuleWithNoFocusedTestsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7420,7 +7420,7 @@ export function GET() {
 			},
 			RuleWithNoForEachOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7435,7 +7435,7 @@ export function GET() {
 			},
 			RuleWithNoFunctionAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7450,7 +7450,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7465,7 +7465,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalDirnameFilenameOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7484,7 +7484,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalEvalOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7499,7 +7499,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalIsFiniteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7518,7 +7518,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalIsNanOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7537,7 +7537,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalObjectCallsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7552,7 +7552,7 @@ export function GET() {
 			},
 			RuleWithNoHeadElementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7567,7 +7567,7 @@ export function GET() {
 			},
 			RuleWithNoHeadImportInDocumentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7582,7 +7582,7 @@ export function GET() {
 			},
 			RuleWithNoHeaderScopeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7601,7 +7601,7 @@ export function GET() {
 			},
 			RuleWithNoImgElementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7616,7 +7616,7 @@ export function GET() {
 			},
 			RuleWithNoImplicitAnyLetOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7631,7 +7631,7 @@ export function GET() {
 			},
 			RuleWithNoImplicitBooleanOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7650,7 +7650,7 @@ export function GET() {
 			},
 			RuleWithNoImplicitCoercionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7669,7 +7669,7 @@ export function GET() {
 			},
 			RuleWithNoImportAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7684,7 +7684,7 @@ export function GET() {
 			},
 			RuleWithNoImportCyclesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7699,7 +7699,7 @@ export function GET() {
 			},
 			RuleWithNoImportantInKeyframeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7714,7 +7714,7 @@ export function GET() {
 			},
 			RuleWithNoImportantStylesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7733,7 +7733,7 @@ export function GET() {
 			},
 			RuleWithNoInferrableTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7752,7 +7752,7 @@ export function GET() {
 			},
 			RuleWithNoInnerDeclarationsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7767,7 +7767,7 @@ export function GET() {
 			},
 			RuleWithNoInteractiveElementToNoninteractiveRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7790,7 +7790,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidBuiltinInstantiationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7811,7 +7811,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidConstructorSuperOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7826,7 +7826,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidDirectionInLinearGradientOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7845,7 +7845,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidGridAreasOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7860,7 +7860,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidPositionAtImportRuleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7877,7 +7877,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidUseBeforeDeclarationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7894,7 +7894,7 @@ export function GET() {
 			},
 			RuleWithNoIrregularWhitespaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7909,7 +7909,7 @@ export function GET() {
 			},
 			RuleWithNoJsxLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7924,7 +7924,7 @@ export function GET() {
 			},
 			RuleWithNoLabelVarOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7939,7 +7939,7 @@ export function GET() {
 			},
 			RuleWithNoLabelWithoutControlOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7954,7 +7954,7 @@ export function GET() {
 			},
 			RuleWithNoMagicNumbersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7969,7 +7969,7 @@ export function GET() {
 			},
 			RuleWithNoMisleadingCharacterClassOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7990,7 +7990,7 @@ export function GET() {
 			},
 			RuleWithNoMisleadingInstantiatorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8005,7 +8005,7 @@ export function GET() {
 			},
 			RuleWithNoMisplacedAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8020,7 +8020,7 @@ export function GET() {
 			},
 			RuleWithNoMisrefactoredShorthandAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8041,7 +8041,7 @@ export function GET() {
 			},
 			RuleWithNoMissingVarFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8056,7 +8056,7 @@ export function GET() {
 			},
 			RuleWithNoMisusedPromisesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8075,7 +8075,7 @@ export function GET() {
 			},
 			RuleWithNoNamespaceImportOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8090,7 +8090,7 @@ export function GET() {
 			},
 			RuleWithNoNamespaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8105,7 +8105,7 @@ export function GET() {
 			},
 			RuleWithNoNegationElseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8124,7 +8124,7 @@ export function GET() {
 			},
 			RuleWithNoNestedComponentDefinitionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8141,7 +8141,7 @@ export function GET() {
 			},
 			RuleWithNoNestedTernaryOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8156,7 +8156,7 @@ export function GET() {
 			},
 			RuleWithNoNextAsyncClientComponentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8173,7 +8173,7 @@ export function GET() {
 			},
 			RuleWithNoNodejsModulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8188,7 +8188,7 @@ export function GET() {
 			},
 			RuleWithNoNonNullAssertedOptionalChainOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8205,7 +8205,7 @@ export function GET() {
 			},
 			RuleWithNoNonNullAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8224,7 +8224,7 @@ export function GET() {
 			},
 			RuleWithNoNoninteractiveElementInteractionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8243,7 +8243,7 @@ export function GET() {
 			},
 			RuleWithNoNoninteractiveElementToInteractiveRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8266,7 +8266,7 @@ export function GET() {
 			},
 			RuleWithNoNoninteractiveTabindexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8285,7 +8285,7 @@ export function GET() {
 			},
 			RuleWithNoNonoctalDecimalEscapeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8304,7 +8304,7 @@ export function GET() {
 			},
 			RuleWithNoOctalEscapeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8323,7 +8323,7 @@ export function GET() {
 			},
 			RuleWithNoParameterAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8338,7 +8338,7 @@ export function GET() {
 			},
 			RuleWithNoParameterPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8353,7 +8353,7 @@ export function GET() {
 			},
 			RuleWithNoPositiveTabindexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8372,7 +8372,7 @@ export function GET() {
 			},
 			RuleWithNoPrecisionLossOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8387,7 +8387,7 @@ export function GET() {
 			},
 			RuleWithNoPrivateImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8402,7 +8402,7 @@ export function GET() {
 			},
 			RuleWithNoProcessEnvOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8417,7 +8417,7 @@ export function GET() {
 			},
 			RuleWithNoProcessGlobalOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8436,7 +8436,7 @@ export function GET() {
 			},
 			RuleWithNoPrototypeBuiltinsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8455,7 +8455,7 @@ export function GET() {
 			},
 			RuleWithNoQuickfixBiomeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8474,7 +8474,7 @@ export function GET() {
 			},
 			RuleWithNoQwikUseVisibleTaskOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8489,7 +8489,7 @@ export function GET() {
 			},
 			RuleWithNoReExportAllOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8504,7 +8504,7 @@ export function GET() {
 			},
 			RuleWithNoReactForwardRefOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8523,7 +8523,7 @@ export function GET() {
 			},
 			RuleWithNoReactPropAssignmentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8538,7 +8538,7 @@ export function GET() {
 			},
 			RuleWithNoReactSpecificPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8557,7 +8557,7 @@ export function GET() {
 			},
 			RuleWithNoRedeclareOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8572,7 +8572,7 @@ export function GET() {
 			},
 			RuleWithNoRedundantAltOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8587,7 +8587,7 @@ export function GET() {
 			},
 			RuleWithNoRedundantRolesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8606,7 +8606,7 @@ export function GET() {
 			},
 			RuleWithNoRedundantUseStrictOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8625,7 +8625,7 @@ export function GET() {
 			},
 			RuleWithNoRenderReturnValueOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8640,7 +8640,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8655,7 +8655,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedGlobalsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8670,7 +8670,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8685,7 +8685,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8704,7 +8704,7 @@ export function GET() {
 			},
 			RuleWithNoSecretsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8719,7 +8719,7 @@ export function GET() {
 			},
 			RuleWithNoSelfAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8734,7 +8734,7 @@ export function GET() {
 			},
 			RuleWithNoSelfCompareOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8749,7 +8749,7 @@ export function GET() {
 			},
 			RuleWithNoSetterReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8764,7 +8764,7 @@ export function GET() {
 			},
 			RuleWithNoShadowOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8779,7 +8779,7 @@ export function GET() {
 			},
 			RuleWithNoShadowRestrictedNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8794,7 +8794,7 @@ export function GET() {
 			},
 			RuleWithNoShorthandPropertyOverridesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8811,7 +8811,7 @@ export function GET() {
 			},
 			RuleWithNoShoutyConstantsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8830,7 +8830,7 @@ export function GET() {
 			},
 			RuleWithNoSkippedTestsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8849,7 +8849,7 @@ export function GET() {
 			},
 			RuleWithNoSolidDestructuredPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8864,7 +8864,7 @@ export function GET() {
 			},
 			RuleWithNoSparseArrayOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8883,7 +8883,7 @@ export function GET() {
 			},
 			RuleWithNoStaticElementInteractionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8900,7 +8900,7 @@ export function GET() {
 			},
 			RuleWithNoStaticOnlyClassOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8915,7 +8915,7 @@ export function GET() {
 			},
 			RuleWithNoStringCaseMismatchOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8934,7 +8934,7 @@ export function GET() {
 			},
 			RuleWithNoSubstrOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8953,7 +8953,7 @@ export function GET() {
 			},
 			RuleWithNoSuspiciousSemicolonInJsxOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8970,7 +8970,7 @@ export function GET() {
 			},
 			RuleWithNoSvgWithoutTitleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8985,7 +8985,7 @@ export function GET() {
 			},
 			RuleWithNoSwitchDeclarationsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9004,7 +9004,7 @@ export function GET() {
 			},
 			RuleWithNoTemplateCurlyInStringOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9019,7 +9019,7 @@ export function GET() {
 			},
 			RuleWithNoThenPropertyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9034,7 +9034,7 @@ export function GET() {
 			},
 			RuleWithNoThisInStaticOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9053,7 +9053,7 @@ export function GET() {
 			},
 			RuleWithNoTsIgnoreOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9072,7 +9072,7 @@ export function GET() {
 			},
 			RuleWithNoUnassignedVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9087,7 +9087,7 @@ export function GET() {
 			},
 			RuleWithNoUndeclaredDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9102,7 +9102,7 @@ export function GET() {
 			},
 			RuleWithNoUndeclaredVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9117,7 +9117,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownAtRulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9132,7 +9132,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9147,7 +9147,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownMediaFeatureNameOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9162,7 +9162,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownPropertyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9177,7 +9177,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownPseudoClassOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9192,7 +9192,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownPseudoElementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9207,7 +9207,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownTypeSelectorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9222,7 +9222,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownUnitOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9237,7 +9237,7 @@ export function GET() {
 			},
 			RuleWithNoUnmatchableAnbSelectorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9252,7 +9252,7 @@ export function GET() {
 			},
 			RuleWithNoUnnecessaryConditionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9267,7 +9267,7 @@ export function GET() {
 			},
 			RuleWithNoUnreachableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9282,7 +9282,7 @@ export function GET() {
 			},
 			RuleWithNoUnreachableSuperOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9297,7 +9297,7 @@ export function GET() {
 			},
 			RuleWithNoUnresolvedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9312,7 +9312,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeDeclarationMergingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9329,7 +9329,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeFinallyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9344,7 +9344,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeNegationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9363,7 +9363,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeOptionalChainingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9378,7 +9378,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedExpressionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9393,7 +9393,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedFunctionParametersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9414,7 +9414,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9433,7 +9433,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedLabelsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9452,7 +9452,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedPrivateClassMembersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9473,7 +9473,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedTemplateLiteralOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9492,7 +9492,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9511,7 +9511,7 @@ export function GET() {
 			},
 			RuleWithNoUnwantedPolyfillioOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9526,7 +9526,7 @@ export function GET() {
 			},
 			RuleWithNoUselessCatchBindingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9545,7 +9545,7 @@ export function GET() {
 			},
 			RuleWithNoUselessCatchOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9564,7 +9564,7 @@ export function GET() {
 			},
 			RuleWithNoUselessConstructorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9583,7 +9583,7 @@ export function GET() {
 			},
 			RuleWithNoUselessContinueOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9602,7 +9602,7 @@ export function GET() {
 			},
 			RuleWithNoUselessElseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9621,7 +9621,7 @@ export function GET() {
 			},
 			RuleWithNoUselessEmptyExportOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9640,7 +9640,7 @@ export function GET() {
 			},
 			RuleWithNoUselessEscapeInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9659,7 +9659,7 @@ export function GET() {
 			},
 			RuleWithNoUselessEscapeInStringOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9678,7 +9678,7 @@ export function GET() {
 			},
 			RuleWithNoUselessFragmentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9697,7 +9697,7 @@ export function GET() {
 			},
 			RuleWithNoUselessLabelOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9716,7 +9716,7 @@ export function GET() {
 			},
 			RuleWithNoUselessLoneBlockStatementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9737,7 +9737,7 @@ export function GET() {
 			},
 			RuleWithNoUselessRegexBackrefsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9752,7 +9752,7 @@ export function GET() {
 			},
 			RuleWithNoUselessRenameOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9771,7 +9771,7 @@ export function GET() {
 			},
 			RuleWithNoUselessStringConcatOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9790,7 +9790,7 @@ export function GET() {
 			},
 			RuleWithNoUselessStringRawOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9805,7 +9805,7 @@ export function GET() {
 			},
 			RuleWithNoUselessSwitchCaseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9824,7 +9824,7 @@ export function GET() {
 			},
 			RuleWithNoUselessTernaryOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9843,7 +9843,7 @@ export function GET() {
 			},
 			RuleWithNoUselessThisAliasOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9862,7 +9862,7 @@ export function GET() {
 			},
 			RuleWithNoUselessTypeConstraintOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9881,7 +9881,7 @@ export function GET() {
 			},
 			RuleWithNoUselessUndefinedInitializationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9902,7 +9902,7 @@ export function GET() {
 			},
 			RuleWithNoUselessUndefinedOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9921,7 +9921,7 @@ export function GET() {
 			},
 			RuleWithNoValueAtRuleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9936,7 +9936,7 @@ export function GET() {
 			},
 			RuleWithNoVarOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9955,7 +9955,7 @@ export function GET() {
 			},
 			RuleWithNoVoidElementsWithChildrenOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9976,7 +9976,7 @@ export function GET() {
 			},
 			RuleWithNoVoidOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9991,7 +9991,7 @@ export function GET() {
 			},
 			RuleWithNoVoidTypeReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10006,7 +10006,7 @@ export function GET() {
 			},
 			RuleWithNoVueDataObjectDeclarationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10027,7 +10027,7 @@ export function GET() {
 			},
 			RuleWithNoVueDuplicateKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10042,7 +10042,7 @@ export function GET() {
 			},
 			RuleWithNoVueReservedKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10057,7 +10057,7 @@ export function GET() {
 			},
 			RuleWithNoVueReservedPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10072,7 +10072,7 @@ export function GET() {
 			},
 			RuleWithNoWithOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10087,7 +10087,7 @@ export function GET() {
 			},
 			RuleWithNoYodaExpressionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10106,7 +10106,7 @@ export function GET() {
 			},
 			RuleWithUseAdjacentOverloadSignaturesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10123,7 +10123,7 @@ export function GET() {
 			},
 			RuleWithUseAltTextOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10138,7 +10138,7 @@ export function GET() {
 			},
 			RuleWithUseAnchorContentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10157,7 +10157,7 @@ export function GET() {
 			},
 			RuleWithUseAnchorHrefOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10172,7 +10172,7 @@ export function GET() {
 			},
 			RuleWithUseAriaActivedescendantWithTabindexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10195,7 +10195,7 @@ export function GET() {
 			},
 			RuleWithUseAriaPropsForRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10210,7 +10210,7 @@ export function GET() {
 			},
 			RuleWithUseAriaPropsSupportedByRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10227,7 +10227,7 @@ export function GET() {
 			},
 			RuleWithUseArrayLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10246,7 +10246,7 @@ export function GET() {
 			},
 			RuleWithUseArrowFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10265,7 +10265,7 @@ export function GET() {
 			},
 			RuleWithUseAsConstAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10284,7 +10284,7 @@ export function GET() {
 			},
 			RuleWithUseAtIndexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10303,7 +10303,7 @@ export function GET() {
 			},
 			RuleWithUseAwaitOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10318,7 +10318,7 @@ export function GET() {
 			},
 			RuleWithUseBiomeIgnoreFolderOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10337,7 +10337,7 @@ export function GET() {
 			},
 			RuleWithUseBlockStatementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10356,7 +10356,7 @@ export function GET() {
 			},
 			RuleWithUseButtonTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10371,7 +10371,7 @@ export function GET() {
 			},
 			RuleWithUseCollapsedElseIfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10390,7 +10390,7 @@ export function GET() {
 			},
 			RuleWithUseCollapsedIfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10409,7 +10409,7 @@ export function GET() {
 			},
 			RuleWithUseComponentExportOnlyModulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10426,7 +10426,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentArrayTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10445,7 +10445,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentArrowReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10464,7 +10464,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentBuiltinInstantiationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10487,7 +10487,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentCurlyBracesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10506,7 +10506,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentMemberAccessibilityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10523,7 +10523,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentObjectDefinitionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10544,7 +10544,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentTypeDefinitionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10565,7 +10565,7 @@ export function GET() {
 			},
 			RuleWithUseConstOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10584,7 +10584,7 @@ export function GET() {
 			},
 			RuleWithUseDateNowOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10603,7 +10603,7 @@ export function GET() {
 			},
 			RuleWithUseDefaultParameterLastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10622,7 +10622,7 @@ export function GET() {
 			},
 			RuleWithUseDefaultSwitchClauseLastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10639,7 +10639,7 @@ export function GET() {
 			},
 			RuleWithUseDefaultSwitchClauseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10654,7 +10654,7 @@ export function GET() {
 			},
 			RuleWithUseDeprecatedReasonOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10669,7 +10669,7 @@ export function GET() {
 			},
 			RuleWithUseEnumInitializersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10688,7 +10688,7 @@ export function GET() {
 			},
 			RuleWithUseErrorMessageOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10703,7 +10703,7 @@ export function GET() {
 			},
 			RuleWithUseExhaustiveDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10722,7 +10722,7 @@ export function GET() {
 			},
 			RuleWithUseExhaustiveSwitchCasesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10741,7 +10741,7 @@ export function GET() {
 			},
 			RuleWithUseExplicitLengthCheckOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10760,7 +10760,7 @@ export function GET() {
 			},
 			RuleWithUseExplicitTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10775,7 +10775,7 @@ export function GET() {
 			},
 			RuleWithUseExponentiationOperatorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10794,7 +10794,7 @@ export function GET() {
 			},
 			RuleWithUseExportTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10813,7 +10813,7 @@ export function GET() {
 			},
 			RuleWithUseExportsLastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10828,7 +10828,7 @@ export function GET() {
 			},
 			RuleWithUseFilenamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10843,7 +10843,7 @@ export function GET() {
 			},
 			RuleWithUseFlatMapOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10862,7 +10862,7 @@ export function GET() {
 			},
 			RuleWithUseFocusableInteractiveOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10877,7 +10877,7 @@ export function GET() {
 			},
 			RuleWithUseForOfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10892,7 +10892,7 @@ export function GET() {
 			},
 			RuleWithUseFragmentSyntaxOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10911,7 +10911,7 @@ export function GET() {
 			},
 			RuleWithUseGenericFontNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10926,7 +10926,7 @@ export function GET() {
 			},
 			RuleWithUseGetterReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10941,7 +10941,7 @@ export function GET() {
 			},
 			RuleWithUseGoogleFontDisplayOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10956,7 +10956,7 @@ export function GET() {
 			},
 			RuleWithUseGoogleFontPreconnectOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10975,7 +10975,7 @@ export function GET() {
 			},
 			RuleWithUseGraphqlNamedOperationsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10994,7 +10994,7 @@ export function GET() {
 			},
 			RuleWithUseGraphqlNamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11011,7 +11011,7 @@ export function GET() {
 			},
 			RuleWithUseGroupedAccessorPairsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11026,7 +11026,7 @@ export function GET() {
 			},
 			RuleWithUseGuardForInOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11041,7 +11041,7 @@ export function GET() {
 			},
 			RuleWithUseHeadingContentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11056,7 +11056,7 @@ export function GET() {
 			},
 			RuleWithUseHookAtTopLevelOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11071,7 +11071,7 @@ export function GET() {
 			},
 			RuleWithUseHtmlLangOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11086,7 +11086,7 @@ export function GET() {
 			},
 			RuleWithUseIframeTitleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11101,7 +11101,7 @@ export function GET() {
 			},
 			RuleWithUseImageSizeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11116,7 +11116,7 @@ export function GET() {
 			},
 			RuleWithUseImportExtensionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11135,7 +11135,7 @@ export function GET() {
 			},
 			RuleWithUseImportTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11154,7 +11154,7 @@ export function GET() {
 			},
 			RuleWithUseIndexOfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11173,7 +11173,7 @@ export function GET() {
 			},
 			RuleWithUseIsArrayOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11192,7 +11192,7 @@ export function GET() {
 			},
 			RuleWithUseIsNanOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11211,7 +11211,7 @@ export function GET() {
 			},
 			RuleWithUseIterableCallbackReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11226,7 +11226,7 @@ export function GET() {
 			},
 			RuleWithUseJsonImportAttributesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11245,7 +11245,7 @@ export function GET() {
 			},
 			RuleWithUseJsxKeyInIterableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11260,7 +11260,7 @@ export function GET() {
 			},
 			RuleWithUseKeyWithClickEventsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11275,7 +11275,7 @@ export function GET() {
 			},
 			RuleWithUseKeyWithMouseEventsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11290,7 +11290,7 @@ export function GET() {
 			},
 			RuleWithUseLiteralEnumMembersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11305,7 +11305,7 @@ export function GET() {
 			},
 			RuleWithUseLiteralKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11324,7 +11324,7 @@ export function GET() {
 			},
 			RuleWithUseMaxParamsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11339,7 +11339,7 @@ export function GET() {
 			},
 			RuleWithUseMediaCaptionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11354,7 +11354,7 @@ export function GET() {
 			},
 			RuleWithUseNamespaceKeywordOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11373,7 +11373,7 @@ export function GET() {
 			},
 			RuleWithUseNamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11392,7 +11392,7 @@ export function GET() {
 			},
 			RuleWithUseNodeAssertStrictOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11411,7 +11411,7 @@ export function GET() {
 			},
 			RuleWithUseNodejsImportProtocolOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11430,7 +11430,7 @@ export function GET() {
 			},
 			RuleWithUseNumberNamespaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11449,7 +11449,7 @@ export function GET() {
 			},
 			RuleWithUseNumberToFixedDigitsArgumentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11470,7 +11470,7 @@ export function GET() {
 			},
 			RuleWithUseNumericLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11489,7 +11489,7 @@ export function GET() {
 			},
 			RuleWithUseNumericSeparatorsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11508,7 +11508,7 @@ export function GET() {
 			},
 			RuleWithUseObjectSpreadOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11527,7 +11527,7 @@ export function GET() {
 			},
 			RuleWithUseOptionalChainOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11546,7 +11546,7 @@ export function GET() {
 			},
 			RuleWithUseParseIntRadixOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11565,7 +11565,7 @@ export function GET() {
 			},
 			RuleWithUseQwikClasslistOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11580,7 +11580,7 @@ export function GET() {
 			},
 			RuleWithUseReactFunctionComponentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11597,7 +11597,7 @@ export function GET() {
 			},
 			RuleWithUseReadonlyClassPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11618,7 +11618,7 @@ export function GET() {
 			},
 			RuleWithUseRegexLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11637,7 +11637,7 @@ export function GET() {
 			},
 			RuleWithUseSelfClosingElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11656,7 +11656,7 @@ export function GET() {
 			},
 			RuleWithUseSemanticElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11671,7 +11671,7 @@ export function GET() {
 			},
 			RuleWithUseShorthandAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11690,7 +11690,7 @@ export function GET() {
 			},
 			RuleWithUseShorthandFunctionTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11709,7 +11709,7 @@ export function GET() {
 			},
 			RuleWithUseSimpleNumberKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11728,7 +11728,7 @@ export function GET() {
 			},
 			RuleWithUseSimplifiedLogicExpressionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11749,7 +11749,7 @@ export function GET() {
 			},
 			RuleWithUseSingleJsDocAsteriskOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11768,7 +11768,7 @@ export function GET() {
 			},
 			RuleWithUseSingleVarDeclaratorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11787,7 +11787,7 @@ export function GET() {
 			},
 			RuleWithUseSolidForComponentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11802,7 +11802,7 @@ export function GET() {
 			},
 			RuleWithUseSortedClassesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11821,7 +11821,7 @@ export function GET() {
 			},
 			RuleWithUseStaticResponseMethodsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11840,7 +11840,7 @@ export function GET() {
 			},
 			RuleWithUseStrictModeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11859,7 +11859,7 @@ export function GET() {
 			},
 			RuleWithUseSymbolDescriptionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11874,7 +11874,7 @@ export function GET() {
 			},
 			RuleWithUseTemplateOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11893,7 +11893,7 @@ export function GET() {
 			},
 			RuleWithUseThrowNewErrorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11912,7 +11912,7 @@ export function GET() {
 			},
 			RuleWithUseThrowOnlyErrorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11927,7 +11927,7 @@ export function GET() {
 			},
 			RuleWithUseTopLevelRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11942,7 +11942,7 @@ export function GET() {
 			},
 			RuleWithUseTrimStartEndOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11961,7 +11961,7 @@ export function GET() {
 			},
 			RuleWithUseUnifiedTypeSignaturesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11980,7 +11980,7 @@ export function GET() {
 			},
 			RuleWithUseUniqueElementIdsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11995,7 +11995,7 @@ export function GET() {
 			},
 			RuleWithUseValidAnchorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12010,7 +12010,7 @@ export function GET() {
 			},
 			RuleWithUseValidAriaPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12029,7 +12029,7 @@ export function GET() {
 			},
 			RuleWithUseValidAriaRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12048,7 +12048,7 @@ export function GET() {
 			},
 			RuleWithUseValidAriaValuesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12063,7 +12063,7 @@ export function GET() {
 			},
 			RuleWithUseValidAutocompleteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12078,7 +12078,7 @@ export function GET() {
 			},
 			RuleWithUseValidForDirectionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12093,7 +12093,7 @@ export function GET() {
 			},
 			RuleWithUseValidLangOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12108,7 +12108,7 @@ export function GET() {
 			},
 			RuleWithUseValidTypeofOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12127,7 +12127,7 @@ export function GET() {
 			},
 			RuleWithUseVueMultiWordComponentNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12144,7 +12144,7 @@ export function GET() {
 			},
 			RuleWithUseWhileOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12163,7 +12163,7 @@ export function GET() {
 			},
 			RuleWithUseYieldOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",

--- a/src/pages/schemas/2.2.6/schema.json.js
+++ b/src/pages/schemas/2.2.6/schema.json.js
@@ -5929,7 +5929,7 @@ export function GET() {
 			RuleAssistPlainConfiguration: { type: "string", enum: ["off", "on"] },
 			RuleAssistWithOptions_for_OrganizeImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5944,7 +5944,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_UseSortedAttributesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5959,7 +5959,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_UseSortedKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5974,7 +5974,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_UseSortedPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6084,7 +6084,7 @@ export function GET() {
 			},
 			RuleWithNoAccessKeyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6103,7 +6103,7 @@ export function GET() {
 			},
 			RuleWithNoAccumulatingSpreadOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6118,7 +6118,7 @@ export function GET() {
 			},
 			RuleWithNoAdjacentSpacesInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6137,7 +6137,7 @@ export function GET() {
 			},
 			RuleWithNoAlertOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6152,7 +6152,7 @@ export function GET() {
 			},
 			RuleWithNoApproximativeNumericConstantOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6173,7 +6173,7 @@ export function GET() {
 			},
 			RuleWithNoArgumentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6188,7 +6188,7 @@ export function GET() {
 			},
 			RuleWithNoAriaHiddenOnFocusableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6207,7 +6207,7 @@ export function GET() {
 			},
 			RuleWithNoAriaUnsupportedElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6226,7 +6226,7 @@ export function GET() {
 			},
 			RuleWithNoArrayIndexKeyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6241,7 +6241,7 @@ export function GET() {
 			},
 			RuleWithNoAssignInExpressionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6256,7 +6256,7 @@ export function GET() {
 			},
 			RuleWithNoAsyncPromiseExecutorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6271,7 +6271,7 @@ export function GET() {
 			},
 			RuleWithNoAutofocusOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6290,7 +6290,7 @@ export function GET() {
 			},
 			RuleWithNoAwaitInLoopsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6305,7 +6305,7 @@ export function GET() {
 			},
 			RuleWithNoBannedTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6324,7 +6324,7 @@ export function GET() {
 			},
 			RuleWithNoBarrelFileOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6339,7 +6339,7 @@ export function GET() {
 			},
 			RuleWithNoBiomeFirstExceptionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6358,7 +6358,7 @@ export function GET() {
 			},
 			RuleWithNoBitwiseOperatorsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6373,7 +6373,7 @@ export function GET() {
 			},
 			RuleWithNoBlankTargetOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6392,7 +6392,7 @@ export function GET() {
 			},
 			RuleWithNoCatchAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6407,7 +6407,7 @@ export function GET() {
 			},
 			RuleWithNoChildrenPropOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6422,7 +6422,7 @@ export function GET() {
 			},
 			RuleWithNoClassAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6437,7 +6437,7 @@ export function GET() {
 			},
 			RuleWithNoCommaOperatorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6452,7 +6452,7 @@ export function GET() {
 			},
 			RuleWithNoCommentTextOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6471,7 +6471,7 @@ export function GET() {
 			},
 			RuleWithNoCommonJsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6486,7 +6486,7 @@ export function GET() {
 			},
 			RuleWithNoCompareNegZeroOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6505,7 +6505,7 @@ export function GET() {
 			},
 			RuleWithNoConfusingLabelsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6520,7 +6520,7 @@ export function GET() {
 			},
 			RuleWithNoConfusingVoidTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6539,7 +6539,7 @@ export function GET() {
 			},
 			RuleWithNoConsoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6558,7 +6558,7 @@ export function GET() {
 			},
 			RuleWithNoConstAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6577,7 +6577,7 @@ export function GET() {
 			},
 			RuleWithNoConstEnumOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6596,7 +6596,7 @@ export function GET() {
 			},
 			RuleWithNoConstantBinaryExpressionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6613,7 +6613,7 @@ export function GET() {
 			},
 			RuleWithNoConstantConditionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6628,7 +6628,7 @@ export function GET() {
 			},
 			RuleWithNoConstantMathMinMaxClampOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6647,7 +6647,7 @@ export function GET() {
 			},
 			RuleWithNoConstructorReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6662,7 +6662,7 @@ export function GET() {
 			},
 			RuleWithNoControlCharactersInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6679,7 +6679,7 @@ export function GET() {
 			},
 			RuleWithNoDangerouslySetInnerHtmlOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6694,7 +6694,7 @@ export function GET() {
 			},
 			RuleWithNoDangerouslySetInnerHtmlWithChildrenOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6713,7 +6713,7 @@ export function GET() {
 			},
 			RuleWithNoDebuggerOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6732,7 +6732,7 @@ export function GET() {
 			},
 			RuleWithNoDefaultExportOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6747,7 +6747,7 @@ export function GET() {
 			},
 			RuleWithNoDeleteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6766,7 +6766,7 @@ export function GET() {
 			},
 			RuleWithNoDeprecatedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6781,7 +6781,7 @@ export function GET() {
 			},
 			RuleWithNoDescendingSpecificityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6796,7 +6796,7 @@ export function GET() {
 			},
 			RuleWithNoDistractingElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6815,7 +6815,7 @@ export function GET() {
 			},
 			RuleWithNoDocumentCookieOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6830,7 +6830,7 @@ export function GET() {
 			},
 			RuleWithNoDocumentImportInPageOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6845,7 +6845,7 @@ export function GET() {
 			},
 			RuleWithNoDoneCallbackOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6860,7 +6860,7 @@ export function GET() {
 			},
 			RuleWithNoDoubleEqualsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6879,7 +6879,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateAtImportRulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6894,7 +6894,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateCaseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6909,7 +6909,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateClassMembersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6924,7 +6924,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateCustomPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6941,7 +6941,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6956,7 +6956,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateElseIfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6971,7 +6971,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateFieldsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6986,7 +6986,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateFontNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7001,7 +7001,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateJsxPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7016,7 +7016,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateObjectKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7031,7 +7031,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateParametersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7046,7 +7046,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicatePropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7061,7 +7061,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateSelectorsKeyframeBlockOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7080,7 +7080,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateTestHooksOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7095,7 +7095,7 @@ export function GET() {
 			},
 			RuleWithNoDynamicNamespaceImportAccessOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7112,7 +7112,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyBlockOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7127,7 +7127,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyBlockStatementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7142,7 +7142,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyCharacterClassInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7159,7 +7159,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyInterfaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7178,7 +7178,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyPatternOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7193,7 +7193,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyTypeParametersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7208,7 +7208,7 @@ export function GET() {
 			},
 			RuleWithNoEnumOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7223,7 +7223,7 @@ export function GET() {
 			},
 			RuleWithNoEvolvingTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7238,7 +7238,7 @@ export function GET() {
 			},
 			RuleWithNoExcessiveCognitiveComplexityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7255,7 +7255,7 @@ export function GET() {
 			},
 			RuleWithNoExcessiveLinesPerFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7272,7 +7272,7 @@ export function GET() {
 			},
 			RuleWithNoExcessiveNestedTestSuitesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7289,7 +7289,7 @@ export function GET() {
 			},
 			RuleWithNoExplicitAnyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7304,7 +7304,7 @@ export function GET() {
 			},
 			RuleWithNoExportedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7319,7 +7319,7 @@ export function GET() {
 			},
 			RuleWithNoExportsInTestOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7334,7 +7334,7 @@ export function GET() {
 			},
 			RuleWithNoExtraBooleanCastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7353,7 +7353,7 @@ export function GET() {
 			},
 			RuleWithNoExtraNonNullAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7372,7 +7372,7 @@ export function GET() {
 			},
 			RuleWithNoFallthroughSwitchClauseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7387,7 +7387,7 @@ export function GET() {
 			},
 			RuleWithNoFlatMapIdentityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7406,7 +7406,7 @@ export function GET() {
 			},
 			RuleWithNoFloatingPromisesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7425,7 +7425,7 @@ export function GET() {
 			},
 			RuleWithNoFocusedTestsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7444,7 +7444,7 @@ export function GET() {
 			},
 			RuleWithNoForEachOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7459,7 +7459,7 @@ export function GET() {
 			},
 			RuleWithNoFunctionAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7474,7 +7474,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7489,7 +7489,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalDirnameFilenameOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7508,7 +7508,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalEvalOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7523,7 +7523,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalIsFiniteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7542,7 +7542,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalIsNanOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7561,7 +7561,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalObjectCallsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7576,7 +7576,7 @@ export function GET() {
 			},
 			RuleWithNoHeadElementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7591,7 +7591,7 @@ export function GET() {
 			},
 			RuleWithNoHeadImportInDocumentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7606,7 +7606,7 @@ export function GET() {
 			},
 			RuleWithNoHeaderScopeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7625,7 +7625,7 @@ export function GET() {
 			},
 			RuleWithNoImgElementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7640,7 +7640,7 @@ export function GET() {
 			},
 			RuleWithNoImplicitAnyLetOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7655,7 +7655,7 @@ export function GET() {
 			},
 			RuleWithNoImplicitBooleanOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7674,7 +7674,7 @@ export function GET() {
 			},
 			RuleWithNoImplicitCoercionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7693,7 +7693,7 @@ export function GET() {
 			},
 			RuleWithNoImportAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7708,7 +7708,7 @@ export function GET() {
 			},
 			RuleWithNoImportCyclesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7723,7 +7723,7 @@ export function GET() {
 			},
 			RuleWithNoImportantInKeyframeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7738,7 +7738,7 @@ export function GET() {
 			},
 			RuleWithNoImportantStylesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7757,7 +7757,7 @@ export function GET() {
 			},
 			RuleWithNoInferrableTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7776,7 +7776,7 @@ export function GET() {
 			},
 			RuleWithNoInnerDeclarationsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7791,7 +7791,7 @@ export function GET() {
 			},
 			RuleWithNoInteractiveElementToNoninteractiveRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7814,7 +7814,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidBuiltinInstantiationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7835,7 +7835,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidConstructorSuperOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7850,7 +7850,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidDirectionInLinearGradientOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7869,7 +7869,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidGridAreasOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7884,7 +7884,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidPositionAtImportRuleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7901,7 +7901,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidUseBeforeDeclarationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7918,7 +7918,7 @@ export function GET() {
 			},
 			RuleWithNoIrregularWhitespaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7933,7 +7933,7 @@ export function GET() {
 			},
 			RuleWithNoJsxLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7948,7 +7948,7 @@ export function GET() {
 			},
 			RuleWithNoLabelVarOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7963,7 +7963,7 @@ export function GET() {
 			},
 			RuleWithNoLabelWithoutControlOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7978,7 +7978,7 @@ export function GET() {
 			},
 			RuleWithNoMagicNumbersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7993,7 +7993,7 @@ export function GET() {
 			},
 			RuleWithNoMisleadingCharacterClassOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8014,7 +8014,7 @@ export function GET() {
 			},
 			RuleWithNoMisleadingInstantiatorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8029,7 +8029,7 @@ export function GET() {
 			},
 			RuleWithNoMisplacedAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8044,7 +8044,7 @@ export function GET() {
 			},
 			RuleWithNoMisrefactoredShorthandAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8065,7 +8065,7 @@ export function GET() {
 			},
 			RuleWithNoMissingVarFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8080,7 +8080,7 @@ export function GET() {
 			},
 			RuleWithNoMisusedPromisesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8099,7 +8099,7 @@ export function GET() {
 			},
 			RuleWithNoNamespaceImportOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8114,7 +8114,7 @@ export function GET() {
 			},
 			RuleWithNoNamespaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8129,7 +8129,7 @@ export function GET() {
 			},
 			RuleWithNoNegationElseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8148,7 +8148,7 @@ export function GET() {
 			},
 			RuleWithNoNestedComponentDefinitionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8165,7 +8165,7 @@ export function GET() {
 			},
 			RuleWithNoNestedTernaryOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8180,7 +8180,7 @@ export function GET() {
 			},
 			RuleWithNoNextAsyncClientComponentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8197,7 +8197,7 @@ export function GET() {
 			},
 			RuleWithNoNodejsModulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8212,7 +8212,7 @@ export function GET() {
 			},
 			RuleWithNoNonNullAssertedOptionalChainOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8229,7 +8229,7 @@ export function GET() {
 			},
 			RuleWithNoNonNullAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8248,7 +8248,7 @@ export function GET() {
 			},
 			RuleWithNoNoninteractiveElementInteractionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8267,7 +8267,7 @@ export function GET() {
 			},
 			RuleWithNoNoninteractiveElementToInteractiveRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8290,7 +8290,7 @@ export function GET() {
 			},
 			RuleWithNoNoninteractiveTabindexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8309,7 +8309,7 @@ export function GET() {
 			},
 			RuleWithNoNonoctalDecimalEscapeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8328,7 +8328,7 @@ export function GET() {
 			},
 			RuleWithNoOctalEscapeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8347,7 +8347,7 @@ export function GET() {
 			},
 			RuleWithNoParameterAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8362,7 +8362,7 @@ export function GET() {
 			},
 			RuleWithNoParameterPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8377,7 +8377,7 @@ export function GET() {
 			},
 			RuleWithNoPositiveTabindexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8396,7 +8396,7 @@ export function GET() {
 			},
 			RuleWithNoPrecisionLossOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8411,7 +8411,7 @@ export function GET() {
 			},
 			RuleWithNoPrivateImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8426,7 +8426,7 @@ export function GET() {
 			},
 			RuleWithNoProcessEnvOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8441,7 +8441,7 @@ export function GET() {
 			},
 			RuleWithNoProcessGlobalOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8460,7 +8460,7 @@ export function GET() {
 			},
 			RuleWithNoPrototypeBuiltinsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8479,7 +8479,7 @@ export function GET() {
 			},
 			RuleWithNoQuickfixBiomeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8498,7 +8498,7 @@ export function GET() {
 			},
 			RuleWithNoQwikUseVisibleTaskOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8513,7 +8513,7 @@ export function GET() {
 			},
 			RuleWithNoReExportAllOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8528,7 +8528,7 @@ export function GET() {
 			},
 			RuleWithNoReactForwardRefOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8547,7 +8547,7 @@ export function GET() {
 			},
 			RuleWithNoReactPropAssignmentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8562,7 +8562,7 @@ export function GET() {
 			},
 			RuleWithNoReactSpecificPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8581,7 +8581,7 @@ export function GET() {
 			},
 			RuleWithNoRedeclareOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8596,7 +8596,7 @@ export function GET() {
 			},
 			RuleWithNoRedundantAltOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8611,7 +8611,7 @@ export function GET() {
 			},
 			RuleWithNoRedundantRolesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8630,7 +8630,7 @@ export function GET() {
 			},
 			RuleWithNoRedundantUseStrictOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8649,7 +8649,7 @@ export function GET() {
 			},
 			RuleWithNoRenderReturnValueOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8664,7 +8664,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8679,7 +8679,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedGlobalsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8694,7 +8694,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8709,7 +8709,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8728,7 +8728,7 @@ export function GET() {
 			},
 			RuleWithNoSecretsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8743,7 +8743,7 @@ export function GET() {
 			},
 			RuleWithNoSelfAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8758,7 +8758,7 @@ export function GET() {
 			},
 			RuleWithNoSelfCompareOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8773,7 +8773,7 @@ export function GET() {
 			},
 			RuleWithNoSetterReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8788,7 +8788,7 @@ export function GET() {
 			},
 			RuleWithNoShadowOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8803,7 +8803,7 @@ export function GET() {
 			},
 			RuleWithNoShadowRestrictedNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8818,7 +8818,7 @@ export function GET() {
 			},
 			RuleWithNoShorthandPropertyOverridesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8835,7 +8835,7 @@ export function GET() {
 			},
 			RuleWithNoShoutyConstantsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8854,7 +8854,7 @@ export function GET() {
 			},
 			RuleWithNoSkippedTestsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8873,7 +8873,7 @@ export function GET() {
 			},
 			RuleWithNoSolidDestructuredPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8888,7 +8888,7 @@ export function GET() {
 			},
 			RuleWithNoSparseArrayOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8907,7 +8907,7 @@ export function GET() {
 			},
 			RuleWithNoStaticElementInteractionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8924,7 +8924,7 @@ export function GET() {
 			},
 			RuleWithNoStaticOnlyClassOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8939,7 +8939,7 @@ export function GET() {
 			},
 			RuleWithNoStringCaseMismatchOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8958,7 +8958,7 @@ export function GET() {
 			},
 			RuleWithNoSubstrOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8977,7 +8977,7 @@ export function GET() {
 			},
 			RuleWithNoSuspiciousSemicolonInJsxOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8994,7 +8994,7 @@ export function GET() {
 			},
 			RuleWithNoSvgWithoutTitleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9009,7 +9009,7 @@ export function GET() {
 			},
 			RuleWithNoSwitchDeclarationsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9028,7 +9028,7 @@ export function GET() {
 			},
 			RuleWithNoTemplateCurlyInStringOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9043,7 +9043,7 @@ export function GET() {
 			},
 			RuleWithNoThenPropertyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9058,7 +9058,7 @@ export function GET() {
 			},
 			RuleWithNoThisInStaticOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9077,7 +9077,7 @@ export function GET() {
 			},
 			RuleWithNoTsIgnoreOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9096,7 +9096,7 @@ export function GET() {
 			},
 			RuleWithNoUnassignedVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9111,7 +9111,7 @@ export function GET() {
 			},
 			RuleWithNoUndeclaredDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9126,7 +9126,7 @@ export function GET() {
 			},
 			RuleWithNoUndeclaredVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9141,7 +9141,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownAtRulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9156,7 +9156,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9171,7 +9171,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownMediaFeatureNameOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9186,7 +9186,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownPropertyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9201,7 +9201,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownPseudoClassOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9216,7 +9216,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownPseudoElementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9231,7 +9231,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownTypeSelectorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9246,7 +9246,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownUnitOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9261,7 +9261,7 @@ export function GET() {
 			},
 			RuleWithNoUnmatchableAnbSelectorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9276,7 +9276,7 @@ export function GET() {
 			},
 			RuleWithNoUnnecessaryConditionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9291,7 +9291,7 @@ export function GET() {
 			},
 			RuleWithNoUnreachableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9306,7 +9306,7 @@ export function GET() {
 			},
 			RuleWithNoUnreachableSuperOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9321,7 +9321,7 @@ export function GET() {
 			},
 			RuleWithNoUnresolvedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9336,7 +9336,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeDeclarationMergingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9353,7 +9353,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeFinallyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9368,7 +9368,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeNegationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9387,7 +9387,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeOptionalChainingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9402,7 +9402,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedExpressionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9417,7 +9417,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedFunctionParametersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9438,7 +9438,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9457,7 +9457,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedLabelsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9476,7 +9476,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedPrivateClassMembersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9497,7 +9497,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedTemplateLiteralOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9516,7 +9516,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9535,7 +9535,7 @@ export function GET() {
 			},
 			RuleWithNoUnwantedPolyfillioOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9550,7 +9550,7 @@ export function GET() {
 			},
 			RuleWithNoUselessCatchBindingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9569,7 +9569,7 @@ export function GET() {
 			},
 			RuleWithNoUselessCatchOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9588,7 +9588,7 @@ export function GET() {
 			},
 			RuleWithNoUselessConstructorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9607,7 +9607,7 @@ export function GET() {
 			},
 			RuleWithNoUselessContinueOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9626,7 +9626,7 @@ export function GET() {
 			},
 			RuleWithNoUselessElseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9645,7 +9645,7 @@ export function GET() {
 			},
 			RuleWithNoUselessEmptyExportOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9664,7 +9664,7 @@ export function GET() {
 			},
 			RuleWithNoUselessEscapeInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9683,7 +9683,7 @@ export function GET() {
 			},
 			RuleWithNoUselessEscapeInStringOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9702,7 +9702,7 @@ export function GET() {
 			},
 			RuleWithNoUselessFragmentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9721,7 +9721,7 @@ export function GET() {
 			},
 			RuleWithNoUselessLabelOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9740,7 +9740,7 @@ export function GET() {
 			},
 			RuleWithNoUselessLoneBlockStatementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9761,7 +9761,7 @@ export function GET() {
 			},
 			RuleWithNoUselessRegexBackrefsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9776,7 +9776,7 @@ export function GET() {
 			},
 			RuleWithNoUselessRenameOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9795,7 +9795,7 @@ export function GET() {
 			},
 			RuleWithNoUselessStringConcatOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9814,7 +9814,7 @@ export function GET() {
 			},
 			RuleWithNoUselessStringRawOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9829,7 +9829,7 @@ export function GET() {
 			},
 			RuleWithNoUselessSwitchCaseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9848,7 +9848,7 @@ export function GET() {
 			},
 			RuleWithNoUselessTernaryOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9867,7 +9867,7 @@ export function GET() {
 			},
 			RuleWithNoUselessThisAliasOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9886,7 +9886,7 @@ export function GET() {
 			},
 			RuleWithNoUselessTypeConstraintOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9905,7 +9905,7 @@ export function GET() {
 			},
 			RuleWithNoUselessUndefinedInitializationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9926,7 +9926,7 @@ export function GET() {
 			},
 			RuleWithNoUselessUndefinedOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9945,7 +9945,7 @@ export function GET() {
 			},
 			RuleWithNoValueAtRuleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9960,7 +9960,7 @@ export function GET() {
 			},
 			RuleWithNoVarOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9979,7 +9979,7 @@ export function GET() {
 			},
 			RuleWithNoVoidElementsWithChildrenOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10000,7 +10000,7 @@ export function GET() {
 			},
 			RuleWithNoVoidOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10015,7 +10015,7 @@ export function GET() {
 			},
 			RuleWithNoVoidTypeReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10030,7 +10030,7 @@ export function GET() {
 			},
 			RuleWithNoVueDataObjectDeclarationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10051,7 +10051,7 @@ export function GET() {
 			},
 			RuleWithNoVueDuplicateKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10066,7 +10066,7 @@ export function GET() {
 			},
 			RuleWithNoVueReservedKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10081,7 +10081,7 @@ export function GET() {
 			},
 			RuleWithNoVueReservedPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10096,7 +10096,7 @@ export function GET() {
 			},
 			RuleWithNoWithOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10111,7 +10111,7 @@ export function GET() {
 			},
 			RuleWithNoYodaExpressionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10130,7 +10130,7 @@ export function GET() {
 			},
 			RuleWithUseAdjacentOverloadSignaturesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10147,7 +10147,7 @@ export function GET() {
 			},
 			RuleWithUseAltTextOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10162,7 +10162,7 @@ export function GET() {
 			},
 			RuleWithUseAnchorContentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10181,7 +10181,7 @@ export function GET() {
 			},
 			RuleWithUseAnchorHrefOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10196,7 +10196,7 @@ export function GET() {
 			},
 			RuleWithUseAriaActivedescendantWithTabindexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10219,7 +10219,7 @@ export function GET() {
 			},
 			RuleWithUseAriaPropsForRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10234,7 +10234,7 @@ export function GET() {
 			},
 			RuleWithUseAriaPropsSupportedByRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10251,7 +10251,7 @@ export function GET() {
 			},
 			RuleWithUseArrayLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10270,7 +10270,7 @@ export function GET() {
 			},
 			RuleWithUseArrowFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10289,7 +10289,7 @@ export function GET() {
 			},
 			RuleWithUseAsConstAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10308,7 +10308,7 @@ export function GET() {
 			},
 			RuleWithUseAtIndexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10327,7 +10327,7 @@ export function GET() {
 			},
 			RuleWithUseAwaitOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10342,7 +10342,7 @@ export function GET() {
 			},
 			RuleWithUseBiomeIgnoreFolderOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10361,7 +10361,7 @@ export function GET() {
 			},
 			RuleWithUseBlockStatementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10380,7 +10380,7 @@ export function GET() {
 			},
 			RuleWithUseButtonTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10395,7 +10395,7 @@ export function GET() {
 			},
 			RuleWithUseCollapsedElseIfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10414,7 +10414,7 @@ export function GET() {
 			},
 			RuleWithUseCollapsedIfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10433,7 +10433,7 @@ export function GET() {
 			},
 			RuleWithUseComponentExportOnlyModulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10450,7 +10450,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentArrayTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10469,7 +10469,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentArrowReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10488,7 +10488,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentBuiltinInstantiationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10511,7 +10511,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentCurlyBracesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10530,7 +10530,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentMemberAccessibilityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10547,7 +10547,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentObjectDefinitionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10568,7 +10568,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentTypeDefinitionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10589,7 +10589,7 @@ export function GET() {
 			},
 			RuleWithUseConstOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10608,7 +10608,7 @@ export function GET() {
 			},
 			RuleWithUseDateNowOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10627,7 +10627,7 @@ export function GET() {
 			},
 			RuleWithUseDefaultParameterLastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10646,7 +10646,7 @@ export function GET() {
 			},
 			RuleWithUseDefaultSwitchClauseLastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10663,7 +10663,7 @@ export function GET() {
 			},
 			RuleWithUseDefaultSwitchClauseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10678,7 +10678,7 @@ export function GET() {
 			},
 			RuleWithUseDeprecatedDateOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10693,7 +10693,7 @@ export function GET() {
 			},
 			RuleWithUseDeprecatedReasonOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10708,7 +10708,7 @@ export function GET() {
 			},
 			RuleWithUseEnumInitializersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10727,7 +10727,7 @@ export function GET() {
 			},
 			RuleWithUseErrorMessageOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10742,7 +10742,7 @@ export function GET() {
 			},
 			RuleWithUseExhaustiveDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10761,7 +10761,7 @@ export function GET() {
 			},
 			RuleWithUseExhaustiveSwitchCasesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10780,7 +10780,7 @@ export function GET() {
 			},
 			RuleWithUseExplicitLengthCheckOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10799,7 +10799,7 @@ export function GET() {
 			},
 			RuleWithUseExplicitTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10814,7 +10814,7 @@ export function GET() {
 			},
 			RuleWithUseExponentiationOperatorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10833,7 +10833,7 @@ export function GET() {
 			},
 			RuleWithUseExportTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10852,7 +10852,7 @@ export function GET() {
 			},
 			RuleWithUseExportsLastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10867,7 +10867,7 @@ export function GET() {
 			},
 			RuleWithUseFilenamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10882,7 +10882,7 @@ export function GET() {
 			},
 			RuleWithUseFlatMapOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10901,7 +10901,7 @@ export function GET() {
 			},
 			RuleWithUseFocusableInteractiveOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10916,7 +10916,7 @@ export function GET() {
 			},
 			RuleWithUseForOfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10931,7 +10931,7 @@ export function GET() {
 			},
 			RuleWithUseFragmentSyntaxOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10950,7 +10950,7 @@ export function GET() {
 			},
 			RuleWithUseGenericFontNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10965,7 +10965,7 @@ export function GET() {
 			},
 			RuleWithUseGetterReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10980,7 +10980,7 @@ export function GET() {
 			},
 			RuleWithUseGoogleFontDisplayOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10995,7 +10995,7 @@ export function GET() {
 			},
 			RuleWithUseGoogleFontPreconnectOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11014,7 +11014,7 @@ export function GET() {
 			},
 			RuleWithUseGraphqlNamedOperationsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11033,7 +11033,7 @@ export function GET() {
 			},
 			RuleWithUseGraphqlNamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11050,7 +11050,7 @@ export function GET() {
 			},
 			RuleWithUseGroupedAccessorPairsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11065,7 +11065,7 @@ export function GET() {
 			},
 			RuleWithUseGuardForInOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11080,7 +11080,7 @@ export function GET() {
 			},
 			RuleWithUseHeadingContentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11095,7 +11095,7 @@ export function GET() {
 			},
 			RuleWithUseHookAtTopLevelOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11110,7 +11110,7 @@ export function GET() {
 			},
 			RuleWithUseHtmlLangOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11125,7 +11125,7 @@ export function GET() {
 			},
 			RuleWithUseIframeTitleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11140,7 +11140,7 @@ export function GET() {
 			},
 			RuleWithUseImageSizeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11155,7 +11155,7 @@ export function GET() {
 			},
 			RuleWithUseImportExtensionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11174,7 +11174,7 @@ export function GET() {
 			},
 			RuleWithUseImportTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11193,7 +11193,7 @@ export function GET() {
 			},
 			RuleWithUseIndexOfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11212,7 +11212,7 @@ export function GET() {
 			},
 			RuleWithUseIsArrayOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11231,7 +11231,7 @@ export function GET() {
 			},
 			RuleWithUseIsNanOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11250,7 +11250,7 @@ export function GET() {
 			},
 			RuleWithUseIterableCallbackReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11265,7 +11265,7 @@ export function GET() {
 			},
 			RuleWithUseJsonImportAttributesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11284,7 +11284,7 @@ export function GET() {
 			},
 			RuleWithUseJsxKeyInIterableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11299,7 +11299,7 @@ export function GET() {
 			},
 			RuleWithUseKeyWithClickEventsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11314,7 +11314,7 @@ export function GET() {
 			},
 			RuleWithUseKeyWithMouseEventsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11329,7 +11329,7 @@ export function GET() {
 			},
 			RuleWithUseLiteralEnumMembersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11344,7 +11344,7 @@ export function GET() {
 			},
 			RuleWithUseLiteralKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11363,7 +11363,7 @@ export function GET() {
 			},
 			RuleWithUseMaxParamsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11378,7 +11378,7 @@ export function GET() {
 			},
 			RuleWithUseMediaCaptionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11393,7 +11393,7 @@ export function GET() {
 			},
 			RuleWithUseNamespaceKeywordOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11412,7 +11412,7 @@ export function GET() {
 			},
 			RuleWithUseNamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11431,7 +11431,7 @@ export function GET() {
 			},
 			RuleWithUseNodeAssertStrictOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11450,7 +11450,7 @@ export function GET() {
 			},
 			RuleWithUseNodejsImportProtocolOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11469,7 +11469,7 @@ export function GET() {
 			},
 			RuleWithUseNumberNamespaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11488,7 +11488,7 @@ export function GET() {
 			},
 			RuleWithUseNumberToFixedDigitsArgumentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11509,7 +11509,7 @@ export function GET() {
 			},
 			RuleWithUseNumericLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11528,7 +11528,7 @@ export function GET() {
 			},
 			RuleWithUseNumericSeparatorsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11547,7 +11547,7 @@ export function GET() {
 			},
 			RuleWithUseObjectSpreadOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11566,7 +11566,7 @@ export function GET() {
 			},
 			RuleWithUseOptionalChainOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11585,7 +11585,7 @@ export function GET() {
 			},
 			RuleWithUseParseIntRadixOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11604,7 +11604,7 @@ export function GET() {
 			},
 			RuleWithUseQwikClasslistOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11619,7 +11619,7 @@ export function GET() {
 			},
 			RuleWithUseQwikMethodUsageOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11634,7 +11634,7 @@ export function GET() {
 			},
 			RuleWithUseQwikValidLexicalScopeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11649,7 +11649,7 @@ export function GET() {
 			},
 			RuleWithUseReactFunctionComponentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11666,7 +11666,7 @@ export function GET() {
 			},
 			RuleWithUseReadonlyClassPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11687,7 +11687,7 @@ export function GET() {
 			},
 			RuleWithUseRegexLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11706,7 +11706,7 @@ export function GET() {
 			},
 			RuleWithUseSelfClosingElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11725,7 +11725,7 @@ export function GET() {
 			},
 			RuleWithUseSemanticElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11740,7 +11740,7 @@ export function GET() {
 			},
 			RuleWithUseShorthandAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11759,7 +11759,7 @@ export function GET() {
 			},
 			RuleWithUseShorthandFunctionTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11778,7 +11778,7 @@ export function GET() {
 			},
 			RuleWithUseSimpleNumberKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11797,7 +11797,7 @@ export function GET() {
 			},
 			RuleWithUseSimplifiedLogicExpressionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11818,7 +11818,7 @@ export function GET() {
 			},
 			RuleWithUseSingleJsDocAsteriskOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11837,7 +11837,7 @@ export function GET() {
 			},
 			RuleWithUseSingleVarDeclaratorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11856,7 +11856,7 @@ export function GET() {
 			},
 			RuleWithUseSolidForComponentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11871,7 +11871,7 @@ export function GET() {
 			},
 			RuleWithUseSortedClassesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11890,7 +11890,7 @@ export function GET() {
 			},
 			RuleWithUseStaticResponseMethodsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11909,7 +11909,7 @@ export function GET() {
 			},
 			RuleWithUseStrictModeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11928,7 +11928,7 @@ export function GET() {
 			},
 			RuleWithUseSymbolDescriptionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11943,7 +11943,7 @@ export function GET() {
 			},
 			RuleWithUseTemplateOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11962,7 +11962,7 @@ export function GET() {
 			},
 			RuleWithUseThrowNewErrorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11981,7 +11981,7 @@ export function GET() {
 			},
 			RuleWithUseThrowOnlyErrorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11996,7 +11996,7 @@ export function GET() {
 			},
 			RuleWithUseTopLevelRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12011,7 +12011,7 @@ export function GET() {
 			},
 			RuleWithUseTrimStartEndOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12030,7 +12030,7 @@ export function GET() {
 			},
 			RuleWithUseUnifiedTypeSignaturesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12049,7 +12049,7 @@ export function GET() {
 			},
 			RuleWithUseUniqueElementIdsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12064,7 +12064,7 @@ export function GET() {
 			},
 			RuleWithUseValidAnchorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12079,7 +12079,7 @@ export function GET() {
 			},
 			RuleWithUseValidAriaPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12098,7 +12098,7 @@ export function GET() {
 			},
 			RuleWithUseValidAriaRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12117,7 +12117,7 @@ export function GET() {
 			},
 			RuleWithUseValidAriaValuesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12132,7 +12132,7 @@ export function GET() {
 			},
 			RuleWithUseValidAutocompleteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12147,7 +12147,7 @@ export function GET() {
 			},
 			RuleWithUseValidForDirectionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12162,7 +12162,7 @@ export function GET() {
 			},
 			RuleWithUseValidLangOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12177,7 +12177,7 @@ export function GET() {
 			},
 			RuleWithUseValidTypeofOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12196,7 +12196,7 @@ export function GET() {
 			},
 			RuleWithUseVueMultiWordComponentNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12213,7 +12213,7 @@ export function GET() {
 			},
 			RuleWithUseWhileOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12232,7 +12232,7 @@ export function GET() {
 			},
 			RuleWithUseYieldOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",

--- a/src/pages/schemas/2.2.7/schema.json.js
+++ b/src/pages/schemas/2.2.7/schema.json.js
@@ -5953,7 +5953,7 @@ export function GET() {
 			RuleAssistPlainConfiguration: { type: "string", enum: ["off", "on"] },
 			RuleAssistWithOptions_for_OrganizeImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5968,7 +5968,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_UseSortedAttributesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5983,7 +5983,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_UseSortedKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5998,7 +5998,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_UseSortedPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6108,7 +6108,7 @@ export function GET() {
 			},
 			RuleWithNoAccessKeyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6127,7 +6127,7 @@ export function GET() {
 			},
 			RuleWithNoAccumulatingSpreadOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6142,7 +6142,7 @@ export function GET() {
 			},
 			RuleWithNoAdjacentSpacesInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6161,7 +6161,7 @@ export function GET() {
 			},
 			RuleWithNoAlertOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6176,7 +6176,7 @@ export function GET() {
 			},
 			RuleWithNoApproximativeNumericConstantOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6197,7 +6197,7 @@ export function GET() {
 			},
 			RuleWithNoArgumentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6212,7 +6212,7 @@ export function GET() {
 			},
 			RuleWithNoAriaHiddenOnFocusableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6231,7 +6231,7 @@ export function GET() {
 			},
 			RuleWithNoAriaUnsupportedElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6250,7 +6250,7 @@ export function GET() {
 			},
 			RuleWithNoArrayIndexKeyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6265,7 +6265,7 @@ export function GET() {
 			},
 			RuleWithNoAssignInExpressionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6280,7 +6280,7 @@ export function GET() {
 			},
 			RuleWithNoAsyncPromiseExecutorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6295,7 +6295,7 @@ export function GET() {
 			},
 			RuleWithNoAutofocusOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6314,7 +6314,7 @@ export function GET() {
 			},
 			RuleWithNoAwaitInLoopsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6329,7 +6329,7 @@ export function GET() {
 			},
 			RuleWithNoBannedTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6348,7 +6348,7 @@ export function GET() {
 			},
 			RuleWithNoBarrelFileOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6363,7 +6363,7 @@ export function GET() {
 			},
 			RuleWithNoBiomeFirstExceptionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6382,7 +6382,7 @@ export function GET() {
 			},
 			RuleWithNoBitwiseOperatorsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6397,7 +6397,7 @@ export function GET() {
 			},
 			RuleWithNoBlankTargetOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6416,7 +6416,7 @@ export function GET() {
 			},
 			RuleWithNoCatchAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6431,7 +6431,7 @@ export function GET() {
 			},
 			RuleWithNoChildrenPropOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6446,7 +6446,7 @@ export function GET() {
 			},
 			RuleWithNoClassAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6461,7 +6461,7 @@ export function GET() {
 			},
 			RuleWithNoCommaOperatorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6476,7 +6476,7 @@ export function GET() {
 			},
 			RuleWithNoCommentTextOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6495,7 +6495,7 @@ export function GET() {
 			},
 			RuleWithNoCommonJsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6510,7 +6510,7 @@ export function GET() {
 			},
 			RuleWithNoCompareNegZeroOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6529,7 +6529,7 @@ export function GET() {
 			},
 			RuleWithNoConfusingLabelsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6544,7 +6544,7 @@ export function GET() {
 			},
 			RuleWithNoConfusingVoidTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6563,7 +6563,7 @@ export function GET() {
 			},
 			RuleWithNoConsoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6582,7 +6582,7 @@ export function GET() {
 			},
 			RuleWithNoConstAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6601,7 +6601,7 @@ export function GET() {
 			},
 			RuleWithNoConstEnumOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6620,7 +6620,7 @@ export function GET() {
 			},
 			RuleWithNoConstantBinaryExpressionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6637,7 +6637,7 @@ export function GET() {
 			},
 			RuleWithNoConstantConditionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6652,7 +6652,7 @@ export function GET() {
 			},
 			RuleWithNoConstantMathMinMaxClampOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6671,7 +6671,7 @@ export function GET() {
 			},
 			RuleWithNoConstructorReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6686,7 +6686,7 @@ export function GET() {
 			},
 			RuleWithNoControlCharactersInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6703,7 +6703,7 @@ export function GET() {
 			},
 			RuleWithNoDangerouslySetInnerHtmlOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6718,7 +6718,7 @@ export function GET() {
 			},
 			RuleWithNoDangerouslySetInnerHtmlWithChildrenOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6737,7 +6737,7 @@ export function GET() {
 			},
 			RuleWithNoDebuggerOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6756,7 +6756,7 @@ export function GET() {
 			},
 			RuleWithNoDefaultExportOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6771,7 +6771,7 @@ export function GET() {
 			},
 			RuleWithNoDeleteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6790,7 +6790,7 @@ export function GET() {
 			},
 			RuleWithNoDeprecatedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6805,7 +6805,7 @@ export function GET() {
 			},
 			RuleWithNoDescendingSpecificityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6820,7 +6820,7 @@ export function GET() {
 			},
 			RuleWithNoDistractingElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6839,7 +6839,7 @@ export function GET() {
 			},
 			RuleWithNoDocumentCookieOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6854,7 +6854,7 @@ export function GET() {
 			},
 			RuleWithNoDocumentImportInPageOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6869,7 +6869,7 @@ export function GET() {
 			},
 			RuleWithNoDoneCallbackOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6884,7 +6884,7 @@ export function GET() {
 			},
 			RuleWithNoDoubleEqualsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6903,7 +6903,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateAtImportRulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6918,7 +6918,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateCaseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6933,7 +6933,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateClassMembersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6948,7 +6948,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateCustomPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6965,7 +6965,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6980,7 +6980,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateElseIfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6995,7 +6995,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateFieldsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7010,7 +7010,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateFontNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7025,7 +7025,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateJsxPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7040,7 +7040,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateObjectKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7055,7 +7055,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateParametersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7070,7 +7070,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicatePropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7085,7 +7085,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateSelectorsKeyframeBlockOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7104,7 +7104,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateTestHooksOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7119,7 +7119,7 @@ export function GET() {
 			},
 			RuleWithNoDynamicNamespaceImportAccessOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7136,7 +7136,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyBlockOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7151,7 +7151,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyBlockStatementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7166,7 +7166,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyCharacterClassInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7183,7 +7183,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyInterfaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7202,7 +7202,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyPatternOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7217,7 +7217,7 @@ export function GET() {
 			},
 			RuleWithNoEmptySourceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7232,7 +7232,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyTypeParametersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7247,7 +7247,7 @@ export function GET() {
 			},
 			RuleWithNoEnumOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7262,7 +7262,7 @@ export function GET() {
 			},
 			RuleWithNoEvolvingTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7277,7 +7277,7 @@ export function GET() {
 			},
 			RuleWithNoExcessiveCognitiveComplexityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7294,7 +7294,7 @@ export function GET() {
 			},
 			RuleWithNoExcessiveLinesPerFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7311,7 +7311,7 @@ export function GET() {
 			},
 			RuleWithNoExcessiveNestedTestSuitesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7328,7 +7328,7 @@ export function GET() {
 			},
 			RuleWithNoExplicitAnyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7343,7 +7343,7 @@ export function GET() {
 			},
 			RuleWithNoExportedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7358,7 +7358,7 @@ export function GET() {
 			},
 			RuleWithNoExportsInTestOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7373,7 +7373,7 @@ export function GET() {
 			},
 			RuleWithNoExtraBooleanCastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7392,7 +7392,7 @@ export function GET() {
 			},
 			RuleWithNoExtraNonNullAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7411,7 +7411,7 @@ export function GET() {
 			},
 			RuleWithNoFallthroughSwitchClauseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7426,7 +7426,7 @@ export function GET() {
 			},
 			RuleWithNoFlatMapIdentityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7445,7 +7445,7 @@ export function GET() {
 			},
 			RuleWithNoFloatingPromisesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7464,7 +7464,7 @@ export function GET() {
 			},
 			RuleWithNoFocusedTestsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7483,7 +7483,7 @@ export function GET() {
 			},
 			RuleWithNoForEachOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7498,7 +7498,7 @@ export function GET() {
 			},
 			RuleWithNoFunctionAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7513,7 +7513,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7528,7 +7528,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalDirnameFilenameOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7547,7 +7547,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalEvalOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7562,7 +7562,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalIsFiniteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7581,7 +7581,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalIsNanOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7600,7 +7600,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalObjectCallsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7615,7 +7615,7 @@ export function GET() {
 			},
 			RuleWithNoHeadElementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7630,7 +7630,7 @@ export function GET() {
 			},
 			RuleWithNoHeadImportInDocumentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7645,7 +7645,7 @@ export function GET() {
 			},
 			RuleWithNoHeaderScopeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7664,7 +7664,7 @@ export function GET() {
 			},
 			RuleWithNoImgElementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7679,7 +7679,7 @@ export function GET() {
 			},
 			RuleWithNoImplicitAnyLetOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7694,7 +7694,7 @@ export function GET() {
 			},
 			RuleWithNoImplicitBooleanOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7713,7 +7713,7 @@ export function GET() {
 			},
 			RuleWithNoImplicitCoercionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7732,7 +7732,7 @@ export function GET() {
 			},
 			RuleWithNoImportAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7747,7 +7747,7 @@ export function GET() {
 			},
 			RuleWithNoImportCyclesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7762,7 +7762,7 @@ export function GET() {
 			},
 			RuleWithNoImportantInKeyframeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7777,7 +7777,7 @@ export function GET() {
 			},
 			RuleWithNoImportantStylesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7796,7 +7796,7 @@ export function GET() {
 			},
 			RuleWithNoInferrableTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7815,7 +7815,7 @@ export function GET() {
 			},
 			RuleWithNoInnerDeclarationsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7830,7 +7830,7 @@ export function GET() {
 			},
 			RuleWithNoInteractiveElementToNoninteractiveRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7853,7 +7853,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidBuiltinInstantiationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7874,7 +7874,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidConstructorSuperOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7889,7 +7889,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidDirectionInLinearGradientOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7908,7 +7908,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidGridAreasOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7923,7 +7923,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidPositionAtImportRuleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7940,7 +7940,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidUseBeforeDeclarationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7957,7 +7957,7 @@ export function GET() {
 			},
 			RuleWithNoIrregularWhitespaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7972,7 +7972,7 @@ export function GET() {
 			},
 			RuleWithNoJsxLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7987,7 +7987,7 @@ export function GET() {
 			},
 			RuleWithNoLabelVarOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8002,7 +8002,7 @@ export function GET() {
 			},
 			RuleWithNoLabelWithoutControlOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8017,7 +8017,7 @@ export function GET() {
 			},
 			RuleWithNoMagicNumbersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8032,7 +8032,7 @@ export function GET() {
 			},
 			RuleWithNoMisleadingCharacterClassOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8053,7 +8053,7 @@ export function GET() {
 			},
 			RuleWithNoMisleadingInstantiatorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8068,7 +8068,7 @@ export function GET() {
 			},
 			RuleWithNoMisplacedAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8083,7 +8083,7 @@ export function GET() {
 			},
 			RuleWithNoMisrefactoredShorthandAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8104,7 +8104,7 @@ export function GET() {
 			},
 			RuleWithNoMissingVarFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8119,7 +8119,7 @@ export function GET() {
 			},
 			RuleWithNoMisusedPromisesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8138,7 +8138,7 @@ export function GET() {
 			},
 			RuleWithNoNamespaceImportOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8153,7 +8153,7 @@ export function GET() {
 			},
 			RuleWithNoNamespaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8168,7 +8168,7 @@ export function GET() {
 			},
 			RuleWithNoNegationElseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8187,7 +8187,7 @@ export function GET() {
 			},
 			RuleWithNoNestedComponentDefinitionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8204,7 +8204,7 @@ export function GET() {
 			},
 			RuleWithNoNestedTernaryOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8219,7 +8219,7 @@ export function GET() {
 			},
 			RuleWithNoNextAsyncClientComponentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8236,7 +8236,7 @@ export function GET() {
 			},
 			RuleWithNoNodejsModulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8251,7 +8251,7 @@ export function GET() {
 			},
 			RuleWithNoNonNullAssertedOptionalChainOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8268,7 +8268,7 @@ export function GET() {
 			},
 			RuleWithNoNonNullAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8287,7 +8287,7 @@ export function GET() {
 			},
 			RuleWithNoNoninteractiveElementInteractionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8306,7 +8306,7 @@ export function GET() {
 			},
 			RuleWithNoNoninteractiveElementToInteractiveRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8329,7 +8329,7 @@ export function GET() {
 			},
 			RuleWithNoNoninteractiveTabindexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8348,7 +8348,7 @@ export function GET() {
 			},
 			RuleWithNoNonoctalDecimalEscapeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8367,7 +8367,7 @@ export function GET() {
 			},
 			RuleWithNoOctalEscapeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8386,7 +8386,7 @@ export function GET() {
 			},
 			RuleWithNoParameterAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8401,7 +8401,7 @@ export function GET() {
 			},
 			RuleWithNoParameterPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8416,7 +8416,7 @@ export function GET() {
 			},
 			RuleWithNoPositiveTabindexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8435,7 +8435,7 @@ export function GET() {
 			},
 			RuleWithNoPrecisionLossOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8450,7 +8450,7 @@ export function GET() {
 			},
 			RuleWithNoPrivateImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8465,7 +8465,7 @@ export function GET() {
 			},
 			RuleWithNoProcessEnvOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8480,7 +8480,7 @@ export function GET() {
 			},
 			RuleWithNoProcessGlobalOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8499,7 +8499,7 @@ export function GET() {
 			},
 			RuleWithNoPrototypeBuiltinsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8518,7 +8518,7 @@ export function GET() {
 			},
 			RuleWithNoQuickfixBiomeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8537,7 +8537,7 @@ export function GET() {
 			},
 			RuleWithNoQwikUseVisibleTaskOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8552,7 +8552,7 @@ export function GET() {
 			},
 			RuleWithNoReExportAllOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8567,7 +8567,7 @@ export function GET() {
 			},
 			RuleWithNoReactForwardRefOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8586,7 +8586,7 @@ export function GET() {
 			},
 			RuleWithNoReactPropAssignmentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8601,7 +8601,7 @@ export function GET() {
 			},
 			RuleWithNoReactSpecificPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8620,7 +8620,7 @@ export function GET() {
 			},
 			RuleWithNoRedeclareOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8635,7 +8635,7 @@ export function GET() {
 			},
 			RuleWithNoRedundantAltOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8650,7 +8650,7 @@ export function GET() {
 			},
 			RuleWithNoRedundantRolesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8669,7 +8669,7 @@ export function GET() {
 			},
 			RuleWithNoRedundantUseStrictOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8688,7 +8688,7 @@ export function GET() {
 			},
 			RuleWithNoRenderReturnValueOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8703,7 +8703,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8718,7 +8718,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedGlobalsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8733,7 +8733,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8748,7 +8748,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8767,7 +8767,7 @@ export function GET() {
 			},
 			RuleWithNoSecretsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8782,7 +8782,7 @@ export function GET() {
 			},
 			RuleWithNoSelfAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8797,7 +8797,7 @@ export function GET() {
 			},
 			RuleWithNoSelfCompareOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8812,7 +8812,7 @@ export function GET() {
 			},
 			RuleWithNoSetterReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8827,7 +8827,7 @@ export function GET() {
 			},
 			RuleWithNoShadowOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8842,7 +8842,7 @@ export function GET() {
 			},
 			RuleWithNoShadowRestrictedNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8857,7 +8857,7 @@ export function GET() {
 			},
 			RuleWithNoShorthandPropertyOverridesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8874,7 +8874,7 @@ export function GET() {
 			},
 			RuleWithNoShoutyConstantsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8893,7 +8893,7 @@ export function GET() {
 			},
 			RuleWithNoSkippedTestsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8912,7 +8912,7 @@ export function GET() {
 			},
 			RuleWithNoSolidDestructuredPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8927,7 +8927,7 @@ export function GET() {
 			},
 			RuleWithNoSparseArrayOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8946,7 +8946,7 @@ export function GET() {
 			},
 			RuleWithNoStaticElementInteractionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8963,7 +8963,7 @@ export function GET() {
 			},
 			RuleWithNoStaticOnlyClassOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8978,7 +8978,7 @@ export function GET() {
 			},
 			RuleWithNoStringCaseMismatchOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8997,7 +8997,7 @@ export function GET() {
 			},
 			RuleWithNoSubstrOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9016,7 +9016,7 @@ export function GET() {
 			},
 			RuleWithNoSuspiciousSemicolonInJsxOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9033,7 +9033,7 @@ export function GET() {
 			},
 			RuleWithNoSvgWithoutTitleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9048,7 +9048,7 @@ export function GET() {
 			},
 			RuleWithNoSwitchDeclarationsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9067,7 +9067,7 @@ export function GET() {
 			},
 			RuleWithNoTemplateCurlyInStringOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9082,7 +9082,7 @@ export function GET() {
 			},
 			RuleWithNoThenPropertyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9097,7 +9097,7 @@ export function GET() {
 			},
 			RuleWithNoThisInStaticOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9116,7 +9116,7 @@ export function GET() {
 			},
 			RuleWithNoTsIgnoreOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9135,7 +9135,7 @@ export function GET() {
 			},
 			RuleWithNoUnassignedVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9150,7 +9150,7 @@ export function GET() {
 			},
 			RuleWithNoUndeclaredDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9165,7 +9165,7 @@ export function GET() {
 			},
 			RuleWithNoUndeclaredVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9180,7 +9180,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownAtRulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9195,7 +9195,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9210,7 +9210,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownMediaFeatureNameOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9225,7 +9225,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownPropertyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9240,7 +9240,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownPseudoClassOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9255,7 +9255,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownPseudoElementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9270,7 +9270,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownTypeSelectorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9285,7 +9285,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownUnitOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9300,7 +9300,7 @@ export function GET() {
 			},
 			RuleWithNoUnmatchableAnbSelectorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9315,7 +9315,7 @@ export function GET() {
 			},
 			RuleWithNoUnnecessaryConditionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9330,7 +9330,7 @@ export function GET() {
 			},
 			RuleWithNoUnreachableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9345,7 +9345,7 @@ export function GET() {
 			},
 			RuleWithNoUnreachableSuperOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9360,7 +9360,7 @@ export function GET() {
 			},
 			RuleWithNoUnresolvedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9375,7 +9375,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeDeclarationMergingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9392,7 +9392,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeFinallyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9407,7 +9407,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeNegationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9426,7 +9426,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeOptionalChainingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9441,7 +9441,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedExpressionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9456,7 +9456,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedFunctionParametersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9477,7 +9477,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9496,7 +9496,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedLabelsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9515,7 +9515,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedPrivateClassMembersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9536,7 +9536,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedTemplateLiteralOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9555,7 +9555,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9574,7 +9574,7 @@ export function GET() {
 			},
 			RuleWithNoUnwantedPolyfillioOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9589,7 +9589,7 @@ export function GET() {
 			},
 			RuleWithNoUselessCatchBindingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9608,7 +9608,7 @@ export function GET() {
 			},
 			RuleWithNoUselessCatchOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9627,7 +9627,7 @@ export function GET() {
 			},
 			RuleWithNoUselessConstructorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9646,7 +9646,7 @@ export function GET() {
 			},
 			RuleWithNoUselessContinueOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9665,7 +9665,7 @@ export function GET() {
 			},
 			RuleWithNoUselessElseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9684,7 +9684,7 @@ export function GET() {
 			},
 			RuleWithNoUselessEmptyExportOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9703,7 +9703,7 @@ export function GET() {
 			},
 			RuleWithNoUselessEscapeInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9722,7 +9722,7 @@ export function GET() {
 			},
 			RuleWithNoUselessEscapeInStringOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9741,7 +9741,7 @@ export function GET() {
 			},
 			RuleWithNoUselessFragmentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9760,7 +9760,7 @@ export function GET() {
 			},
 			RuleWithNoUselessLabelOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9779,7 +9779,7 @@ export function GET() {
 			},
 			RuleWithNoUselessLoneBlockStatementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9800,7 +9800,7 @@ export function GET() {
 			},
 			RuleWithNoUselessRegexBackrefsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9815,7 +9815,7 @@ export function GET() {
 			},
 			RuleWithNoUselessRenameOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9834,7 +9834,7 @@ export function GET() {
 			},
 			RuleWithNoUselessStringConcatOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9853,7 +9853,7 @@ export function GET() {
 			},
 			RuleWithNoUselessStringRawOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9868,7 +9868,7 @@ export function GET() {
 			},
 			RuleWithNoUselessSwitchCaseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9887,7 +9887,7 @@ export function GET() {
 			},
 			RuleWithNoUselessTernaryOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9906,7 +9906,7 @@ export function GET() {
 			},
 			RuleWithNoUselessThisAliasOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9925,7 +9925,7 @@ export function GET() {
 			},
 			RuleWithNoUselessTypeConstraintOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9944,7 +9944,7 @@ export function GET() {
 			},
 			RuleWithNoUselessUndefinedInitializationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9965,7 +9965,7 @@ export function GET() {
 			},
 			RuleWithNoUselessUndefinedOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9984,7 +9984,7 @@ export function GET() {
 			},
 			RuleWithNoValueAtRuleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9999,7 +9999,7 @@ export function GET() {
 			},
 			RuleWithNoVarOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10018,7 +10018,7 @@ export function GET() {
 			},
 			RuleWithNoVoidElementsWithChildrenOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10039,7 +10039,7 @@ export function GET() {
 			},
 			RuleWithNoVoidOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10054,7 +10054,7 @@ export function GET() {
 			},
 			RuleWithNoVoidTypeReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10069,7 +10069,7 @@ export function GET() {
 			},
 			RuleWithNoVueDataObjectDeclarationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10090,7 +10090,7 @@ export function GET() {
 			},
 			RuleWithNoVueDuplicateKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10105,7 +10105,7 @@ export function GET() {
 			},
 			RuleWithNoVueReservedKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10120,7 +10120,7 @@ export function GET() {
 			},
 			RuleWithNoVueReservedPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10135,7 +10135,7 @@ export function GET() {
 			},
 			RuleWithNoWithOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10150,7 +10150,7 @@ export function GET() {
 			},
 			RuleWithNoYodaExpressionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10169,7 +10169,7 @@ export function GET() {
 			},
 			RuleWithUseAdjacentOverloadSignaturesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10186,7 +10186,7 @@ export function GET() {
 			},
 			RuleWithUseAltTextOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10201,7 +10201,7 @@ export function GET() {
 			},
 			RuleWithUseAnchorContentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10220,7 +10220,7 @@ export function GET() {
 			},
 			RuleWithUseAnchorHrefOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10235,7 +10235,7 @@ export function GET() {
 			},
 			RuleWithUseAriaActivedescendantWithTabindexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10258,7 +10258,7 @@ export function GET() {
 			},
 			RuleWithUseAriaPropsForRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10273,7 +10273,7 @@ export function GET() {
 			},
 			RuleWithUseAriaPropsSupportedByRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10290,7 +10290,7 @@ export function GET() {
 			},
 			RuleWithUseArrayLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10309,7 +10309,7 @@ export function GET() {
 			},
 			RuleWithUseArrowFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10328,7 +10328,7 @@ export function GET() {
 			},
 			RuleWithUseAsConstAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10347,7 +10347,7 @@ export function GET() {
 			},
 			RuleWithUseAtIndexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10366,7 +10366,7 @@ export function GET() {
 			},
 			RuleWithUseAwaitOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10381,7 +10381,7 @@ export function GET() {
 			},
 			RuleWithUseBiomeIgnoreFolderOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10400,7 +10400,7 @@ export function GET() {
 			},
 			RuleWithUseBlockStatementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10419,7 +10419,7 @@ export function GET() {
 			},
 			RuleWithUseButtonTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10434,7 +10434,7 @@ export function GET() {
 			},
 			RuleWithUseCollapsedElseIfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10453,7 +10453,7 @@ export function GET() {
 			},
 			RuleWithUseCollapsedIfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10472,7 +10472,7 @@ export function GET() {
 			},
 			RuleWithUseComponentExportOnlyModulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10489,7 +10489,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentArrayTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10508,7 +10508,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentArrowReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10527,7 +10527,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentBuiltinInstantiationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10550,7 +10550,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentCurlyBracesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10569,7 +10569,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentMemberAccessibilityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10586,7 +10586,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentObjectDefinitionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10607,7 +10607,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentTypeDefinitionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10628,7 +10628,7 @@ export function GET() {
 			},
 			RuleWithUseConstOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10647,7 +10647,7 @@ export function GET() {
 			},
 			RuleWithUseDateNowOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10666,7 +10666,7 @@ export function GET() {
 			},
 			RuleWithUseDefaultParameterLastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10685,7 +10685,7 @@ export function GET() {
 			},
 			RuleWithUseDefaultSwitchClauseLastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10702,7 +10702,7 @@ export function GET() {
 			},
 			RuleWithUseDefaultSwitchClauseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10717,7 +10717,7 @@ export function GET() {
 			},
 			RuleWithUseDeprecatedDateOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10732,7 +10732,7 @@ export function GET() {
 			},
 			RuleWithUseDeprecatedReasonOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10747,7 +10747,7 @@ export function GET() {
 			},
 			RuleWithUseEnumInitializersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10766,7 +10766,7 @@ export function GET() {
 			},
 			RuleWithUseErrorMessageOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10781,7 +10781,7 @@ export function GET() {
 			},
 			RuleWithUseExhaustiveDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10800,7 +10800,7 @@ export function GET() {
 			},
 			RuleWithUseExhaustiveSwitchCasesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10819,7 +10819,7 @@ export function GET() {
 			},
 			RuleWithUseExplicitLengthCheckOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10838,7 +10838,7 @@ export function GET() {
 			},
 			RuleWithUseExplicitTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10853,7 +10853,7 @@ export function GET() {
 			},
 			RuleWithUseExponentiationOperatorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10872,7 +10872,7 @@ export function GET() {
 			},
 			RuleWithUseExportTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10891,7 +10891,7 @@ export function GET() {
 			},
 			RuleWithUseExportsLastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10906,7 +10906,7 @@ export function GET() {
 			},
 			RuleWithUseFilenamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10921,7 +10921,7 @@ export function GET() {
 			},
 			RuleWithUseFlatMapOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10940,7 +10940,7 @@ export function GET() {
 			},
 			RuleWithUseFocusableInteractiveOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10955,7 +10955,7 @@ export function GET() {
 			},
 			RuleWithUseForOfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10970,7 +10970,7 @@ export function GET() {
 			},
 			RuleWithUseFragmentSyntaxOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10989,7 +10989,7 @@ export function GET() {
 			},
 			RuleWithUseGenericFontNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11004,7 +11004,7 @@ export function GET() {
 			},
 			RuleWithUseGetterReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11019,7 +11019,7 @@ export function GET() {
 			},
 			RuleWithUseGoogleFontDisplayOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11034,7 +11034,7 @@ export function GET() {
 			},
 			RuleWithUseGoogleFontPreconnectOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11053,7 +11053,7 @@ export function GET() {
 			},
 			RuleWithUseGraphqlNamedOperationsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11072,7 +11072,7 @@ export function GET() {
 			},
 			RuleWithUseGraphqlNamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11089,7 +11089,7 @@ export function GET() {
 			},
 			RuleWithUseGroupedAccessorPairsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11104,7 +11104,7 @@ export function GET() {
 			},
 			RuleWithUseGuardForInOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11119,7 +11119,7 @@ export function GET() {
 			},
 			RuleWithUseHeadingContentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11134,7 +11134,7 @@ export function GET() {
 			},
 			RuleWithUseHookAtTopLevelOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11149,7 +11149,7 @@ export function GET() {
 			},
 			RuleWithUseHtmlLangOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11164,7 +11164,7 @@ export function GET() {
 			},
 			RuleWithUseIframeTitleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11179,7 +11179,7 @@ export function GET() {
 			},
 			RuleWithUseImageSizeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11194,7 +11194,7 @@ export function GET() {
 			},
 			RuleWithUseImportExtensionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11213,7 +11213,7 @@ export function GET() {
 			},
 			RuleWithUseImportTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11232,7 +11232,7 @@ export function GET() {
 			},
 			RuleWithUseIndexOfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11251,7 +11251,7 @@ export function GET() {
 			},
 			RuleWithUseIsArrayOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11270,7 +11270,7 @@ export function GET() {
 			},
 			RuleWithUseIsNanOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11289,7 +11289,7 @@ export function GET() {
 			},
 			RuleWithUseIterableCallbackReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11304,7 +11304,7 @@ export function GET() {
 			},
 			RuleWithUseJsonImportAttributesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11323,7 +11323,7 @@ export function GET() {
 			},
 			RuleWithUseJsxKeyInIterableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11338,7 +11338,7 @@ export function GET() {
 			},
 			RuleWithUseKeyWithClickEventsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11353,7 +11353,7 @@ export function GET() {
 			},
 			RuleWithUseKeyWithMouseEventsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11368,7 +11368,7 @@ export function GET() {
 			},
 			RuleWithUseLiteralEnumMembersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11383,7 +11383,7 @@ export function GET() {
 			},
 			RuleWithUseLiteralKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11402,7 +11402,7 @@ export function GET() {
 			},
 			RuleWithUseMaxParamsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11417,7 +11417,7 @@ export function GET() {
 			},
 			RuleWithUseMediaCaptionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11432,7 +11432,7 @@ export function GET() {
 			},
 			RuleWithUseNamespaceKeywordOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11451,7 +11451,7 @@ export function GET() {
 			},
 			RuleWithUseNamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11470,7 +11470,7 @@ export function GET() {
 			},
 			RuleWithUseNodeAssertStrictOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11489,7 +11489,7 @@ export function GET() {
 			},
 			RuleWithUseNodejsImportProtocolOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11508,7 +11508,7 @@ export function GET() {
 			},
 			RuleWithUseNumberNamespaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11527,7 +11527,7 @@ export function GET() {
 			},
 			RuleWithUseNumberToFixedDigitsArgumentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11548,7 +11548,7 @@ export function GET() {
 			},
 			RuleWithUseNumericLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11567,7 +11567,7 @@ export function GET() {
 			},
 			RuleWithUseNumericSeparatorsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11586,7 +11586,7 @@ export function GET() {
 			},
 			RuleWithUseObjectSpreadOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11605,7 +11605,7 @@ export function GET() {
 			},
 			RuleWithUseOptionalChainOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11624,7 +11624,7 @@ export function GET() {
 			},
 			RuleWithUseParseIntRadixOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11643,7 +11643,7 @@ export function GET() {
 			},
 			RuleWithUseQwikClasslistOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11658,7 +11658,7 @@ export function GET() {
 			},
 			RuleWithUseQwikMethodUsageOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11673,7 +11673,7 @@ export function GET() {
 			},
 			RuleWithUseQwikValidLexicalScopeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11688,7 +11688,7 @@ export function GET() {
 			},
 			RuleWithUseReactFunctionComponentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11705,7 +11705,7 @@ export function GET() {
 			},
 			RuleWithUseReadonlyClassPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11726,7 +11726,7 @@ export function GET() {
 			},
 			RuleWithUseRegexLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11745,7 +11745,7 @@ export function GET() {
 			},
 			RuleWithUseSelfClosingElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11764,7 +11764,7 @@ export function GET() {
 			},
 			RuleWithUseSemanticElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11779,7 +11779,7 @@ export function GET() {
 			},
 			RuleWithUseShorthandAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11798,7 +11798,7 @@ export function GET() {
 			},
 			RuleWithUseShorthandFunctionTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11817,7 +11817,7 @@ export function GET() {
 			},
 			RuleWithUseSimpleNumberKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11836,7 +11836,7 @@ export function GET() {
 			},
 			RuleWithUseSimplifiedLogicExpressionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11857,7 +11857,7 @@ export function GET() {
 			},
 			RuleWithUseSingleJsDocAsteriskOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11876,7 +11876,7 @@ export function GET() {
 			},
 			RuleWithUseSingleVarDeclaratorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11895,7 +11895,7 @@ export function GET() {
 			},
 			RuleWithUseSolidForComponentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11910,7 +11910,7 @@ export function GET() {
 			},
 			RuleWithUseSortedClassesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11929,7 +11929,7 @@ export function GET() {
 			},
 			RuleWithUseStaticResponseMethodsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11948,7 +11948,7 @@ export function GET() {
 			},
 			RuleWithUseStrictModeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11967,7 +11967,7 @@ export function GET() {
 			},
 			RuleWithUseSymbolDescriptionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11982,7 +11982,7 @@ export function GET() {
 			},
 			RuleWithUseTemplateOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12001,7 +12001,7 @@ export function GET() {
 			},
 			RuleWithUseThrowNewErrorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12020,7 +12020,7 @@ export function GET() {
 			},
 			RuleWithUseThrowOnlyErrorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12035,7 +12035,7 @@ export function GET() {
 			},
 			RuleWithUseTopLevelRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12050,7 +12050,7 @@ export function GET() {
 			},
 			RuleWithUseTrimStartEndOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12069,7 +12069,7 @@ export function GET() {
 			},
 			RuleWithUseUnifiedTypeSignaturesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12088,7 +12088,7 @@ export function GET() {
 			},
 			RuleWithUseUniqueElementIdsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12103,7 +12103,7 @@ export function GET() {
 			},
 			RuleWithUseValidAnchorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12118,7 +12118,7 @@ export function GET() {
 			},
 			RuleWithUseValidAriaPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12137,7 +12137,7 @@ export function GET() {
 			},
 			RuleWithUseValidAriaRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12156,7 +12156,7 @@ export function GET() {
 			},
 			RuleWithUseValidAriaValuesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12171,7 +12171,7 @@ export function GET() {
 			},
 			RuleWithUseValidAutocompleteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12186,7 +12186,7 @@ export function GET() {
 			},
 			RuleWithUseValidForDirectionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12201,7 +12201,7 @@ export function GET() {
 			},
 			RuleWithUseValidLangOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12216,7 +12216,7 @@ export function GET() {
 			},
 			RuleWithUseValidTypeofOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12235,7 +12235,7 @@ export function GET() {
 			},
 			RuleWithUseVueMultiWordComponentNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12252,7 +12252,7 @@ export function GET() {
 			},
 			RuleWithUseWhileOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12271,7 +12271,7 @@ export function GET() {
 			},
 			RuleWithUseYieldOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",

--- a/src/pages/schemas/2.3.0/schema.json.js
+++ b/src/pages/schemas/2.3.0/schema.json.js
@@ -5978,7 +5978,7 @@ export function GET() {
 			RuleAssistPlainConfiguration: { type: "string", enum: ["off", "on"] },
 			RuleAssistWithOptions_for_OrganizeImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5993,7 +5993,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_UseSortedAttributesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6008,7 +6008,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_UseSortedKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6023,7 +6023,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_UseSortedPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6133,7 +6133,7 @@ export function GET() {
 			},
 			RuleWithNoAccessKeyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6152,7 +6152,7 @@ export function GET() {
 			},
 			RuleWithNoAccumulatingSpreadOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6167,7 +6167,7 @@ export function GET() {
 			},
 			RuleWithNoAdjacentSpacesInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6186,7 +6186,7 @@ export function GET() {
 			},
 			RuleWithNoAlertOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6201,7 +6201,7 @@ export function GET() {
 			},
 			RuleWithNoApproximativeNumericConstantOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6222,7 +6222,7 @@ export function GET() {
 			},
 			RuleWithNoArgumentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6237,7 +6237,7 @@ export function GET() {
 			},
 			RuleWithNoAriaHiddenOnFocusableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6256,7 +6256,7 @@ export function GET() {
 			},
 			RuleWithNoAriaUnsupportedElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6275,7 +6275,7 @@ export function GET() {
 			},
 			RuleWithNoArrayIndexKeyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6290,7 +6290,7 @@ export function GET() {
 			},
 			RuleWithNoAssignInExpressionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6305,7 +6305,7 @@ export function GET() {
 			},
 			RuleWithNoAsyncPromiseExecutorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6320,7 +6320,7 @@ export function GET() {
 			},
 			RuleWithNoAutofocusOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6339,7 +6339,7 @@ export function GET() {
 			},
 			RuleWithNoAwaitInLoopsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6354,7 +6354,7 @@ export function GET() {
 			},
 			RuleWithNoBannedTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6373,7 +6373,7 @@ export function GET() {
 			},
 			RuleWithNoBarrelFileOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6388,7 +6388,7 @@ export function GET() {
 			},
 			RuleWithNoBiomeFirstExceptionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6407,7 +6407,7 @@ export function GET() {
 			},
 			RuleWithNoBitwiseOperatorsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6422,7 +6422,7 @@ export function GET() {
 			},
 			RuleWithNoBlankTargetOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6441,7 +6441,7 @@ export function GET() {
 			},
 			RuleWithNoCatchAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6456,7 +6456,7 @@ export function GET() {
 			},
 			RuleWithNoChildrenPropOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6471,7 +6471,7 @@ export function GET() {
 			},
 			RuleWithNoClassAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6486,7 +6486,7 @@ export function GET() {
 			},
 			RuleWithNoCommaOperatorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6501,7 +6501,7 @@ export function GET() {
 			},
 			RuleWithNoCommentTextOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6520,7 +6520,7 @@ export function GET() {
 			},
 			RuleWithNoCommonJsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6535,7 +6535,7 @@ export function GET() {
 			},
 			RuleWithNoCompareNegZeroOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6554,7 +6554,7 @@ export function GET() {
 			},
 			RuleWithNoConfusingLabelsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6569,7 +6569,7 @@ export function GET() {
 			},
 			RuleWithNoConfusingVoidTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6588,7 +6588,7 @@ export function GET() {
 			},
 			RuleWithNoConsoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6607,7 +6607,7 @@ export function GET() {
 			},
 			RuleWithNoConstAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6626,7 +6626,7 @@ export function GET() {
 			},
 			RuleWithNoConstEnumOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6645,7 +6645,7 @@ export function GET() {
 			},
 			RuleWithNoConstantBinaryExpressionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6662,7 +6662,7 @@ export function GET() {
 			},
 			RuleWithNoConstantConditionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6677,7 +6677,7 @@ export function GET() {
 			},
 			RuleWithNoConstantMathMinMaxClampOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6696,7 +6696,7 @@ export function GET() {
 			},
 			RuleWithNoConstructorReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6711,7 +6711,7 @@ export function GET() {
 			},
 			RuleWithNoControlCharactersInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6728,7 +6728,7 @@ export function GET() {
 			},
 			RuleWithNoDangerouslySetInnerHtmlOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6743,7 +6743,7 @@ export function GET() {
 			},
 			RuleWithNoDangerouslySetInnerHtmlWithChildrenOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6762,7 +6762,7 @@ export function GET() {
 			},
 			RuleWithNoDebuggerOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6781,7 +6781,7 @@ export function GET() {
 			},
 			RuleWithNoDefaultExportOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6796,7 +6796,7 @@ export function GET() {
 			},
 			RuleWithNoDeleteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6815,7 +6815,7 @@ export function GET() {
 			},
 			RuleWithNoDeprecatedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6830,7 +6830,7 @@ export function GET() {
 			},
 			RuleWithNoDescendingSpecificityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6845,7 +6845,7 @@ export function GET() {
 			},
 			RuleWithNoDistractingElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6864,7 +6864,7 @@ export function GET() {
 			},
 			RuleWithNoDocumentCookieOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6879,7 +6879,7 @@ export function GET() {
 			},
 			RuleWithNoDocumentImportInPageOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6894,7 +6894,7 @@ export function GET() {
 			},
 			RuleWithNoDoneCallbackOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6909,7 +6909,7 @@ export function GET() {
 			},
 			RuleWithNoDoubleEqualsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6928,7 +6928,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateAtImportRulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6943,7 +6943,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateCaseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6958,7 +6958,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateClassMembersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6973,7 +6973,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateCustomPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6990,7 +6990,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7005,7 +7005,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateElseIfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7020,7 +7020,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateFieldsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7035,7 +7035,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateFontNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7050,7 +7050,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateJsxPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7065,7 +7065,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateObjectKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7080,7 +7080,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateParametersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7095,7 +7095,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicatePropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7110,7 +7110,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateSelectorsKeyframeBlockOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7129,7 +7129,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateTestHooksOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7144,7 +7144,7 @@ export function GET() {
 			},
 			RuleWithNoDynamicNamespaceImportAccessOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7161,7 +7161,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyBlockOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7176,7 +7176,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyBlockStatementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7191,7 +7191,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyCharacterClassInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7208,7 +7208,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyInterfaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7227,7 +7227,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyPatternOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7242,7 +7242,7 @@ export function GET() {
 			},
 			RuleWithNoEmptySourceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7257,7 +7257,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyTypeParametersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7272,7 +7272,7 @@ export function GET() {
 			},
 			RuleWithNoEnumOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7287,7 +7287,7 @@ export function GET() {
 			},
 			RuleWithNoEvolvingTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7302,7 +7302,7 @@ export function GET() {
 			},
 			RuleWithNoExcessiveCognitiveComplexityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7319,7 +7319,7 @@ export function GET() {
 			},
 			RuleWithNoExcessiveLinesPerFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7336,7 +7336,7 @@ export function GET() {
 			},
 			RuleWithNoExcessiveNestedTestSuitesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7353,7 +7353,7 @@ export function GET() {
 			},
 			RuleWithNoExplicitAnyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7368,7 +7368,7 @@ export function GET() {
 			},
 			RuleWithNoExportedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7383,7 +7383,7 @@ export function GET() {
 			},
 			RuleWithNoExportsInTestOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7398,7 +7398,7 @@ export function GET() {
 			},
 			RuleWithNoExtraBooleanCastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7417,7 +7417,7 @@ export function GET() {
 			},
 			RuleWithNoExtraNonNullAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7436,7 +7436,7 @@ export function GET() {
 			},
 			RuleWithNoFallthroughSwitchClauseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7451,7 +7451,7 @@ export function GET() {
 			},
 			RuleWithNoFlatMapIdentityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7470,7 +7470,7 @@ export function GET() {
 			},
 			RuleWithNoFloatingPromisesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7489,7 +7489,7 @@ export function GET() {
 			},
 			RuleWithNoFocusedTestsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7508,7 +7508,7 @@ export function GET() {
 			},
 			RuleWithNoForEachOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7523,7 +7523,7 @@ export function GET() {
 			},
 			RuleWithNoFunctionAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7538,7 +7538,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7553,7 +7553,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalDirnameFilenameOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7572,7 +7572,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalEvalOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7587,7 +7587,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalIsFiniteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7606,7 +7606,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalIsNanOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7625,7 +7625,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalObjectCallsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7640,7 +7640,7 @@ export function GET() {
 			},
 			RuleWithNoHeadElementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7655,7 +7655,7 @@ export function GET() {
 			},
 			RuleWithNoHeadImportInDocumentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7670,7 +7670,7 @@ export function GET() {
 			},
 			RuleWithNoHeaderScopeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7689,7 +7689,7 @@ export function GET() {
 			},
 			RuleWithNoImgElementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7704,7 +7704,7 @@ export function GET() {
 			},
 			RuleWithNoImplicitAnyLetOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7719,7 +7719,7 @@ export function GET() {
 			},
 			RuleWithNoImplicitBooleanOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7738,7 +7738,7 @@ export function GET() {
 			},
 			RuleWithNoImplicitCoercionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7757,7 +7757,7 @@ export function GET() {
 			},
 			RuleWithNoImportAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7772,7 +7772,7 @@ export function GET() {
 			},
 			RuleWithNoImportCyclesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7787,7 +7787,7 @@ export function GET() {
 			},
 			RuleWithNoImportantInKeyframeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7802,7 +7802,7 @@ export function GET() {
 			},
 			RuleWithNoImportantStylesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7821,7 +7821,7 @@ export function GET() {
 			},
 			RuleWithNoInferrableTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7840,7 +7840,7 @@ export function GET() {
 			},
 			RuleWithNoInnerDeclarationsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7855,7 +7855,7 @@ export function GET() {
 			},
 			RuleWithNoInteractiveElementToNoninteractiveRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7878,7 +7878,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidBuiltinInstantiationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7899,7 +7899,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidConstructorSuperOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7914,7 +7914,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidDirectionInLinearGradientOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7933,7 +7933,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidGridAreasOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7948,7 +7948,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidPositionAtImportRuleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7965,7 +7965,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidUseBeforeDeclarationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7982,7 +7982,7 @@ export function GET() {
 			},
 			RuleWithNoIrregularWhitespaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7997,7 +7997,7 @@ export function GET() {
 			},
 			RuleWithNoJsxLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8012,7 +8012,7 @@ export function GET() {
 			},
 			RuleWithNoLabelVarOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8027,7 +8027,7 @@ export function GET() {
 			},
 			RuleWithNoLabelWithoutControlOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8042,7 +8042,7 @@ export function GET() {
 			},
 			RuleWithNoMagicNumbersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8057,7 +8057,7 @@ export function GET() {
 			},
 			RuleWithNoMisleadingCharacterClassOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8078,7 +8078,7 @@ export function GET() {
 			},
 			RuleWithNoMisleadingInstantiatorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8093,7 +8093,7 @@ export function GET() {
 			},
 			RuleWithNoMisplacedAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8108,7 +8108,7 @@ export function GET() {
 			},
 			RuleWithNoMisrefactoredShorthandAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8129,7 +8129,7 @@ export function GET() {
 			},
 			RuleWithNoMissingVarFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8144,7 +8144,7 @@ export function GET() {
 			},
 			RuleWithNoMisusedPromisesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8163,7 +8163,7 @@ export function GET() {
 			},
 			RuleWithNoNamespaceImportOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8178,7 +8178,7 @@ export function GET() {
 			},
 			RuleWithNoNamespaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8193,7 +8193,7 @@ export function GET() {
 			},
 			RuleWithNoNegationElseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8212,7 +8212,7 @@ export function GET() {
 			},
 			RuleWithNoNestedComponentDefinitionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8229,7 +8229,7 @@ export function GET() {
 			},
 			RuleWithNoNestedTernaryOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8244,7 +8244,7 @@ export function GET() {
 			},
 			RuleWithNoNextAsyncClientComponentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8261,7 +8261,7 @@ export function GET() {
 			},
 			RuleWithNoNodejsModulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8276,7 +8276,7 @@ export function GET() {
 			},
 			RuleWithNoNonNullAssertedOptionalChainOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8293,7 +8293,7 @@ export function GET() {
 			},
 			RuleWithNoNonNullAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8312,7 +8312,7 @@ export function GET() {
 			},
 			RuleWithNoNoninteractiveElementInteractionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8331,7 +8331,7 @@ export function GET() {
 			},
 			RuleWithNoNoninteractiveElementToInteractiveRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8354,7 +8354,7 @@ export function GET() {
 			},
 			RuleWithNoNoninteractiveTabindexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8373,7 +8373,7 @@ export function GET() {
 			},
 			RuleWithNoNonoctalDecimalEscapeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8392,7 +8392,7 @@ export function GET() {
 			},
 			RuleWithNoOctalEscapeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8411,7 +8411,7 @@ export function GET() {
 			},
 			RuleWithNoParameterAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8426,7 +8426,7 @@ export function GET() {
 			},
 			RuleWithNoParameterPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8441,7 +8441,7 @@ export function GET() {
 			},
 			RuleWithNoPositiveTabindexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8460,7 +8460,7 @@ export function GET() {
 			},
 			RuleWithNoPrecisionLossOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8475,7 +8475,7 @@ export function GET() {
 			},
 			RuleWithNoPrivateImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8490,7 +8490,7 @@ export function GET() {
 			},
 			RuleWithNoProcessEnvOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8505,7 +8505,7 @@ export function GET() {
 			},
 			RuleWithNoProcessGlobalOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8524,7 +8524,7 @@ export function GET() {
 			},
 			RuleWithNoPrototypeBuiltinsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8543,7 +8543,7 @@ export function GET() {
 			},
 			RuleWithNoQuickfixBiomeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8562,7 +8562,7 @@ export function GET() {
 			},
 			RuleWithNoQwikUseVisibleTaskOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8577,7 +8577,7 @@ export function GET() {
 			},
 			RuleWithNoReExportAllOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8592,7 +8592,7 @@ export function GET() {
 			},
 			RuleWithNoReactForwardRefOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8611,7 +8611,7 @@ export function GET() {
 			},
 			RuleWithNoReactPropAssignmentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8626,7 +8626,7 @@ export function GET() {
 			},
 			RuleWithNoReactSpecificPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8645,7 +8645,7 @@ export function GET() {
 			},
 			RuleWithNoRedeclareOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8660,7 +8660,7 @@ export function GET() {
 			},
 			RuleWithNoRedundantAltOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8675,7 +8675,7 @@ export function GET() {
 			},
 			RuleWithNoRedundantRolesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8694,7 +8694,7 @@ export function GET() {
 			},
 			RuleWithNoRedundantUseStrictOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8713,7 +8713,7 @@ export function GET() {
 			},
 			RuleWithNoRenderReturnValueOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8728,7 +8728,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8743,7 +8743,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedGlobalsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8758,7 +8758,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8773,7 +8773,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8792,7 +8792,7 @@ export function GET() {
 			},
 			RuleWithNoSecretsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8807,7 +8807,7 @@ export function GET() {
 			},
 			RuleWithNoSelfAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8822,7 +8822,7 @@ export function GET() {
 			},
 			RuleWithNoSelfCompareOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8837,7 +8837,7 @@ export function GET() {
 			},
 			RuleWithNoSetterReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8852,7 +8852,7 @@ export function GET() {
 			},
 			RuleWithNoShadowOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8867,7 +8867,7 @@ export function GET() {
 			},
 			RuleWithNoShadowRestrictedNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8882,7 +8882,7 @@ export function GET() {
 			},
 			RuleWithNoShorthandPropertyOverridesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8899,7 +8899,7 @@ export function GET() {
 			},
 			RuleWithNoShoutyConstantsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8918,7 +8918,7 @@ export function GET() {
 			},
 			RuleWithNoSkippedTestsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8937,7 +8937,7 @@ export function GET() {
 			},
 			RuleWithNoSolidDestructuredPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8952,7 +8952,7 @@ export function GET() {
 			},
 			RuleWithNoSparseArrayOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8971,7 +8971,7 @@ export function GET() {
 			},
 			RuleWithNoStaticElementInteractionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8988,7 +8988,7 @@ export function GET() {
 			},
 			RuleWithNoStaticOnlyClassOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9003,7 +9003,7 @@ export function GET() {
 			},
 			RuleWithNoStringCaseMismatchOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9022,7 +9022,7 @@ export function GET() {
 			},
 			RuleWithNoSubstrOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9041,7 +9041,7 @@ export function GET() {
 			},
 			RuleWithNoSuspiciousSemicolonInJsxOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9058,7 +9058,7 @@ export function GET() {
 			},
 			RuleWithNoSvgWithoutTitleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9073,7 +9073,7 @@ export function GET() {
 			},
 			RuleWithNoSwitchDeclarationsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9092,7 +9092,7 @@ export function GET() {
 			},
 			RuleWithNoTemplateCurlyInStringOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9107,7 +9107,7 @@ export function GET() {
 			},
 			RuleWithNoThenPropertyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9122,7 +9122,7 @@ export function GET() {
 			},
 			RuleWithNoThisInStaticOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9141,7 +9141,7 @@ export function GET() {
 			},
 			RuleWithNoTsIgnoreOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9160,7 +9160,7 @@ export function GET() {
 			},
 			RuleWithNoUnassignedVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9175,7 +9175,7 @@ export function GET() {
 			},
 			RuleWithNoUndeclaredDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9190,7 +9190,7 @@ export function GET() {
 			},
 			RuleWithNoUndeclaredVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9205,7 +9205,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownAtRulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9220,7 +9220,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9235,7 +9235,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownMediaFeatureNameOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9250,7 +9250,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownPropertyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9265,7 +9265,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownPseudoClassOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9280,7 +9280,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownPseudoElementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9295,7 +9295,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownTypeSelectorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9310,7 +9310,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownUnitOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9325,7 +9325,7 @@ export function GET() {
 			},
 			RuleWithNoUnmatchableAnbSelectorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9340,7 +9340,7 @@ export function GET() {
 			},
 			RuleWithNoUnnecessaryConditionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9355,7 +9355,7 @@ export function GET() {
 			},
 			RuleWithNoUnreachableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9370,7 +9370,7 @@ export function GET() {
 			},
 			RuleWithNoUnreachableSuperOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9385,7 +9385,7 @@ export function GET() {
 			},
 			RuleWithNoUnresolvedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9400,7 +9400,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeDeclarationMergingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9417,7 +9417,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeFinallyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9432,7 +9432,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeNegationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9451,7 +9451,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeOptionalChainingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9466,7 +9466,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedExpressionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9481,7 +9481,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedFunctionParametersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9502,7 +9502,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9521,7 +9521,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedLabelsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9540,7 +9540,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedPrivateClassMembersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9561,7 +9561,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedTemplateLiteralOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9580,7 +9580,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9599,7 +9599,7 @@ export function GET() {
 			},
 			RuleWithNoUnwantedPolyfillioOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9614,7 +9614,7 @@ export function GET() {
 			},
 			RuleWithNoUselessCatchBindingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9633,7 +9633,7 @@ export function GET() {
 			},
 			RuleWithNoUselessCatchOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9652,7 +9652,7 @@ export function GET() {
 			},
 			RuleWithNoUselessConstructorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9671,7 +9671,7 @@ export function GET() {
 			},
 			RuleWithNoUselessContinueOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9690,7 +9690,7 @@ export function GET() {
 			},
 			RuleWithNoUselessElseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9709,7 +9709,7 @@ export function GET() {
 			},
 			RuleWithNoUselessEmptyExportOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9728,7 +9728,7 @@ export function GET() {
 			},
 			RuleWithNoUselessEscapeInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9747,7 +9747,7 @@ export function GET() {
 			},
 			RuleWithNoUselessEscapeInStringOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9766,7 +9766,7 @@ export function GET() {
 			},
 			RuleWithNoUselessFragmentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9785,7 +9785,7 @@ export function GET() {
 			},
 			RuleWithNoUselessLabelOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9804,7 +9804,7 @@ export function GET() {
 			},
 			RuleWithNoUselessLoneBlockStatementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9825,7 +9825,7 @@ export function GET() {
 			},
 			RuleWithNoUselessRegexBackrefsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9840,7 +9840,7 @@ export function GET() {
 			},
 			RuleWithNoUselessRenameOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9859,7 +9859,7 @@ export function GET() {
 			},
 			RuleWithNoUselessStringConcatOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9878,7 +9878,7 @@ export function GET() {
 			},
 			RuleWithNoUselessStringRawOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9893,7 +9893,7 @@ export function GET() {
 			},
 			RuleWithNoUselessSwitchCaseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9912,7 +9912,7 @@ export function GET() {
 			},
 			RuleWithNoUselessTernaryOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9931,7 +9931,7 @@ export function GET() {
 			},
 			RuleWithNoUselessThisAliasOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9950,7 +9950,7 @@ export function GET() {
 			},
 			RuleWithNoUselessTypeConstraintOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9969,7 +9969,7 @@ export function GET() {
 			},
 			RuleWithNoUselessUndefinedInitializationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9990,7 +9990,7 @@ export function GET() {
 			},
 			RuleWithNoUselessUndefinedOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10009,7 +10009,7 @@ export function GET() {
 			},
 			RuleWithNoValueAtRuleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10024,7 +10024,7 @@ export function GET() {
 			},
 			RuleWithNoVarOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10043,7 +10043,7 @@ export function GET() {
 			},
 			RuleWithNoVoidElementsWithChildrenOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10064,7 +10064,7 @@ export function GET() {
 			},
 			RuleWithNoVoidOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10079,7 +10079,7 @@ export function GET() {
 			},
 			RuleWithNoVoidTypeReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10094,7 +10094,7 @@ export function GET() {
 			},
 			RuleWithNoVueDataObjectDeclarationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10115,7 +10115,7 @@ export function GET() {
 			},
 			RuleWithNoVueDuplicateKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10130,7 +10130,7 @@ export function GET() {
 			},
 			RuleWithNoVueReservedKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10145,7 +10145,7 @@ export function GET() {
 			},
 			RuleWithNoVueReservedPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10160,7 +10160,7 @@ export function GET() {
 			},
 			RuleWithNoWithOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10175,7 +10175,7 @@ export function GET() {
 			},
 			RuleWithNoYodaExpressionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10194,7 +10194,7 @@ export function GET() {
 			},
 			RuleWithUseAdjacentOverloadSignaturesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10211,7 +10211,7 @@ export function GET() {
 			},
 			RuleWithUseAltTextOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10226,7 +10226,7 @@ export function GET() {
 			},
 			RuleWithUseAnchorContentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10245,7 +10245,7 @@ export function GET() {
 			},
 			RuleWithUseAriaActivedescendantWithTabindexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10268,7 +10268,7 @@ export function GET() {
 			},
 			RuleWithUseAriaPropsForRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10283,7 +10283,7 @@ export function GET() {
 			},
 			RuleWithUseAriaPropsSupportedByRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10300,7 +10300,7 @@ export function GET() {
 			},
 			RuleWithUseArrayLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10319,7 +10319,7 @@ export function GET() {
 			},
 			RuleWithUseArrowFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10338,7 +10338,7 @@ export function GET() {
 			},
 			RuleWithUseAsConstAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10357,7 +10357,7 @@ export function GET() {
 			},
 			RuleWithUseAtIndexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10376,7 +10376,7 @@ export function GET() {
 			},
 			RuleWithUseAwaitOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10391,7 +10391,7 @@ export function GET() {
 			},
 			RuleWithUseBiomeIgnoreFolderOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10410,7 +10410,7 @@ export function GET() {
 			},
 			RuleWithUseBlockStatementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10429,7 +10429,7 @@ export function GET() {
 			},
 			RuleWithUseButtonTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10444,7 +10444,7 @@ export function GET() {
 			},
 			RuleWithUseCollapsedElseIfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10463,7 +10463,7 @@ export function GET() {
 			},
 			RuleWithUseCollapsedIfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10482,7 +10482,7 @@ export function GET() {
 			},
 			RuleWithUseComponentExportOnlyModulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10499,7 +10499,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentArrayTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10518,7 +10518,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentArrowReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10537,7 +10537,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentBuiltinInstantiationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10560,7 +10560,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentCurlyBracesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10579,7 +10579,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentMemberAccessibilityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10596,7 +10596,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentObjectDefinitionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10617,7 +10617,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentTypeDefinitionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10638,7 +10638,7 @@ export function GET() {
 			},
 			RuleWithUseConstOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10657,7 +10657,7 @@ export function GET() {
 			},
 			RuleWithUseDateNowOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10676,7 +10676,7 @@ export function GET() {
 			},
 			RuleWithUseDefaultParameterLastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10695,7 +10695,7 @@ export function GET() {
 			},
 			RuleWithUseDefaultSwitchClauseLastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10712,7 +10712,7 @@ export function GET() {
 			},
 			RuleWithUseDefaultSwitchClauseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10727,7 +10727,7 @@ export function GET() {
 			},
 			RuleWithUseDeprecatedDateOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10742,7 +10742,7 @@ export function GET() {
 			},
 			RuleWithUseDeprecatedReasonOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10757,7 +10757,7 @@ export function GET() {
 			},
 			RuleWithUseEnumInitializersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10776,7 +10776,7 @@ export function GET() {
 			},
 			RuleWithUseErrorMessageOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10791,7 +10791,7 @@ export function GET() {
 			},
 			RuleWithUseExhaustiveDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10810,7 +10810,7 @@ export function GET() {
 			},
 			RuleWithUseExhaustiveSwitchCasesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10829,7 +10829,7 @@ export function GET() {
 			},
 			RuleWithUseExplicitLengthCheckOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10848,7 +10848,7 @@ export function GET() {
 			},
 			RuleWithUseExplicitTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10863,7 +10863,7 @@ export function GET() {
 			},
 			RuleWithUseExponentiationOperatorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10882,7 +10882,7 @@ export function GET() {
 			},
 			RuleWithUseExportTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10901,7 +10901,7 @@ export function GET() {
 			},
 			RuleWithUseExportsLastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10916,7 +10916,7 @@ export function GET() {
 			},
 			RuleWithUseFilenamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10931,7 +10931,7 @@ export function GET() {
 			},
 			RuleWithUseFlatMapOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10950,7 +10950,7 @@ export function GET() {
 			},
 			RuleWithUseFocusableInteractiveOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10965,7 +10965,7 @@ export function GET() {
 			},
 			RuleWithUseForOfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10980,7 +10980,7 @@ export function GET() {
 			},
 			RuleWithUseFragmentSyntaxOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10999,7 +10999,7 @@ export function GET() {
 			},
 			RuleWithUseGenericFontNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11014,7 +11014,7 @@ export function GET() {
 			},
 			RuleWithUseGetterReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11029,7 +11029,7 @@ export function GET() {
 			},
 			RuleWithUseGoogleFontDisplayOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11044,7 +11044,7 @@ export function GET() {
 			},
 			RuleWithUseGoogleFontPreconnectOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11063,7 +11063,7 @@ export function GET() {
 			},
 			RuleWithUseGraphqlNamedOperationsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11082,7 +11082,7 @@ export function GET() {
 			},
 			RuleWithUseGraphqlNamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11099,7 +11099,7 @@ export function GET() {
 			},
 			RuleWithUseGroupedAccessorPairsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11114,7 +11114,7 @@ export function GET() {
 			},
 			RuleWithUseGuardForInOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11129,7 +11129,7 @@ export function GET() {
 			},
 			RuleWithUseHeadingContentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11144,7 +11144,7 @@ export function GET() {
 			},
 			RuleWithUseHookAtTopLevelOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11159,7 +11159,7 @@ export function GET() {
 			},
 			RuleWithUseHtmlLangOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11174,7 +11174,7 @@ export function GET() {
 			},
 			RuleWithUseIframeTitleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11189,7 +11189,7 @@ export function GET() {
 			},
 			RuleWithUseImageSizeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11204,7 +11204,7 @@ export function GET() {
 			},
 			RuleWithUseImportExtensionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11223,7 +11223,7 @@ export function GET() {
 			},
 			RuleWithUseImportTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11242,7 +11242,7 @@ export function GET() {
 			},
 			RuleWithUseIndexOfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11261,7 +11261,7 @@ export function GET() {
 			},
 			RuleWithUseIsArrayOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11280,7 +11280,7 @@ export function GET() {
 			},
 			RuleWithUseIsNanOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11299,7 +11299,7 @@ export function GET() {
 			},
 			RuleWithUseIterableCallbackReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11314,7 +11314,7 @@ export function GET() {
 			},
 			RuleWithUseJsonImportAttributesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11333,7 +11333,7 @@ export function GET() {
 			},
 			RuleWithUseJsxKeyInIterableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11348,7 +11348,7 @@ export function GET() {
 			},
 			RuleWithUseKeyWithClickEventsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11363,7 +11363,7 @@ export function GET() {
 			},
 			RuleWithUseKeyWithMouseEventsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11378,7 +11378,7 @@ export function GET() {
 			},
 			RuleWithUseLiteralEnumMembersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11393,7 +11393,7 @@ export function GET() {
 			},
 			RuleWithUseLiteralKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11412,7 +11412,7 @@ export function GET() {
 			},
 			RuleWithUseMaxParamsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11427,7 +11427,7 @@ export function GET() {
 			},
 			RuleWithUseMediaCaptionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11442,7 +11442,7 @@ export function GET() {
 			},
 			RuleWithUseNamespaceKeywordOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11461,7 +11461,7 @@ export function GET() {
 			},
 			RuleWithUseNamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11480,7 +11480,7 @@ export function GET() {
 			},
 			RuleWithUseNodeAssertStrictOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11499,7 +11499,7 @@ export function GET() {
 			},
 			RuleWithUseNodejsImportProtocolOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11518,7 +11518,7 @@ export function GET() {
 			},
 			RuleWithUseNumberNamespaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11537,7 +11537,7 @@ export function GET() {
 			},
 			RuleWithUseNumberToFixedDigitsArgumentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11558,7 +11558,7 @@ export function GET() {
 			},
 			RuleWithUseNumericLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11577,7 +11577,7 @@ export function GET() {
 			},
 			RuleWithUseNumericSeparatorsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11596,7 +11596,7 @@ export function GET() {
 			},
 			RuleWithUseObjectSpreadOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11615,7 +11615,7 @@ export function GET() {
 			},
 			RuleWithUseOptionalChainOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11634,7 +11634,7 @@ export function GET() {
 			},
 			RuleWithUseParseIntRadixOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11653,7 +11653,7 @@ export function GET() {
 			},
 			RuleWithUseQwikClasslistOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11668,7 +11668,7 @@ export function GET() {
 			},
 			RuleWithUseQwikMethodUsageOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11683,7 +11683,7 @@ export function GET() {
 			},
 			RuleWithUseQwikValidLexicalScopeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11698,7 +11698,7 @@ export function GET() {
 			},
 			RuleWithUseReactFunctionComponentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11715,7 +11715,7 @@ export function GET() {
 			},
 			RuleWithUseReadonlyClassPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11736,7 +11736,7 @@ export function GET() {
 			},
 			RuleWithUseRegexLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11755,7 +11755,7 @@ export function GET() {
 			},
 			RuleWithUseSelfClosingElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11774,7 +11774,7 @@ export function GET() {
 			},
 			RuleWithUseSemanticElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11789,7 +11789,7 @@ export function GET() {
 			},
 			RuleWithUseShorthandAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11808,7 +11808,7 @@ export function GET() {
 			},
 			RuleWithUseShorthandFunctionTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11827,7 +11827,7 @@ export function GET() {
 			},
 			RuleWithUseSimpleNumberKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11846,7 +11846,7 @@ export function GET() {
 			},
 			RuleWithUseSimplifiedLogicExpressionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11867,7 +11867,7 @@ export function GET() {
 			},
 			RuleWithUseSingleJsDocAsteriskOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11886,7 +11886,7 @@ export function GET() {
 			},
 			RuleWithUseSingleVarDeclaratorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11905,7 +11905,7 @@ export function GET() {
 			},
 			RuleWithUseSolidForComponentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11920,7 +11920,7 @@ export function GET() {
 			},
 			RuleWithUseSortedClassesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11939,7 +11939,7 @@ export function GET() {
 			},
 			RuleWithUseStaticResponseMethodsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11958,7 +11958,7 @@ export function GET() {
 			},
 			RuleWithUseStrictModeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11977,7 +11977,7 @@ export function GET() {
 			},
 			RuleWithUseSymbolDescriptionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11992,7 +11992,7 @@ export function GET() {
 			},
 			RuleWithUseTemplateOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12011,7 +12011,7 @@ export function GET() {
 			},
 			RuleWithUseThrowNewErrorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12030,7 +12030,7 @@ export function GET() {
 			},
 			RuleWithUseThrowOnlyErrorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12045,7 +12045,7 @@ export function GET() {
 			},
 			RuleWithUseTopLevelRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12060,7 +12060,7 @@ export function GET() {
 			},
 			RuleWithUseTrimStartEndOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12079,7 +12079,7 @@ export function GET() {
 			},
 			RuleWithUseUnifiedTypeSignaturesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12098,7 +12098,7 @@ export function GET() {
 			},
 			RuleWithUseUniqueElementIdsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12113,7 +12113,7 @@ export function GET() {
 			},
 			RuleWithUseValidAnchorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12128,7 +12128,7 @@ export function GET() {
 			},
 			RuleWithUseValidAriaPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12147,7 +12147,7 @@ export function GET() {
 			},
 			RuleWithUseValidAriaRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12166,7 +12166,7 @@ export function GET() {
 			},
 			RuleWithUseValidAriaValuesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12181,7 +12181,7 @@ export function GET() {
 			},
 			RuleWithUseValidAutocompleteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12196,7 +12196,7 @@ export function GET() {
 			},
 			RuleWithUseValidForDirectionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12211,7 +12211,7 @@ export function GET() {
 			},
 			RuleWithUseValidLangOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12226,7 +12226,7 @@ export function GET() {
 			},
 			RuleWithUseValidTypeofOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12245,7 +12245,7 @@ export function GET() {
 			},
 			RuleWithUseVueDefineMacrosOrderOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12264,7 +12264,7 @@ export function GET() {
 			},
 			RuleWithUseVueMultiWordComponentNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12281,7 +12281,7 @@ export function GET() {
 			},
 			RuleWithUseWhileOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12300,7 +12300,7 @@ export function GET() {
 			},
 			RuleWithUseYieldOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",

--- a/src/pages/schemas/2.3.1/schema.json.js
+++ b/src/pages/schemas/2.3.1/schema.json.js
@@ -5978,7 +5978,7 @@ export function GET() {
 			RuleAssistPlainConfiguration: { type: "string", enum: ["off", "on"] },
 			RuleAssistWithOptions_for_OrganizeImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -5993,7 +5993,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_UseSortedAttributesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6008,7 +6008,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_UseSortedKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6023,7 +6023,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_UseSortedPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6133,7 +6133,7 @@ export function GET() {
 			},
 			RuleWithNoAccessKeyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6152,7 +6152,7 @@ export function GET() {
 			},
 			RuleWithNoAccumulatingSpreadOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6167,7 +6167,7 @@ export function GET() {
 			},
 			RuleWithNoAdjacentSpacesInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6186,7 +6186,7 @@ export function GET() {
 			},
 			RuleWithNoAlertOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6201,7 +6201,7 @@ export function GET() {
 			},
 			RuleWithNoApproximativeNumericConstantOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6222,7 +6222,7 @@ export function GET() {
 			},
 			RuleWithNoArgumentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6237,7 +6237,7 @@ export function GET() {
 			},
 			RuleWithNoAriaHiddenOnFocusableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6256,7 +6256,7 @@ export function GET() {
 			},
 			RuleWithNoAriaUnsupportedElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6275,7 +6275,7 @@ export function GET() {
 			},
 			RuleWithNoArrayIndexKeyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6290,7 +6290,7 @@ export function GET() {
 			},
 			RuleWithNoAssignInExpressionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6305,7 +6305,7 @@ export function GET() {
 			},
 			RuleWithNoAsyncPromiseExecutorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6320,7 +6320,7 @@ export function GET() {
 			},
 			RuleWithNoAutofocusOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6339,7 +6339,7 @@ export function GET() {
 			},
 			RuleWithNoAwaitInLoopsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6354,7 +6354,7 @@ export function GET() {
 			},
 			RuleWithNoBannedTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6373,7 +6373,7 @@ export function GET() {
 			},
 			RuleWithNoBarrelFileOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6388,7 +6388,7 @@ export function GET() {
 			},
 			RuleWithNoBiomeFirstExceptionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6407,7 +6407,7 @@ export function GET() {
 			},
 			RuleWithNoBitwiseOperatorsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6422,7 +6422,7 @@ export function GET() {
 			},
 			RuleWithNoBlankTargetOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6441,7 +6441,7 @@ export function GET() {
 			},
 			RuleWithNoCatchAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6456,7 +6456,7 @@ export function GET() {
 			},
 			RuleWithNoChildrenPropOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6471,7 +6471,7 @@ export function GET() {
 			},
 			RuleWithNoClassAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6486,7 +6486,7 @@ export function GET() {
 			},
 			RuleWithNoCommaOperatorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6501,7 +6501,7 @@ export function GET() {
 			},
 			RuleWithNoCommentTextOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6520,7 +6520,7 @@ export function GET() {
 			},
 			RuleWithNoCommonJsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6535,7 +6535,7 @@ export function GET() {
 			},
 			RuleWithNoCompareNegZeroOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6554,7 +6554,7 @@ export function GET() {
 			},
 			RuleWithNoConfusingLabelsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6569,7 +6569,7 @@ export function GET() {
 			},
 			RuleWithNoConfusingVoidTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6588,7 +6588,7 @@ export function GET() {
 			},
 			RuleWithNoConsoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6607,7 +6607,7 @@ export function GET() {
 			},
 			RuleWithNoConstAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6626,7 +6626,7 @@ export function GET() {
 			},
 			RuleWithNoConstEnumOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6645,7 +6645,7 @@ export function GET() {
 			},
 			RuleWithNoConstantBinaryExpressionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6662,7 +6662,7 @@ export function GET() {
 			},
 			RuleWithNoConstantConditionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6677,7 +6677,7 @@ export function GET() {
 			},
 			RuleWithNoConstantMathMinMaxClampOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6696,7 +6696,7 @@ export function GET() {
 			},
 			RuleWithNoConstructorReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6711,7 +6711,7 @@ export function GET() {
 			},
 			RuleWithNoControlCharactersInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6728,7 +6728,7 @@ export function GET() {
 			},
 			RuleWithNoDangerouslySetInnerHtmlOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6743,7 +6743,7 @@ export function GET() {
 			},
 			RuleWithNoDangerouslySetInnerHtmlWithChildrenOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6762,7 +6762,7 @@ export function GET() {
 			},
 			RuleWithNoDebuggerOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6781,7 +6781,7 @@ export function GET() {
 			},
 			RuleWithNoDefaultExportOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6796,7 +6796,7 @@ export function GET() {
 			},
 			RuleWithNoDeleteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6815,7 +6815,7 @@ export function GET() {
 			},
 			RuleWithNoDeprecatedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6830,7 +6830,7 @@ export function GET() {
 			},
 			RuleWithNoDescendingSpecificityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6845,7 +6845,7 @@ export function GET() {
 			},
 			RuleWithNoDistractingElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6864,7 +6864,7 @@ export function GET() {
 			},
 			RuleWithNoDocumentCookieOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6879,7 +6879,7 @@ export function GET() {
 			},
 			RuleWithNoDocumentImportInPageOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6894,7 +6894,7 @@ export function GET() {
 			},
 			RuleWithNoDoneCallbackOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6909,7 +6909,7 @@ export function GET() {
 			},
 			RuleWithNoDoubleEqualsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6928,7 +6928,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateAtImportRulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6943,7 +6943,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateCaseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6958,7 +6958,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateClassMembersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6973,7 +6973,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateCustomPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6990,7 +6990,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7005,7 +7005,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateElseIfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7020,7 +7020,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateFieldsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7035,7 +7035,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateFontNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7050,7 +7050,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateJsxPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7065,7 +7065,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateObjectKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7080,7 +7080,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateParametersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7095,7 +7095,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicatePropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7110,7 +7110,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateSelectorsKeyframeBlockOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7129,7 +7129,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateTestHooksOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7144,7 +7144,7 @@ export function GET() {
 			},
 			RuleWithNoDynamicNamespaceImportAccessOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7161,7 +7161,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyBlockOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7176,7 +7176,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyBlockStatementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7191,7 +7191,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyCharacterClassInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7208,7 +7208,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyInterfaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7227,7 +7227,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyPatternOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7242,7 +7242,7 @@ export function GET() {
 			},
 			RuleWithNoEmptySourceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7257,7 +7257,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyTypeParametersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7272,7 +7272,7 @@ export function GET() {
 			},
 			RuleWithNoEnumOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7287,7 +7287,7 @@ export function GET() {
 			},
 			RuleWithNoEvolvingTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7302,7 +7302,7 @@ export function GET() {
 			},
 			RuleWithNoExcessiveCognitiveComplexityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7319,7 +7319,7 @@ export function GET() {
 			},
 			RuleWithNoExcessiveLinesPerFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7336,7 +7336,7 @@ export function GET() {
 			},
 			RuleWithNoExcessiveNestedTestSuitesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7353,7 +7353,7 @@ export function GET() {
 			},
 			RuleWithNoExplicitAnyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7368,7 +7368,7 @@ export function GET() {
 			},
 			RuleWithNoExportedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7383,7 +7383,7 @@ export function GET() {
 			},
 			RuleWithNoExportsInTestOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7398,7 +7398,7 @@ export function GET() {
 			},
 			RuleWithNoExtraBooleanCastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7417,7 +7417,7 @@ export function GET() {
 			},
 			RuleWithNoExtraNonNullAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7436,7 +7436,7 @@ export function GET() {
 			},
 			RuleWithNoFallthroughSwitchClauseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7451,7 +7451,7 @@ export function GET() {
 			},
 			RuleWithNoFlatMapIdentityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7470,7 +7470,7 @@ export function GET() {
 			},
 			RuleWithNoFloatingPromisesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7489,7 +7489,7 @@ export function GET() {
 			},
 			RuleWithNoFocusedTestsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7508,7 +7508,7 @@ export function GET() {
 			},
 			RuleWithNoForEachOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7523,7 +7523,7 @@ export function GET() {
 			},
 			RuleWithNoFunctionAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7538,7 +7538,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7553,7 +7553,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalDirnameFilenameOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7572,7 +7572,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalEvalOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7587,7 +7587,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalIsFiniteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7606,7 +7606,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalIsNanOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7625,7 +7625,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalObjectCallsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7640,7 +7640,7 @@ export function GET() {
 			},
 			RuleWithNoHeadElementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7655,7 +7655,7 @@ export function GET() {
 			},
 			RuleWithNoHeadImportInDocumentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7670,7 +7670,7 @@ export function GET() {
 			},
 			RuleWithNoHeaderScopeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7689,7 +7689,7 @@ export function GET() {
 			},
 			RuleWithNoImgElementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7704,7 +7704,7 @@ export function GET() {
 			},
 			RuleWithNoImplicitAnyLetOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7719,7 +7719,7 @@ export function GET() {
 			},
 			RuleWithNoImplicitBooleanOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7738,7 +7738,7 @@ export function GET() {
 			},
 			RuleWithNoImplicitCoercionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7757,7 +7757,7 @@ export function GET() {
 			},
 			RuleWithNoImportAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7772,7 +7772,7 @@ export function GET() {
 			},
 			RuleWithNoImportCyclesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7787,7 +7787,7 @@ export function GET() {
 			},
 			RuleWithNoImportantInKeyframeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7802,7 +7802,7 @@ export function GET() {
 			},
 			RuleWithNoImportantStylesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7821,7 +7821,7 @@ export function GET() {
 			},
 			RuleWithNoInferrableTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7840,7 +7840,7 @@ export function GET() {
 			},
 			RuleWithNoInnerDeclarationsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7855,7 +7855,7 @@ export function GET() {
 			},
 			RuleWithNoInteractiveElementToNoninteractiveRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7878,7 +7878,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidBuiltinInstantiationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7899,7 +7899,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidConstructorSuperOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7914,7 +7914,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidDirectionInLinearGradientOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7933,7 +7933,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidGridAreasOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7948,7 +7948,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidPositionAtImportRuleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7965,7 +7965,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidUseBeforeDeclarationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7982,7 +7982,7 @@ export function GET() {
 			},
 			RuleWithNoIrregularWhitespaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7997,7 +7997,7 @@ export function GET() {
 			},
 			RuleWithNoJsxLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8012,7 +8012,7 @@ export function GET() {
 			},
 			RuleWithNoLabelVarOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8027,7 +8027,7 @@ export function GET() {
 			},
 			RuleWithNoLabelWithoutControlOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8042,7 +8042,7 @@ export function GET() {
 			},
 			RuleWithNoMagicNumbersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8057,7 +8057,7 @@ export function GET() {
 			},
 			RuleWithNoMisleadingCharacterClassOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8078,7 +8078,7 @@ export function GET() {
 			},
 			RuleWithNoMisleadingInstantiatorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8093,7 +8093,7 @@ export function GET() {
 			},
 			RuleWithNoMisplacedAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8108,7 +8108,7 @@ export function GET() {
 			},
 			RuleWithNoMisrefactoredShorthandAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8129,7 +8129,7 @@ export function GET() {
 			},
 			RuleWithNoMissingVarFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8144,7 +8144,7 @@ export function GET() {
 			},
 			RuleWithNoMisusedPromisesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8163,7 +8163,7 @@ export function GET() {
 			},
 			RuleWithNoNamespaceImportOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8178,7 +8178,7 @@ export function GET() {
 			},
 			RuleWithNoNamespaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8193,7 +8193,7 @@ export function GET() {
 			},
 			RuleWithNoNegationElseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8212,7 +8212,7 @@ export function GET() {
 			},
 			RuleWithNoNestedComponentDefinitionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8229,7 +8229,7 @@ export function GET() {
 			},
 			RuleWithNoNestedTernaryOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8244,7 +8244,7 @@ export function GET() {
 			},
 			RuleWithNoNextAsyncClientComponentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8261,7 +8261,7 @@ export function GET() {
 			},
 			RuleWithNoNodejsModulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8276,7 +8276,7 @@ export function GET() {
 			},
 			RuleWithNoNonNullAssertedOptionalChainOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8293,7 +8293,7 @@ export function GET() {
 			},
 			RuleWithNoNonNullAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8312,7 +8312,7 @@ export function GET() {
 			},
 			RuleWithNoNoninteractiveElementInteractionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8331,7 +8331,7 @@ export function GET() {
 			},
 			RuleWithNoNoninteractiveElementToInteractiveRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8354,7 +8354,7 @@ export function GET() {
 			},
 			RuleWithNoNoninteractiveTabindexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8373,7 +8373,7 @@ export function GET() {
 			},
 			RuleWithNoNonoctalDecimalEscapeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8392,7 +8392,7 @@ export function GET() {
 			},
 			RuleWithNoOctalEscapeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8411,7 +8411,7 @@ export function GET() {
 			},
 			RuleWithNoParameterAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8426,7 +8426,7 @@ export function GET() {
 			},
 			RuleWithNoParameterPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8441,7 +8441,7 @@ export function GET() {
 			},
 			RuleWithNoPositiveTabindexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8460,7 +8460,7 @@ export function GET() {
 			},
 			RuleWithNoPrecisionLossOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8475,7 +8475,7 @@ export function GET() {
 			},
 			RuleWithNoPrivateImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8490,7 +8490,7 @@ export function GET() {
 			},
 			RuleWithNoProcessEnvOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8505,7 +8505,7 @@ export function GET() {
 			},
 			RuleWithNoProcessGlobalOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8524,7 +8524,7 @@ export function GET() {
 			},
 			RuleWithNoPrototypeBuiltinsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8543,7 +8543,7 @@ export function GET() {
 			},
 			RuleWithNoQuickfixBiomeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8562,7 +8562,7 @@ export function GET() {
 			},
 			RuleWithNoQwikUseVisibleTaskOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8577,7 +8577,7 @@ export function GET() {
 			},
 			RuleWithNoReExportAllOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8592,7 +8592,7 @@ export function GET() {
 			},
 			RuleWithNoReactForwardRefOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8611,7 +8611,7 @@ export function GET() {
 			},
 			RuleWithNoReactPropAssignmentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8626,7 +8626,7 @@ export function GET() {
 			},
 			RuleWithNoReactSpecificPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8645,7 +8645,7 @@ export function GET() {
 			},
 			RuleWithNoRedeclareOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8660,7 +8660,7 @@ export function GET() {
 			},
 			RuleWithNoRedundantAltOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8675,7 +8675,7 @@ export function GET() {
 			},
 			RuleWithNoRedundantRolesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8694,7 +8694,7 @@ export function GET() {
 			},
 			RuleWithNoRedundantUseStrictOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8713,7 +8713,7 @@ export function GET() {
 			},
 			RuleWithNoRenderReturnValueOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8728,7 +8728,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8743,7 +8743,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedGlobalsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8758,7 +8758,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8773,7 +8773,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8792,7 +8792,7 @@ export function GET() {
 			},
 			RuleWithNoSecretsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8807,7 +8807,7 @@ export function GET() {
 			},
 			RuleWithNoSelfAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8822,7 +8822,7 @@ export function GET() {
 			},
 			RuleWithNoSelfCompareOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8837,7 +8837,7 @@ export function GET() {
 			},
 			RuleWithNoSetterReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8852,7 +8852,7 @@ export function GET() {
 			},
 			RuleWithNoShadowOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8867,7 +8867,7 @@ export function GET() {
 			},
 			RuleWithNoShadowRestrictedNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8882,7 +8882,7 @@ export function GET() {
 			},
 			RuleWithNoShorthandPropertyOverridesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8899,7 +8899,7 @@ export function GET() {
 			},
 			RuleWithNoShoutyConstantsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8918,7 +8918,7 @@ export function GET() {
 			},
 			RuleWithNoSkippedTestsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8937,7 +8937,7 @@ export function GET() {
 			},
 			RuleWithNoSolidDestructuredPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8952,7 +8952,7 @@ export function GET() {
 			},
 			RuleWithNoSparseArrayOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8971,7 +8971,7 @@ export function GET() {
 			},
 			RuleWithNoStaticElementInteractionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8988,7 +8988,7 @@ export function GET() {
 			},
 			RuleWithNoStaticOnlyClassOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9003,7 +9003,7 @@ export function GET() {
 			},
 			RuleWithNoStringCaseMismatchOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9022,7 +9022,7 @@ export function GET() {
 			},
 			RuleWithNoSubstrOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9041,7 +9041,7 @@ export function GET() {
 			},
 			RuleWithNoSuspiciousSemicolonInJsxOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9058,7 +9058,7 @@ export function GET() {
 			},
 			RuleWithNoSvgWithoutTitleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9073,7 +9073,7 @@ export function GET() {
 			},
 			RuleWithNoSwitchDeclarationsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9092,7 +9092,7 @@ export function GET() {
 			},
 			RuleWithNoTemplateCurlyInStringOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9107,7 +9107,7 @@ export function GET() {
 			},
 			RuleWithNoThenPropertyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9122,7 +9122,7 @@ export function GET() {
 			},
 			RuleWithNoThisInStaticOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9141,7 +9141,7 @@ export function GET() {
 			},
 			RuleWithNoTsIgnoreOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9160,7 +9160,7 @@ export function GET() {
 			},
 			RuleWithNoUnassignedVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9175,7 +9175,7 @@ export function GET() {
 			},
 			RuleWithNoUndeclaredDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9190,7 +9190,7 @@ export function GET() {
 			},
 			RuleWithNoUndeclaredVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9205,7 +9205,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownAtRulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9220,7 +9220,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9235,7 +9235,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownMediaFeatureNameOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9250,7 +9250,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownPropertyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9265,7 +9265,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownPseudoClassOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9280,7 +9280,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownPseudoElementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9295,7 +9295,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownTypeSelectorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9310,7 +9310,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownUnitOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9325,7 +9325,7 @@ export function GET() {
 			},
 			RuleWithNoUnmatchableAnbSelectorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9340,7 +9340,7 @@ export function GET() {
 			},
 			RuleWithNoUnnecessaryConditionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9355,7 +9355,7 @@ export function GET() {
 			},
 			RuleWithNoUnreachableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9370,7 +9370,7 @@ export function GET() {
 			},
 			RuleWithNoUnreachableSuperOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9385,7 +9385,7 @@ export function GET() {
 			},
 			RuleWithNoUnresolvedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9400,7 +9400,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeDeclarationMergingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9417,7 +9417,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeFinallyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9432,7 +9432,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeNegationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9451,7 +9451,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeOptionalChainingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9466,7 +9466,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedExpressionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9481,7 +9481,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedFunctionParametersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9502,7 +9502,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9521,7 +9521,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedLabelsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9540,7 +9540,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedPrivateClassMembersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9561,7 +9561,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedTemplateLiteralOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9580,7 +9580,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9599,7 +9599,7 @@ export function GET() {
 			},
 			RuleWithNoUnwantedPolyfillioOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9614,7 +9614,7 @@ export function GET() {
 			},
 			RuleWithNoUselessCatchBindingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9633,7 +9633,7 @@ export function GET() {
 			},
 			RuleWithNoUselessCatchOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9652,7 +9652,7 @@ export function GET() {
 			},
 			RuleWithNoUselessConstructorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9671,7 +9671,7 @@ export function GET() {
 			},
 			RuleWithNoUselessContinueOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9690,7 +9690,7 @@ export function GET() {
 			},
 			RuleWithNoUselessElseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9709,7 +9709,7 @@ export function GET() {
 			},
 			RuleWithNoUselessEmptyExportOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9728,7 +9728,7 @@ export function GET() {
 			},
 			RuleWithNoUselessEscapeInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9747,7 +9747,7 @@ export function GET() {
 			},
 			RuleWithNoUselessEscapeInStringOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9766,7 +9766,7 @@ export function GET() {
 			},
 			RuleWithNoUselessFragmentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9785,7 +9785,7 @@ export function GET() {
 			},
 			RuleWithNoUselessLabelOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9804,7 +9804,7 @@ export function GET() {
 			},
 			RuleWithNoUselessLoneBlockStatementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9825,7 +9825,7 @@ export function GET() {
 			},
 			RuleWithNoUselessRegexBackrefsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9840,7 +9840,7 @@ export function GET() {
 			},
 			RuleWithNoUselessRenameOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9859,7 +9859,7 @@ export function GET() {
 			},
 			RuleWithNoUselessStringConcatOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9878,7 +9878,7 @@ export function GET() {
 			},
 			RuleWithNoUselessStringRawOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9893,7 +9893,7 @@ export function GET() {
 			},
 			RuleWithNoUselessSwitchCaseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9912,7 +9912,7 @@ export function GET() {
 			},
 			RuleWithNoUselessTernaryOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9931,7 +9931,7 @@ export function GET() {
 			},
 			RuleWithNoUselessThisAliasOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9950,7 +9950,7 @@ export function GET() {
 			},
 			RuleWithNoUselessTypeConstraintOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9969,7 +9969,7 @@ export function GET() {
 			},
 			RuleWithNoUselessUndefinedInitializationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9990,7 +9990,7 @@ export function GET() {
 			},
 			RuleWithNoUselessUndefinedOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10009,7 +10009,7 @@ export function GET() {
 			},
 			RuleWithNoValueAtRuleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10024,7 +10024,7 @@ export function GET() {
 			},
 			RuleWithNoVarOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10043,7 +10043,7 @@ export function GET() {
 			},
 			RuleWithNoVoidElementsWithChildrenOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10064,7 +10064,7 @@ export function GET() {
 			},
 			RuleWithNoVoidOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10079,7 +10079,7 @@ export function GET() {
 			},
 			RuleWithNoVoidTypeReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10094,7 +10094,7 @@ export function GET() {
 			},
 			RuleWithNoVueDataObjectDeclarationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10115,7 +10115,7 @@ export function GET() {
 			},
 			RuleWithNoVueDuplicateKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10130,7 +10130,7 @@ export function GET() {
 			},
 			RuleWithNoVueReservedKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10145,7 +10145,7 @@ export function GET() {
 			},
 			RuleWithNoVueReservedPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10160,7 +10160,7 @@ export function GET() {
 			},
 			RuleWithNoWithOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10175,7 +10175,7 @@ export function GET() {
 			},
 			RuleWithNoYodaExpressionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10194,7 +10194,7 @@ export function GET() {
 			},
 			RuleWithUseAdjacentOverloadSignaturesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10211,7 +10211,7 @@ export function GET() {
 			},
 			RuleWithUseAltTextOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10226,7 +10226,7 @@ export function GET() {
 			},
 			RuleWithUseAnchorContentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10245,7 +10245,7 @@ export function GET() {
 			},
 			RuleWithUseAriaActivedescendantWithTabindexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10268,7 +10268,7 @@ export function GET() {
 			},
 			RuleWithUseAriaPropsForRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10283,7 +10283,7 @@ export function GET() {
 			},
 			RuleWithUseAriaPropsSupportedByRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10300,7 +10300,7 @@ export function GET() {
 			},
 			RuleWithUseArrayLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10319,7 +10319,7 @@ export function GET() {
 			},
 			RuleWithUseArrowFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10338,7 +10338,7 @@ export function GET() {
 			},
 			RuleWithUseAsConstAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10357,7 +10357,7 @@ export function GET() {
 			},
 			RuleWithUseAtIndexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10376,7 +10376,7 @@ export function GET() {
 			},
 			RuleWithUseAwaitOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10391,7 +10391,7 @@ export function GET() {
 			},
 			RuleWithUseBiomeIgnoreFolderOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10410,7 +10410,7 @@ export function GET() {
 			},
 			RuleWithUseBlockStatementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10429,7 +10429,7 @@ export function GET() {
 			},
 			RuleWithUseButtonTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10444,7 +10444,7 @@ export function GET() {
 			},
 			RuleWithUseCollapsedElseIfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10463,7 +10463,7 @@ export function GET() {
 			},
 			RuleWithUseCollapsedIfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10482,7 +10482,7 @@ export function GET() {
 			},
 			RuleWithUseComponentExportOnlyModulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10499,7 +10499,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentArrayTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10518,7 +10518,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentArrowReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10537,7 +10537,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentBuiltinInstantiationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10560,7 +10560,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentCurlyBracesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10579,7 +10579,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentMemberAccessibilityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10596,7 +10596,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentObjectDefinitionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10617,7 +10617,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentTypeDefinitionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10638,7 +10638,7 @@ export function GET() {
 			},
 			RuleWithUseConstOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10657,7 +10657,7 @@ export function GET() {
 			},
 			RuleWithUseDateNowOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10676,7 +10676,7 @@ export function GET() {
 			},
 			RuleWithUseDefaultParameterLastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10695,7 +10695,7 @@ export function GET() {
 			},
 			RuleWithUseDefaultSwitchClauseLastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10712,7 +10712,7 @@ export function GET() {
 			},
 			RuleWithUseDefaultSwitchClauseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10727,7 +10727,7 @@ export function GET() {
 			},
 			RuleWithUseDeprecatedDateOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10742,7 +10742,7 @@ export function GET() {
 			},
 			RuleWithUseDeprecatedReasonOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10757,7 +10757,7 @@ export function GET() {
 			},
 			RuleWithUseEnumInitializersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10776,7 +10776,7 @@ export function GET() {
 			},
 			RuleWithUseErrorMessageOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10791,7 +10791,7 @@ export function GET() {
 			},
 			RuleWithUseExhaustiveDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10810,7 +10810,7 @@ export function GET() {
 			},
 			RuleWithUseExhaustiveSwitchCasesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10829,7 +10829,7 @@ export function GET() {
 			},
 			RuleWithUseExplicitLengthCheckOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10848,7 +10848,7 @@ export function GET() {
 			},
 			RuleWithUseExplicitTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10863,7 +10863,7 @@ export function GET() {
 			},
 			RuleWithUseExponentiationOperatorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10882,7 +10882,7 @@ export function GET() {
 			},
 			RuleWithUseExportTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10901,7 +10901,7 @@ export function GET() {
 			},
 			RuleWithUseExportsLastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10916,7 +10916,7 @@ export function GET() {
 			},
 			RuleWithUseFilenamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10931,7 +10931,7 @@ export function GET() {
 			},
 			RuleWithUseFlatMapOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10950,7 +10950,7 @@ export function GET() {
 			},
 			RuleWithUseFocusableInteractiveOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10965,7 +10965,7 @@ export function GET() {
 			},
 			RuleWithUseForOfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10980,7 +10980,7 @@ export function GET() {
 			},
 			RuleWithUseFragmentSyntaxOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10999,7 +10999,7 @@ export function GET() {
 			},
 			RuleWithUseGenericFontNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11014,7 +11014,7 @@ export function GET() {
 			},
 			RuleWithUseGetterReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11029,7 +11029,7 @@ export function GET() {
 			},
 			RuleWithUseGoogleFontDisplayOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11044,7 +11044,7 @@ export function GET() {
 			},
 			RuleWithUseGoogleFontPreconnectOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11063,7 +11063,7 @@ export function GET() {
 			},
 			RuleWithUseGraphqlNamedOperationsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11082,7 +11082,7 @@ export function GET() {
 			},
 			RuleWithUseGraphqlNamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11099,7 +11099,7 @@ export function GET() {
 			},
 			RuleWithUseGroupedAccessorPairsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11114,7 +11114,7 @@ export function GET() {
 			},
 			RuleWithUseGuardForInOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11129,7 +11129,7 @@ export function GET() {
 			},
 			RuleWithUseHeadingContentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11144,7 +11144,7 @@ export function GET() {
 			},
 			RuleWithUseHookAtTopLevelOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11159,7 +11159,7 @@ export function GET() {
 			},
 			RuleWithUseHtmlLangOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11174,7 +11174,7 @@ export function GET() {
 			},
 			RuleWithUseIframeTitleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11189,7 +11189,7 @@ export function GET() {
 			},
 			RuleWithUseImageSizeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11204,7 +11204,7 @@ export function GET() {
 			},
 			RuleWithUseImportExtensionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11223,7 +11223,7 @@ export function GET() {
 			},
 			RuleWithUseImportTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11242,7 +11242,7 @@ export function GET() {
 			},
 			RuleWithUseIndexOfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11261,7 +11261,7 @@ export function GET() {
 			},
 			RuleWithUseIsArrayOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11280,7 +11280,7 @@ export function GET() {
 			},
 			RuleWithUseIsNanOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11299,7 +11299,7 @@ export function GET() {
 			},
 			RuleWithUseIterableCallbackReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11314,7 +11314,7 @@ export function GET() {
 			},
 			RuleWithUseJsonImportAttributesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11333,7 +11333,7 @@ export function GET() {
 			},
 			RuleWithUseJsxKeyInIterableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11348,7 +11348,7 @@ export function GET() {
 			},
 			RuleWithUseKeyWithClickEventsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11363,7 +11363,7 @@ export function GET() {
 			},
 			RuleWithUseKeyWithMouseEventsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11378,7 +11378,7 @@ export function GET() {
 			},
 			RuleWithUseLiteralEnumMembersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11393,7 +11393,7 @@ export function GET() {
 			},
 			RuleWithUseLiteralKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11412,7 +11412,7 @@ export function GET() {
 			},
 			RuleWithUseMaxParamsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11427,7 +11427,7 @@ export function GET() {
 			},
 			RuleWithUseMediaCaptionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11442,7 +11442,7 @@ export function GET() {
 			},
 			RuleWithUseNamespaceKeywordOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11461,7 +11461,7 @@ export function GET() {
 			},
 			RuleWithUseNamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11480,7 +11480,7 @@ export function GET() {
 			},
 			RuleWithUseNodeAssertStrictOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11499,7 +11499,7 @@ export function GET() {
 			},
 			RuleWithUseNodejsImportProtocolOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11518,7 +11518,7 @@ export function GET() {
 			},
 			RuleWithUseNumberNamespaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11537,7 +11537,7 @@ export function GET() {
 			},
 			RuleWithUseNumberToFixedDigitsArgumentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11558,7 +11558,7 @@ export function GET() {
 			},
 			RuleWithUseNumericLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11577,7 +11577,7 @@ export function GET() {
 			},
 			RuleWithUseNumericSeparatorsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11596,7 +11596,7 @@ export function GET() {
 			},
 			RuleWithUseObjectSpreadOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11615,7 +11615,7 @@ export function GET() {
 			},
 			RuleWithUseOptionalChainOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11634,7 +11634,7 @@ export function GET() {
 			},
 			RuleWithUseParseIntRadixOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11653,7 +11653,7 @@ export function GET() {
 			},
 			RuleWithUseQwikClasslistOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11668,7 +11668,7 @@ export function GET() {
 			},
 			RuleWithUseQwikMethodUsageOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11683,7 +11683,7 @@ export function GET() {
 			},
 			RuleWithUseQwikValidLexicalScopeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11698,7 +11698,7 @@ export function GET() {
 			},
 			RuleWithUseReactFunctionComponentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11715,7 +11715,7 @@ export function GET() {
 			},
 			RuleWithUseReadonlyClassPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11736,7 +11736,7 @@ export function GET() {
 			},
 			RuleWithUseRegexLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11755,7 +11755,7 @@ export function GET() {
 			},
 			RuleWithUseSelfClosingElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11774,7 +11774,7 @@ export function GET() {
 			},
 			RuleWithUseSemanticElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11789,7 +11789,7 @@ export function GET() {
 			},
 			RuleWithUseShorthandAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11808,7 +11808,7 @@ export function GET() {
 			},
 			RuleWithUseShorthandFunctionTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11827,7 +11827,7 @@ export function GET() {
 			},
 			RuleWithUseSimpleNumberKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11846,7 +11846,7 @@ export function GET() {
 			},
 			RuleWithUseSimplifiedLogicExpressionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11867,7 +11867,7 @@ export function GET() {
 			},
 			RuleWithUseSingleJsDocAsteriskOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11886,7 +11886,7 @@ export function GET() {
 			},
 			RuleWithUseSingleVarDeclaratorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11905,7 +11905,7 @@ export function GET() {
 			},
 			RuleWithUseSolidForComponentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11920,7 +11920,7 @@ export function GET() {
 			},
 			RuleWithUseSortedClassesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11939,7 +11939,7 @@ export function GET() {
 			},
 			RuleWithUseStaticResponseMethodsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11958,7 +11958,7 @@ export function GET() {
 			},
 			RuleWithUseStrictModeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11977,7 +11977,7 @@ export function GET() {
 			},
 			RuleWithUseSymbolDescriptionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11992,7 +11992,7 @@ export function GET() {
 			},
 			RuleWithUseTemplateOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12011,7 +12011,7 @@ export function GET() {
 			},
 			RuleWithUseThrowNewErrorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12030,7 +12030,7 @@ export function GET() {
 			},
 			RuleWithUseThrowOnlyErrorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12045,7 +12045,7 @@ export function GET() {
 			},
 			RuleWithUseTopLevelRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12060,7 +12060,7 @@ export function GET() {
 			},
 			RuleWithUseTrimStartEndOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12079,7 +12079,7 @@ export function GET() {
 			},
 			RuleWithUseUnifiedTypeSignaturesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12098,7 +12098,7 @@ export function GET() {
 			},
 			RuleWithUseUniqueElementIdsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12113,7 +12113,7 @@ export function GET() {
 			},
 			RuleWithUseValidAnchorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12128,7 +12128,7 @@ export function GET() {
 			},
 			RuleWithUseValidAriaPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12147,7 +12147,7 @@ export function GET() {
 			},
 			RuleWithUseValidAriaRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12166,7 +12166,7 @@ export function GET() {
 			},
 			RuleWithUseValidAriaValuesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12181,7 +12181,7 @@ export function GET() {
 			},
 			RuleWithUseValidAutocompleteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12196,7 +12196,7 @@ export function GET() {
 			},
 			RuleWithUseValidForDirectionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12211,7 +12211,7 @@ export function GET() {
 			},
 			RuleWithUseValidLangOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12226,7 +12226,7 @@ export function GET() {
 			},
 			RuleWithUseValidTypeofOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12245,7 +12245,7 @@ export function GET() {
 			},
 			RuleWithUseVueDefineMacrosOrderOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12264,7 +12264,7 @@ export function GET() {
 			},
 			RuleWithUseVueMultiWordComponentNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12281,7 +12281,7 @@ export function GET() {
 			},
 			RuleWithUseWhileOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12300,7 +12300,7 @@ export function GET() {
 			},
 			RuleWithUseYieldOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",

--- a/src/pages/schemas/2.3.2/schema.json.js
+++ b/src/pages/schemas/2.3.2/schema.json.js
@@ -6004,7 +6004,7 @@ export function GET() {
 			RuleAssistPlainConfiguration: { type: "string", enum: ["off", "on"] },
 			RuleAssistWithOptions_for_OrganizeImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6019,7 +6019,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_UseSortedAttributesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6034,7 +6034,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_UseSortedKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6049,7 +6049,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_UseSortedPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6159,7 +6159,7 @@ export function GET() {
 			},
 			RuleWithNoAccessKeyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6178,7 +6178,7 @@ export function GET() {
 			},
 			RuleWithNoAccumulatingSpreadOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6193,7 +6193,7 @@ export function GET() {
 			},
 			RuleWithNoAdjacentSpacesInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6212,7 +6212,7 @@ export function GET() {
 			},
 			RuleWithNoAlertOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6227,7 +6227,7 @@ export function GET() {
 			},
 			RuleWithNoApproximativeNumericConstantOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6248,7 +6248,7 @@ export function GET() {
 			},
 			RuleWithNoArgumentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6263,7 +6263,7 @@ export function GET() {
 			},
 			RuleWithNoAriaHiddenOnFocusableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6282,7 +6282,7 @@ export function GET() {
 			},
 			RuleWithNoAriaUnsupportedElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6301,7 +6301,7 @@ export function GET() {
 			},
 			RuleWithNoArrayIndexKeyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6316,7 +6316,7 @@ export function GET() {
 			},
 			RuleWithNoAssignInExpressionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6331,7 +6331,7 @@ export function GET() {
 			},
 			RuleWithNoAsyncPromiseExecutorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6346,7 +6346,7 @@ export function GET() {
 			},
 			RuleWithNoAutofocusOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6365,7 +6365,7 @@ export function GET() {
 			},
 			RuleWithNoAwaitInLoopsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6380,7 +6380,7 @@ export function GET() {
 			},
 			RuleWithNoBannedTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6399,7 +6399,7 @@ export function GET() {
 			},
 			RuleWithNoBarrelFileOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6414,7 +6414,7 @@ export function GET() {
 			},
 			RuleWithNoBiomeFirstExceptionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6433,7 +6433,7 @@ export function GET() {
 			},
 			RuleWithNoBitwiseOperatorsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6448,7 +6448,7 @@ export function GET() {
 			},
 			RuleWithNoBlankTargetOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6467,7 +6467,7 @@ export function GET() {
 			},
 			RuleWithNoCatchAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6482,7 +6482,7 @@ export function GET() {
 			},
 			RuleWithNoChildrenPropOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6497,7 +6497,7 @@ export function GET() {
 			},
 			RuleWithNoClassAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6512,7 +6512,7 @@ export function GET() {
 			},
 			RuleWithNoCommaOperatorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6527,7 +6527,7 @@ export function GET() {
 			},
 			RuleWithNoCommentTextOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6546,7 +6546,7 @@ export function GET() {
 			},
 			RuleWithNoCommonJsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6561,7 +6561,7 @@ export function GET() {
 			},
 			RuleWithNoCompareNegZeroOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6580,7 +6580,7 @@ export function GET() {
 			},
 			RuleWithNoConfusingLabelsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6595,7 +6595,7 @@ export function GET() {
 			},
 			RuleWithNoConfusingVoidTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6614,7 +6614,7 @@ export function GET() {
 			},
 			RuleWithNoConsoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6633,7 +6633,7 @@ export function GET() {
 			},
 			RuleWithNoConstAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6652,7 +6652,7 @@ export function GET() {
 			},
 			RuleWithNoConstEnumOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6671,7 +6671,7 @@ export function GET() {
 			},
 			RuleWithNoConstantBinaryExpressionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6688,7 +6688,7 @@ export function GET() {
 			},
 			RuleWithNoConstantConditionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6703,7 +6703,7 @@ export function GET() {
 			},
 			RuleWithNoConstantMathMinMaxClampOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6722,7 +6722,7 @@ export function GET() {
 			},
 			RuleWithNoConstructorReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6737,7 +6737,7 @@ export function GET() {
 			},
 			RuleWithNoControlCharactersInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6754,7 +6754,7 @@ export function GET() {
 			},
 			RuleWithNoDangerouslySetInnerHtmlOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6769,7 +6769,7 @@ export function GET() {
 			},
 			RuleWithNoDangerouslySetInnerHtmlWithChildrenOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6788,7 +6788,7 @@ export function GET() {
 			},
 			RuleWithNoDebuggerOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6807,7 +6807,7 @@ export function GET() {
 			},
 			RuleWithNoDefaultExportOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6822,7 +6822,7 @@ export function GET() {
 			},
 			RuleWithNoDeleteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6841,7 +6841,7 @@ export function GET() {
 			},
 			RuleWithNoDeprecatedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6856,7 +6856,7 @@ export function GET() {
 			},
 			RuleWithNoDescendingSpecificityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6871,7 +6871,7 @@ export function GET() {
 			},
 			RuleWithNoDistractingElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6890,7 +6890,7 @@ export function GET() {
 			},
 			RuleWithNoDocumentCookieOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6905,7 +6905,7 @@ export function GET() {
 			},
 			RuleWithNoDocumentImportInPageOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6920,7 +6920,7 @@ export function GET() {
 			},
 			RuleWithNoDoneCallbackOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6935,7 +6935,7 @@ export function GET() {
 			},
 			RuleWithNoDoubleEqualsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6954,7 +6954,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateAtImportRulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6969,7 +6969,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateCaseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6984,7 +6984,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateClassMembersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6999,7 +6999,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateCustomPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7016,7 +7016,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7031,7 +7031,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateElseIfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7046,7 +7046,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateFieldsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7061,7 +7061,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateFontNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7076,7 +7076,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateJsxPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7091,7 +7091,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateObjectKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7106,7 +7106,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateParametersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7121,7 +7121,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicatePropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7136,7 +7136,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateSelectorsKeyframeBlockOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7155,7 +7155,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateTestHooksOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7170,7 +7170,7 @@ export function GET() {
 			},
 			RuleWithNoDynamicNamespaceImportAccessOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7187,7 +7187,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyBlockOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7202,7 +7202,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyBlockStatementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7217,7 +7217,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyCharacterClassInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7234,7 +7234,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyInterfaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7253,7 +7253,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyPatternOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7268,7 +7268,7 @@ export function GET() {
 			},
 			RuleWithNoEmptySourceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7283,7 +7283,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyTypeParametersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7298,7 +7298,7 @@ export function GET() {
 			},
 			RuleWithNoEnumOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7313,7 +7313,7 @@ export function GET() {
 			},
 			RuleWithNoEvolvingTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7328,7 +7328,7 @@ export function GET() {
 			},
 			RuleWithNoExcessiveCognitiveComplexityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7345,7 +7345,7 @@ export function GET() {
 			},
 			RuleWithNoExcessiveLinesPerFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7362,7 +7362,7 @@ export function GET() {
 			},
 			RuleWithNoExcessiveNestedTestSuitesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7379,7 +7379,7 @@ export function GET() {
 			},
 			RuleWithNoExplicitAnyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7394,7 +7394,7 @@ export function GET() {
 			},
 			RuleWithNoExportedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7409,7 +7409,7 @@ export function GET() {
 			},
 			RuleWithNoExportsInTestOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7424,7 +7424,7 @@ export function GET() {
 			},
 			RuleWithNoExtraBooleanCastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7443,7 +7443,7 @@ export function GET() {
 			},
 			RuleWithNoExtraNonNullAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7462,7 +7462,7 @@ export function GET() {
 			},
 			RuleWithNoFallthroughSwitchClauseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7477,7 +7477,7 @@ export function GET() {
 			},
 			RuleWithNoFlatMapIdentityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7496,7 +7496,7 @@ export function GET() {
 			},
 			RuleWithNoFloatingPromisesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7515,7 +7515,7 @@ export function GET() {
 			},
 			RuleWithNoFocusedTestsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7534,7 +7534,7 @@ export function GET() {
 			},
 			RuleWithNoForEachOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7549,7 +7549,7 @@ export function GET() {
 			},
 			RuleWithNoFunctionAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7564,7 +7564,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7579,7 +7579,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalDirnameFilenameOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7598,7 +7598,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalEvalOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7613,7 +7613,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalIsFiniteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7632,7 +7632,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalIsNanOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7651,7 +7651,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalObjectCallsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7666,7 +7666,7 @@ export function GET() {
 			},
 			RuleWithNoHeadElementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7681,7 +7681,7 @@ export function GET() {
 			},
 			RuleWithNoHeadImportInDocumentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7696,7 +7696,7 @@ export function GET() {
 			},
 			RuleWithNoHeaderScopeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7715,7 +7715,7 @@ export function GET() {
 			},
 			RuleWithNoImgElementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7730,7 +7730,7 @@ export function GET() {
 			},
 			RuleWithNoImplicitAnyLetOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7745,7 +7745,7 @@ export function GET() {
 			},
 			RuleWithNoImplicitBooleanOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7764,7 +7764,7 @@ export function GET() {
 			},
 			RuleWithNoImplicitCoercionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7783,7 +7783,7 @@ export function GET() {
 			},
 			RuleWithNoImportAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7798,7 +7798,7 @@ export function GET() {
 			},
 			RuleWithNoImportCyclesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7813,7 +7813,7 @@ export function GET() {
 			},
 			RuleWithNoImportantInKeyframeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7828,7 +7828,7 @@ export function GET() {
 			},
 			RuleWithNoImportantStylesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7847,7 +7847,7 @@ export function GET() {
 			},
 			RuleWithNoIncrementDecrementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7862,7 +7862,7 @@ export function GET() {
 			},
 			RuleWithNoInferrableTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7881,7 +7881,7 @@ export function GET() {
 			},
 			RuleWithNoInnerDeclarationsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7896,7 +7896,7 @@ export function GET() {
 			},
 			RuleWithNoInteractiveElementToNoninteractiveRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7919,7 +7919,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidBuiltinInstantiationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7940,7 +7940,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidConstructorSuperOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7955,7 +7955,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidDirectionInLinearGradientOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7974,7 +7974,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidGridAreasOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7989,7 +7989,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidPositionAtImportRuleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8006,7 +8006,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidUseBeforeDeclarationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8023,7 +8023,7 @@ export function GET() {
 			},
 			RuleWithNoIrregularWhitespaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8038,7 +8038,7 @@ export function GET() {
 			},
 			RuleWithNoJsxLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8053,7 +8053,7 @@ export function GET() {
 			},
 			RuleWithNoLabelVarOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8068,7 +8068,7 @@ export function GET() {
 			},
 			RuleWithNoLabelWithoutControlOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8083,7 +8083,7 @@ export function GET() {
 			},
 			RuleWithNoMagicNumbersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8098,7 +8098,7 @@ export function GET() {
 			},
 			RuleWithNoMisleadingCharacterClassOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8119,7 +8119,7 @@ export function GET() {
 			},
 			RuleWithNoMisleadingInstantiatorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8134,7 +8134,7 @@ export function GET() {
 			},
 			RuleWithNoMisplacedAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8149,7 +8149,7 @@ export function GET() {
 			},
 			RuleWithNoMisrefactoredShorthandAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8170,7 +8170,7 @@ export function GET() {
 			},
 			RuleWithNoMissingVarFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8185,7 +8185,7 @@ export function GET() {
 			},
 			RuleWithNoMisusedPromisesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8204,7 +8204,7 @@ export function GET() {
 			},
 			RuleWithNoNamespaceImportOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8219,7 +8219,7 @@ export function GET() {
 			},
 			RuleWithNoNamespaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8234,7 +8234,7 @@ export function GET() {
 			},
 			RuleWithNoNegationElseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8253,7 +8253,7 @@ export function GET() {
 			},
 			RuleWithNoNestedComponentDefinitionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8270,7 +8270,7 @@ export function GET() {
 			},
 			RuleWithNoNestedTernaryOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8285,7 +8285,7 @@ export function GET() {
 			},
 			RuleWithNoNextAsyncClientComponentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8302,7 +8302,7 @@ export function GET() {
 			},
 			RuleWithNoNodejsModulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8317,7 +8317,7 @@ export function GET() {
 			},
 			RuleWithNoNonNullAssertedOptionalChainOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8334,7 +8334,7 @@ export function GET() {
 			},
 			RuleWithNoNonNullAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8353,7 +8353,7 @@ export function GET() {
 			},
 			RuleWithNoNoninteractiveElementInteractionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8372,7 +8372,7 @@ export function GET() {
 			},
 			RuleWithNoNoninteractiveElementToInteractiveRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8395,7 +8395,7 @@ export function GET() {
 			},
 			RuleWithNoNoninteractiveTabindexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8414,7 +8414,7 @@ export function GET() {
 			},
 			RuleWithNoNonoctalDecimalEscapeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8433,7 +8433,7 @@ export function GET() {
 			},
 			RuleWithNoOctalEscapeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8452,7 +8452,7 @@ export function GET() {
 			},
 			RuleWithNoParameterAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8467,7 +8467,7 @@ export function GET() {
 			},
 			RuleWithNoParameterPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8482,7 +8482,7 @@ export function GET() {
 			},
 			RuleWithNoPositiveTabindexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8501,7 +8501,7 @@ export function GET() {
 			},
 			RuleWithNoPrecisionLossOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8516,7 +8516,7 @@ export function GET() {
 			},
 			RuleWithNoPrivateImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8531,7 +8531,7 @@ export function GET() {
 			},
 			RuleWithNoProcessEnvOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8546,7 +8546,7 @@ export function GET() {
 			},
 			RuleWithNoProcessGlobalOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8565,7 +8565,7 @@ export function GET() {
 			},
 			RuleWithNoPrototypeBuiltinsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8584,7 +8584,7 @@ export function GET() {
 			},
 			RuleWithNoQuickfixBiomeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8603,7 +8603,7 @@ export function GET() {
 			},
 			RuleWithNoQwikUseVisibleTaskOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8618,7 +8618,7 @@ export function GET() {
 			},
 			RuleWithNoReExportAllOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8633,7 +8633,7 @@ export function GET() {
 			},
 			RuleWithNoReactForwardRefOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8652,7 +8652,7 @@ export function GET() {
 			},
 			RuleWithNoReactPropAssignmentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8667,7 +8667,7 @@ export function GET() {
 			},
 			RuleWithNoReactSpecificPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8686,7 +8686,7 @@ export function GET() {
 			},
 			RuleWithNoRedeclareOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8701,7 +8701,7 @@ export function GET() {
 			},
 			RuleWithNoRedundantAltOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8716,7 +8716,7 @@ export function GET() {
 			},
 			RuleWithNoRedundantRolesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8735,7 +8735,7 @@ export function GET() {
 			},
 			RuleWithNoRedundantUseStrictOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8754,7 +8754,7 @@ export function GET() {
 			},
 			RuleWithNoRenderReturnValueOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8769,7 +8769,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8784,7 +8784,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedGlobalsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8799,7 +8799,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8814,7 +8814,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8833,7 +8833,7 @@ export function GET() {
 			},
 			RuleWithNoSecretsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8848,7 +8848,7 @@ export function GET() {
 			},
 			RuleWithNoSelfAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8863,7 +8863,7 @@ export function GET() {
 			},
 			RuleWithNoSelfCompareOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8878,7 +8878,7 @@ export function GET() {
 			},
 			RuleWithNoSetterReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8893,7 +8893,7 @@ export function GET() {
 			},
 			RuleWithNoShadowOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8908,7 +8908,7 @@ export function GET() {
 			},
 			RuleWithNoShadowRestrictedNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8923,7 +8923,7 @@ export function GET() {
 			},
 			RuleWithNoShorthandPropertyOverridesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8940,7 +8940,7 @@ export function GET() {
 			},
 			RuleWithNoShoutyConstantsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8959,7 +8959,7 @@ export function GET() {
 			},
 			RuleWithNoSkippedTestsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8978,7 +8978,7 @@ export function GET() {
 			},
 			RuleWithNoSolidDestructuredPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8993,7 +8993,7 @@ export function GET() {
 			},
 			RuleWithNoSparseArrayOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9012,7 +9012,7 @@ export function GET() {
 			},
 			RuleWithNoStaticElementInteractionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9029,7 +9029,7 @@ export function GET() {
 			},
 			RuleWithNoStaticOnlyClassOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9044,7 +9044,7 @@ export function GET() {
 			},
 			RuleWithNoStringCaseMismatchOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9063,7 +9063,7 @@ export function GET() {
 			},
 			RuleWithNoSubstrOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9082,7 +9082,7 @@ export function GET() {
 			},
 			RuleWithNoSuspiciousSemicolonInJsxOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9099,7 +9099,7 @@ export function GET() {
 			},
 			RuleWithNoSvgWithoutTitleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9114,7 +9114,7 @@ export function GET() {
 			},
 			RuleWithNoSwitchDeclarationsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9133,7 +9133,7 @@ export function GET() {
 			},
 			RuleWithNoTemplateCurlyInStringOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9148,7 +9148,7 @@ export function GET() {
 			},
 			RuleWithNoThenPropertyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9163,7 +9163,7 @@ export function GET() {
 			},
 			RuleWithNoThisInStaticOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9182,7 +9182,7 @@ export function GET() {
 			},
 			RuleWithNoTsIgnoreOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9201,7 +9201,7 @@ export function GET() {
 			},
 			RuleWithNoUnassignedVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9216,7 +9216,7 @@ export function GET() {
 			},
 			RuleWithNoUndeclaredDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9231,7 +9231,7 @@ export function GET() {
 			},
 			RuleWithNoUndeclaredVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9246,7 +9246,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownAtRulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9261,7 +9261,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9276,7 +9276,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownMediaFeatureNameOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9291,7 +9291,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownPropertyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9306,7 +9306,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownPseudoClassOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9321,7 +9321,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownPseudoElementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9336,7 +9336,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownTypeSelectorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9351,7 +9351,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownUnitOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9366,7 +9366,7 @@ export function GET() {
 			},
 			RuleWithNoUnmatchableAnbSelectorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9381,7 +9381,7 @@ export function GET() {
 			},
 			RuleWithNoUnnecessaryConditionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9396,7 +9396,7 @@ export function GET() {
 			},
 			RuleWithNoUnreachableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9411,7 +9411,7 @@ export function GET() {
 			},
 			RuleWithNoUnreachableSuperOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9426,7 +9426,7 @@ export function GET() {
 			},
 			RuleWithNoUnresolvedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9441,7 +9441,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeDeclarationMergingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9458,7 +9458,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeFinallyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9473,7 +9473,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeNegationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9492,7 +9492,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeOptionalChainingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9507,7 +9507,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedExpressionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9522,7 +9522,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedFunctionParametersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9543,7 +9543,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9562,7 +9562,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedLabelsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9581,7 +9581,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedPrivateClassMembersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9602,7 +9602,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedTemplateLiteralOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9621,7 +9621,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9640,7 +9640,7 @@ export function GET() {
 			},
 			RuleWithNoUnwantedPolyfillioOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9655,7 +9655,7 @@ export function GET() {
 			},
 			RuleWithNoUselessCatchBindingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9674,7 +9674,7 @@ export function GET() {
 			},
 			RuleWithNoUselessCatchOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9693,7 +9693,7 @@ export function GET() {
 			},
 			RuleWithNoUselessConstructorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9712,7 +9712,7 @@ export function GET() {
 			},
 			RuleWithNoUselessContinueOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9731,7 +9731,7 @@ export function GET() {
 			},
 			RuleWithNoUselessElseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9750,7 +9750,7 @@ export function GET() {
 			},
 			RuleWithNoUselessEmptyExportOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9769,7 +9769,7 @@ export function GET() {
 			},
 			RuleWithNoUselessEscapeInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9788,7 +9788,7 @@ export function GET() {
 			},
 			RuleWithNoUselessEscapeInStringOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9807,7 +9807,7 @@ export function GET() {
 			},
 			RuleWithNoUselessFragmentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9826,7 +9826,7 @@ export function GET() {
 			},
 			RuleWithNoUselessLabelOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9845,7 +9845,7 @@ export function GET() {
 			},
 			RuleWithNoUselessLoneBlockStatementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9866,7 +9866,7 @@ export function GET() {
 			},
 			RuleWithNoUselessRegexBackrefsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9881,7 +9881,7 @@ export function GET() {
 			},
 			RuleWithNoUselessRenameOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9900,7 +9900,7 @@ export function GET() {
 			},
 			RuleWithNoUselessStringConcatOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9919,7 +9919,7 @@ export function GET() {
 			},
 			RuleWithNoUselessStringRawOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9934,7 +9934,7 @@ export function GET() {
 			},
 			RuleWithNoUselessSwitchCaseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9953,7 +9953,7 @@ export function GET() {
 			},
 			RuleWithNoUselessTernaryOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9972,7 +9972,7 @@ export function GET() {
 			},
 			RuleWithNoUselessThisAliasOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9991,7 +9991,7 @@ export function GET() {
 			},
 			RuleWithNoUselessTypeConstraintOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10010,7 +10010,7 @@ export function GET() {
 			},
 			RuleWithNoUselessUndefinedInitializationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10031,7 +10031,7 @@ export function GET() {
 			},
 			RuleWithNoUselessUndefinedOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10050,7 +10050,7 @@ export function GET() {
 			},
 			RuleWithNoValueAtRuleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10065,7 +10065,7 @@ export function GET() {
 			},
 			RuleWithNoVarOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10084,7 +10084,7 @@ export function GET() {
 			},
 			RuleWithNoVoidElementsWithChildrenOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10105,7 +10105,7 @@ export function GET() {
 			},
 			RuleWithNoVoidOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10120,7 +10120,7 @@ export function GET() {
 			},
 			RuleWithNoVoidTypeReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10135,7 +10135,7 @@ export function GET() {
 			},
 			RuleWithNoVueDataObjectDeclarationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10156,7 +10156,7 @@ export function GET() {
 			},
 			RuleWithNoVueDuplicateKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10171,7 +10171,7 @@ export function GET() {
 			},
 			RuleWithNoVueReservedKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10186,7 +10186,7 @@ export function GET() {
 			},
 			RuleWithNoVueReservedPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10201,7 +10201,7 @@ export function GET() {
 			},
 			RuleWithNoWithOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10216,7 +10216,7 @@ export function GET() {
 			},
 			RuleWithNoYodaExpressionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10235,7 +10235,7 @@ export function GET() {
 			},
 			RuleWithUseAdjacentOverloadSignaturesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10252,7 +10252,7 @@ export function GET() {
 			},
 			RuleWithUseAltTextOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10267,7 +10267,7 @@ export function GET() {
 			},
 			RuleWithUseAnchorContentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10286,7 +10286,7 @@ export function GET() {
 			},
 			RuleWithUseAriaActivedescendantWithTabindexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10309,7 +10309,7 @@ export function GET() {
 			},
 			RuleWithUseAriaPropsForRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10324,7 +10324,7 @@ export function GET() {
 			},
 			RuleWithUseAriaPropsSupportedByRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10341,7 +10341,7 @@ export function GET() {
 			},
 			RuleWithUseArrayLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10360,7 +10360,7 @@ export function GET() {
 			},
 			RuleWithUseArrowFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10379,7 +10379,7 @@ export function GET() {
 			},
 			RuleWithUseAsConstAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10398,7 +10398,7 @@ export function GET() {
 			},
 			RuleWithUseAtIndexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10417,7 +10417,7 @@ export function GET() {
 			},
 			RuleWithUseAwaitOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10432,7 +10432,7 @@ export function GET() {
 			},
 			RuleWithUseBiomeIgnoreFolderOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10451,7 +10451,7 @@ export function GET() {
 			},
 			RuleWithUseBlockStatementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10470,7 +10470,7 @@ export function GET() {
 			},
 			RuleWithUseButtonTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10485,7 +10485,7 @@ export function GET() {
 			},
 			RuleWithUseCollapsedElseIfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10504,7 +10504,7 @@ export function GET() {
 			},
 			RuleWithUseCollapsedIfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10523,7 +10523,7 @@ export function GET() {
 			},
 			RuleWithUseComponentExportOnlyModulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10540,7 +10540,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentArrayTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10559,7 +10559,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentArrowReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10578,7 +10578,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentBuiltinInstantiationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10601,7 +10601,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentCurlyBracesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10620,7 +10620,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentMemberAccessibilityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10637,7 +10637,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentObjectDefinitionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10658,7 +10658,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentTypeDefinitionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10679,7 +10679,7 @@ export function GET() {
 			},
 			RuleWithUseConstOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10698,7 +10698,7 @@ export function GET() {
 			},
 			RuleWithUseDateNowOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10717,7 +10717,7 @@ export function GET() {
 			},
 			RuleWithUseDefaultParameterLastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10736,7 +10736,7 @@ export function GET() {
 			},
 			RuleWithUseDefaultSwitchClauseLastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10753,7 +10753,7 @@ export function GET() {
 			},
 			RuleWithUseDefaultSwitchClauseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10768,7 +10768,7 @@ export function GET() {
 			},
 			RuleWithUseDeprecatedDateOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10783,7 +10783,7 @@ export function GET() {
 			},
 			RuleWithUseDeprecatedReasonOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10798,7 +10798,7 @@ export function GET() {
 			},
 			RuleWithUseEnumInitializersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10817,7 +10817,7 @@ export function GET() {
 			},
 			RuleWithUseErrorMessageOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10832,7 +10832,7 @@ export function GET() {
 			},
 			RuleWithUseExhaustiveDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10851,7 +10851,7 @@ export function GET() {
 			},
 			RuleWithUseExhaustiveSwitchCasesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10870,7 +10870,7 @@ export function GET() {
 			},
 			RuleWithUseExplicitLengthCheckOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10889,7 +10889,7 @@ export function GET() {
 			},
 			RuleWithUseExplicitTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10904,7 +10904,7 @@ export function GET() {
 			},
 			RuleWithUseExponentiationOperatorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10923,7 +10923,7 @@ export function GET() {
 			},
 			RuleWithUseExportTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10942,7 +10942,7 @@ export function GET() {
 			},
 			RuleWithUseExportsLastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10957,7 +10957,7 @@ export function GET() {
 			},
 			RuleWithUseFilenamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10972,7 +10972,7 @@ export function GET() {
 			},
 			RuleWithUseFlatMapOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10991,7 +10991,7 @@ export function GET() {
 			},
 			RuleWithUseFocusableInteractiveOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11006,7 +11006,7 @@ export function GET() {
 			},
 			RuleWithUseForOfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11021,7 +11021,7 @@ export function GET() {
 			},
 			RuleWithUseFragmentSyntaxOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11040,7 +11040,7 @@ export function GET() {
 			},
 			RuleWithUseGenericFontNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11055,7 +11055,7 @@ export function GET() {
 			},
 			RuleWithUseGetterReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11070,7 +11070,7 @@ export function GET() {
 			},
 			RuleWithUseGoogleFontDisplayOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11085,7 +11085,7 @@ export function GET() {
 			},
 			RuleWithUseGoogleFontPreconnectOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11104,7 +11104,7 @@ export function GET() {
 			},
 			RuleWithUseGraphqlNamedOperationsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11123,7 +11123,7 @@ export function GET() {
 			},
 			RuleWithUseGraphqlNamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11140,7 +11140,7 @@ export function GET() {
 			},
 			RuleWithUseGroupedAccessorPairsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11155,7 +11155,7 @@ export function GET() {
 			},
 			RuleWithUseGuardForInOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11170,7 +11170,7 @@ export function GET() {
 			},
 			RuleWithUseHeadingContentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11185,7 +11185,7 @@ export function GET() {
 			},
 			RuleWithUseHookAtTopLevelOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11200,7 +11200,7 @@ export function GET() {
 			},
 			RuleWithUseHtmlLangOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11215,7 +11215,7 @@ export function GET() {
 			},
 			RuleWithUseIframeTitleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11230,7 +11230,7 @@ export function GET() {
 			},
 			RuleWithUseImageSizeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11245,7 +11245,7 @@ export function GET() {
 			},
 			RuleWithUseImportExtensionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11264,7 +11264,7 @@ export function GET() {
 			},
 			RuleWithUseImportTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11283,7 +11283,7 @@ export function GET() {
 			},
 			RuleWithUseIndexOfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11302,7 +11302,7 @@ export function GET() {
 			},
 			RuleWithUseIsArrayOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11321,7 +11321,7 @@ export function GET() {
 			},
 			RuleWithUseIsNanOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11340,7 +11340,7 @@ export function GET() {
 			},
 			RuleWithUseIterableCallbackReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11355,7 +11355,7 @@ export function GET() {
 			},
 			RuleWithUseJsonImportAttributesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11374,7 +11374,7 @@ export function GET() {
 			},
 			RuleWithUseJsxKeyInIterableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11389,7 +11389,7 @@ export function GET() {
 			},
 			RuleWithUseKeyWithClickEventsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11404,7 +11404,7 @@ export function GET() {
 			},
 			RuleWithUseKeyWithMouseEventsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11419,7 +11419,7 @@ export function GET() {
 			},
 			RuleWithUseLiteralEnumMembersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11434,7 +11434,7 @@ export function GET() {
 			},
 			RuleWithUseLiteralKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11453,7 +11453,7 @@ export function GET() {
 			},
 			RuleWithUseMaxParamsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11468,7 +11468,7 @@ export function GET() {
 			},
 			RuleWithUseMediaCaptionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11483,7 +11483,7 @@ export function GET() {
 			},
 			RuleWithUseNamespaceKeywordOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11502,7 +11502,7 @@ export function GET() {
 			},
 			RuleWithUseNamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11521,7 +11521,7 @@ export function GET() {
 			},
 			RuleWithUseNodeAssertStrictOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11540,7 +11540,7 @@ export function GET() {
 			},
 			RuleWithUseNodejsImportProtocolOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11559,7 +11559,7 @@ export function GET() {
 			},
 			RuleWithUseNumberNamespaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11578,7 +11578,7 @@ export function GET() {
 			},
 			RuleWithUseNumberToFixedDigitsArgumentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11599,7 +11599,7 @@ export function GET() {
 			},
 			RuleWithUseNumericLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11618,7 +11618,7 @@ export function GET() {
 			},
 			RuleWithUseNumericSeparatorsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11637,7 +11637,7 @@ export function GET() {
 			},
 			RuleWithUseObjectSpreadOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11656,7 +11656,7 @@ export function GET() {
 			},
 			RuleWithUseOptionalChainOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11675,7 +11675,7 @@ export function GET() {
 			},
 			RuleWithUseParseIntRadixOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11694,7 +11694,7 @@ export function GET() {
 			},
 			RuleWithUseQwikClasslistOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11709,7 +11709,7 @@ export function GET() {
 			},
 			RuleWithUseQwikMethodUsageOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11724,7 +11724,7 @@ export function GET() {
 			},
 			RuleWithUseQwikValidLexicalScopeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11739,7 +11739,7 @@ export function GET() {
 			},
 			RuleWithUseReactFunctionComponentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11756,7 +11756,7 @@ export function GET() {
 			},
 			RuleWithUseReadonlyClassPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11777,7 +11777,7 @@ export function GET() {
 			},
 			RuleWithUseRegexLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11796,7 +11796,7 @@ export function GET() {
 			},
 			RuleWithUseSelfClosingElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11815,7 +11815,7 @@ export function GET() {
 			},
 			RuleWithUseSemanticElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11830,7 +11830,7 @@ export function GET() {
 			},
 			RuleWithUseShorthandAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11849,7 +11849,7 @@ export function GET() {
 			},
 			RuleWithUseShorthandFunctionTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11868,7 +11868,7 @@ export function GET() {
 			},
 			RuleWithUseSimpleNumberKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11887,7 +11887,7 @@ export function GET() {
 			},
 			RuleWithUseSimplifiedLogicExpressionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11908,7 +11908,7 @@ export function GET() {
 			},
 			RuleWithUseSingleJsDocAsteriskOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11927,7 +11927,7 @@ export function GET() {
 			},
 			RuleWithUseSingleVarDeclaratorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11946,7 +11946,7 @@ export function GET() {
 			},
 			RuleWithUseSolidForComponentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11961,7 +11961,7 @@ export function GET() {
 			},
 			RuleWithUseSortedClassesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11980,7 +11980,7 @@ export function GET() {
 			},
 			RuleWithUseStaticResponseMethodsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11999,7 +11999,7 @@ export function GET() {
 			},
 			RuleWithUseStrictModeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12018,7 +12018,7 @@ export function GET() {
 			},
 			RuleWithUseSymbolDescriptionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12033,7 +12033,7 @@ export function GET() {
 			},
 			RuleWithUseTemplateOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12052,7 +12052,7 @@ export function GET() {
 			},
 			RuleWithUseThrowNewErrorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12071,7 +12071,7 @@ export function GET() {
 			},
 			RuleWithUseThrowOnlyErrorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12086,7 +12086,7 @@ export function GET() {
 			},
 			RuleWithUseTopLevelRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12101,7 +12101,7 @@ export function GET() {
 			},
 			RuleWithUseTrimStartEndOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12120,7 +12120,7 @@ export function GET() {
 			},
 			RuleWithUseUnifiedTypeSignaturesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12139,7 +12139,7 @@ export function GET() {
 			},
 			RuleWithUseUniqueElementIdsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12154,7 +12154,7 @@ export function GET() {
 			},
 			RuleWithUseValidAnchorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12169,7 +12169,7 @@ export function GET() {
 			},
 			RuleWithUseValidAriaPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12188,7 +12188,7 @@ export function GET() {
 			},
 			RuleWithUseValidAriaRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12207,7 +12207,7 @@ export function GET() {
 			},
 			RuleWithUseValidAriaValuesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12222,7 +12222,7 @@ export function GET() {
 			},
 			RuleWithUseValidAutocompleteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12237,7 +12237,7 @@ export function GET() {
 			},
 			RuleWithUseValidForDirectionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12252,7 +12252,7 @@ export function GET() {
 			},
 			RuleWithUseValidLangOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12267,7 +12267,7 @@ export function GET() {
 			},
 			RuleWithUseValidTypeofOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12286,7 +12286,7 @@ export function GET() {
 			},
 			RuleWithUseVueDefineMacrosOrderOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12305,7 +12305,7 @@ export function GET() {
 			},
 			RuleWithUseVueMultiWordComponentNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12322,7 +12322,7 @@ export function GET() {
 			},
 			RuleWithUseWhileOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12341,7 +12341,7 @@ export function GET() {
 			},
 			RuleWithUseYieldOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",

--- a/src/pages/schemas/latest/schema.json.js
+++ b/src/pages/schemas/latest/schema.json.js
@@ -6046,7 +6046,7 @@ export function GET() {
 			RuleAssistPlainConfiguration: { type: "string", enum: ["off", "on"] },
 			RuleAssistWithOptions_for_OrganizeImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6061,7 +6061,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_UseSortedAttributesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6076,7 +6076,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_UseSortedKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6091,7 +6091,7 @@ export function GET() {
 			},
 			RuleAssistWithOptions_for_UseSortedPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6201,7 +6201,7 @@ export function GET() {
 			},
 			RuleWithNoAccessKeyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6220,7 +6220,7 @@ export function GET() {
 			},
 			RuleWithNoAccumulatingSpreadOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6235,7 +6235,7 @@ export function GET() {
 			},
 			RuleWithNoAdjacentSpacesInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6254,7 +6254,7 @@ export function GET() {
 			},
 			RuleWithNoAlertOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6269,7 +6269,7 @@ export function GET() {
 			},
 			RuleWithNoApproximativeNumericConstantOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6290,7 +6290,7 @@ export function GET() {
 			},
 			RuleWithNoArgumentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6305,7 +6305,7 @@ export function GET() {
 			},
 			RuleWithNoAriaHiddenOnFocusableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6324,7 +6324,7 @@ export function GET() {
 			},
 			RuleWithNoAriaUnsupportedElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6343,7 +6343,7 @@ export function GET() {
 			},
 			RuleWithNoArrayIndexKeyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6358,7 +6358,7 @@ export function GET() {
 			},
 			RuleWithNoAssignInExpressionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6373,7 +6373,7 @@ export function GET() {
 			},
 			RuleWithNoAsyncPromiseExecutorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6388,7 +6388,7 @@ export function GET() {
 			},
 			RuleWithNoAutofocusOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6407,7 +6407,7 @@ export function GET() {
 			},
 			RuleWithNoAwaitInLoopsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6422,7 +6422,7 @@ export function GET() {
 			},
 			RuleWithNoBannedTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6441,7 +6441,7 @@ export function GET() {
 			},
 			RuleWithNoBarrelFileOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6456,7 +6456,7 @@ export function GET() {
 			},
 			RuleWithNoBiomeFirstExceptionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6475,7 +6475,7 @@ export function GET() {
 			},
 			RuleWithNoBitwiseOperatorsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6490,7 +6490,7 @@ export function GET() {
 			},
 			RuleWithNoBlankTargetOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6509,7 +6509,7 @@ export function GET() {
 			},
 			RuleWithNoCatchAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6524,7 +6524,7 @@ export function GET() {
 			},
 			RuleWithNoChildrenPropOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6539,7 +6539,7 @@ export function GET() {
 			},
 			RuleWithNoClassAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6554,7 +6554,7 @@ export function GET() {
 			},
 			RuleWithNoCommaOperatorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6569,7 +6569,7 @@ export function GET() {
 			},
 			RuleWithNoCommentTextOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6588,7 +6588,7 @@ export function GET() {
 			},
 			RuleWithNoCommonJsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6603,7 +6603,7 @@ export function GET() {
 			},
 			RuleWithNoCompareNegZeroOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6622,7 +6622,7 @@ export function GET() {
 			},
 			RuleWithNoConfusingLabelsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6637,7 +6637,7 @@ export function GET() {
 			},
 			RuleWithNoConfusingVoidTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6656,7 +6656,7 @@ export function GET() {
 			},
 			RuleWithNoConsoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6675,7 +6675,7 @@ export function GET() {
 			},
 			RuleWithNoConstAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6694,7 +6694,7 @@ export function GET() {
 			},
 			RuleWithNoConstEnumOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6713,7 +6713,7 @@ export function GET() {
 			},
 			RuleWithNoConstantBinaryExpressionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6730,7 +6730,7 @@ export function GET() {
 			},
 			RuleWithNoConstantConditionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6745,7 +6745,7 @@ export function GET() {
 			},
 			RuleWithNoConstantMathMinMaxClampOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6764,7 +6764,7 @@ export function GET() {
 			},
 			RuleWithNoConstructorReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6779,7 +6779,7 @@ export function GET() {
 			},
 			RuleWithNoControlCharactersInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6796,7 +6796,7 @@ export function GET() {
 			},
 			RuleWithNoDangerouslySetInnerHtmlOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6811,7 +6811,7 @@ export function GET() {
 			},
 			RuleWithNoDangerouslySetInnerHtmlWithChildrenOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6830,7 +6830,7 @@ export function GET() {
 			},
 			RuleWithNoDebuggerOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6849,7 +6849,7 @@ export function GET() {
 			},
 			RuleWithNoDefaultExportOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6864,7 +6864,7 @@ export function GET() {
 			},
 			RuleWithNoDeleteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6883,7 +6883,7 @@ export function GET() {
 			},
 			RuleWithNoDeprecatedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6898,7 +6898,7 @@ export function GET() {
 			},
 			RuleWithNoDescendingSpecificityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6913,7 +6913,7 @@ export function GET() {
 			},
 			RuleWithNoDistractingElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6932,7 +6932,7 @@ export function GET() {
 			},
 			RuleWithNoDocumentCookieOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6947,7 +6947,7 @@ export function GET() {
 			},
 			RuleWithNoDocumentImportInPageOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6962,7 +6962,7 @@ export function GET() {
 			},
 			RuleWithNoDoneCallbackOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -6977,7 +6977,7 @@ export function GET() {
 			},
 			RuleWithNoDoubleEqualsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -6996,7 +6996,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateAtImportRulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7011,7 +7011,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateCaseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7026,7 +7026,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateClassMembersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7041,7 +7041,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateCustomPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7058,7 +7058,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7073,7 +7073,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateElseIfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7088,7 +7088,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateFieldsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7103,7 +7103,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateFontNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7118,7 +7118,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateJsxPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7133,7 +7133,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateObjectKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7148,7 +7148,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateParametersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7163,7 +7163,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicatePropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7178,7 +7178,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateSelectorsKeyframeBlockOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7197,7 +7197,7 @@ export function GET() {
 			},
 			RuleWithNoDuplicateTestHooksOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7212,7 +7212,7 @@ export function GET() {
 			},
 			RuleWithNoDynamicNamespaceImportAccessOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7229,7 +7229,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyBlockOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7244,7 +7244,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyBlockStatementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7259,7 +7259,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyCharacterClassInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7276,7 +7276,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyInterfaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7295,7 +7295,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyPatternOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7310,7 +7310,7 @@ export function GET() {
 			},
 			RuleWithNoEmptySourceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7325,7 +7325,7 @@ export function GET() {
 			},
 			RuleWithNoEmptyTypeParametersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7340,7 +7340,7 @@ export function GET() {
 			},
 			RuleWithNoEnumOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7355,7 +7355,7 @@ export function GET() {
 			},
 			RuleWithNoEvolvingTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7370,7 +7370,7 @@ export function GET() {
 			},
 			RuleWithNoExcessiveCognitiveComplexityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7387,7 +7387,7 @@ export function GET() {
 			},
 			RuleWithNoExcessiveLinesPerFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7404,7 +7404,7 @@ export function GET() {
 			},
 			RuleWithNoExcessiveNestedTestSuitesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7421,7 +7421,7 @@ export function GET() {
 			},
 			RuleWithNoExplicitAnyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7436,7 +7436,7 @@ export function GET() {
 			},
 			RuleWithNoExportedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7451,7 +7451,7 @@ export function GET() {
 			},
 			RuleWithNoExportsInTestOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7466,7 +7466,7 @@ export function GET() {
 			},
 			RuleWithNoExtraBooleanCastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7485,7 +7485,7 @@ export function GET() {
 			},
 			RuleWithNoExtraNonNullAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7504,7 +7504,7 @@ export function GET() {
 			},
 			RuleWithNoFallthroughSwitchClauseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7519,7 +7519,7 @@ export function GET() {
 			},
 			RuleWithNoFlatMapIdentityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7538,7 +7538,7 @@ export function GET() {
 			},
 			RuleWithNoFloatingPromisesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7557,7 +7557,7 @@ export function GET() {
 			},
 			RuleWithNoFocusedTestsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7576,7 +7576,7 @@ export function GET() {
 			},
 			RuleWithNoForEachOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7591,7 +7591,7 @@ export function GET() {
 			},
 			RuleWithNoFunctionAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7606,7 +7606,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7621,7 +7621,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalDirnameFilenameOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7640,7 +7640,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalEvalOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7655,7 +7655,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalIsFiniteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7674,7 +7674,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalIsNanOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7693,7 +7693,7 @@ export function GET() {
 			},
 			RuleWithNoGlobalObjectCallsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7708,7 +7708,7 @@ export function GET() {
 			},
 			RuleWithNoHeadElementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7723,7 +7723,7 @@ export function GET() {
 			},
 			RuleWithNoHeadImportInDocumentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7738,7 +7738,7 @@ export function GET() {
 			},
 			RuleWithNoHeaderScopeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7757,7 +7757,7 @@ export function GET() {
 			},
 			RuleWithNoImgElementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7772,7 +7772,7 @@ export function GET() {
 			},
 			RuleWithNoImplicitAnyLetOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7787,7 +7787,7 @@ export function GET() {
 			},
 			RuleWithNoImplicitBooleanOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7806,7 +7806,7 @@ export function GET() {
 			},
 			RuleWithNoImplicitCoercionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7825,7 +7825,7 @@ export function GET() {
 			},
 			RuleWithNoImportAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7840,7 +7840,7 @@ export function GET() {
 			},
 			RuleWithNoImportCyclesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7855,7 +7855,7 @@ export function GET() {
 			},
 			RuleWithNoImportantInKeyframeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7870,7 +7870,7 @@ export function GET() {
 			},
 			RuleWithNoImportantStylesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7889,7 +7889,7 @@ export function GET() {
 			},
 			RuleWithNoIncrementDecrementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7904,7 +7904,7 @@ export function GET() {
 			},
 			RuleWithNoInferrableTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7923,7 +7923,7 @@ export function GET() {
 			},
 			RuleWithNoInnerDeclarationsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7938,7 +7938,7 @@ export function GET() {
 			},
 			RuleWithNoInteractiveElementToNoninteractiveRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7961,7 +7961,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidBuiltinInstantiationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -7982,7 +7982,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidConstructorSuperOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -7997,7 +7997,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidDirectionInLinearGradientOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8016,7 +8016,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidGridAreasOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8031,7 +8031,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidPositionAtImportRuleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8048,7 +8048,7 @@ export function GET() {
 			},
 			RuleWithNoInvalidUseBeforeDeclarationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8065,7 +8065,7 @@ export function GET() {
 			},
 			RuleWithNoIrregularWhitespaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8080,7 +8080,7 @@ export function GET() {
 			},
 			RuleWithNoJsxLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8095,7 +8095,7 @@ export function GET() {
 			},
 			RuleWithNoLabelVarOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8110,7 +8110,7 @@ export function GET() {
 			},
 			RuleWithNoLabelWithoutControlOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8125,7 +8125,7 @@ export function GET() {
 			},
 			RuleWithNoMagicNumbersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8140,7 +8140,7 @@ export function GET() {
 			},
 			RuleWithNoMisleadingCharacterClassOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8161,7 +8161,7 @@ export function GET() {
 			},
 			RuleWithNoMisleadingInstantiatorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8176,7 +8176,7 @@ export function GET() {
 			},
 			RuleWithNoMisplacedAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8191,7 +8191,7 @@ export function GET() {
 			},
 			RuleWithNoMisrefactoredShorthandAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8212,7 +8212,7 @@ export function GET() {
 			},
 			RuleWithNoMissingVarFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8227,7 +8227,7 @@ export function GET() {
 			},
 			RuleWithNoMisusedPromisesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8246,7 +8246,7 @@ export function GET() {
 			},
 			RuleWithNoNamespaceImportOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8261,7 +8261,7 @@ export function GET() {
 			},
 			RuleWithNoNamespaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8276,7 +8276,7 @@ export function GET() {
 			},
 			RuleWithNoNegationElseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8295,7 +8295,7 @@ export function GET() {
 			},
 			RuleWithNoNestedComponentDefinitionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8312,7 +8312,7 @@ export function GET() {
 			},
 			RuleWithNoNestedTernaryOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8327,7 +8327,7 @@ export function GET() {
 			},
 			RuleWithNoNextAsyncClientComponentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8344,7 +8344,7 @@ export function GET() {
 			},
 			RuleWithNoNodejsModulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8359,7 +8359,7 @@ export function GET() {
 			},
 			RuleWithNoNonNullAssertedOptionalChainOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8376,7 +8376,7 @@ export function GET() {
 			},
 			RuleWithNoNonNullAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8395,7 +8395,7 @@ export function GET() {
 			},
 			RuleWithNoNoninteractiveElementInteractionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8414,7 +8414,7 @@ export function GET() {
 			},
 			RuleWithNoNoninteractiveElementToInteractiveRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8437,7 +8437,7 @@ export function GET() {
 			},
 			RuleWithNoNoninteractiveTabindexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8456,7 +8456,7 @@ export function GET() {
 			},
 			RuleWithNoNonoctalDecimalEscapeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8475,7 +8475,7 @@ export function GET() {
 			},
 			RuleWithNoOctalEscapeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8494,7 +8494,7 @@ export function GET() {
 			},
 			RuleWithNoParameterAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8509,7 +8509,7 @@ export function GET() {
 			},
 			RuleWithNoParameterPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8545,7 +8545,7 @@ export function GET() {
 			},
 			RuleWithNoPositiveTabindexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8564,7 +8564,7 @@ export function GET() {
 			},
 			RuleWithNoPrecisionLossOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8579,7 +8579,7 @@ export function GET() {
 			},
 			RuleWithNoPrivateImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8594,7 +8594,7 @@ export function GET() {
 			},
 			RuleWithNoProcessEnvOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8609,7 +8609,7 @@ export function GET() {
 			},
 			RuleWithNoProcessGlobalOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8628,7 +8628,7 @@ export function GET() {
 			},
 			RuleWithNoPrototypeBuiltinsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8647,7 +8647,7 @@ export function GET() {
 			},
 			RuleWithNoQuickfixBiomeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8666,7 +8666,7 @@ export function GET() {
 			},
 			RuleWithNoQwikUseVisibleTaskOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8681,7 +8681,7 @@ export function GET() {
 			},
 			RuleWithNoReExportAllOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8696,7 +8696,7 @@ export function GET() {
 			},
 			RuleWithNoReactForwardRefOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8715,7 +8715,7 @@ export function GET() {
 			},
 			RuleWithNoReactPropAssignmentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8730,7 +8730,7 @@ export function GET() {
 			},
 			RuleWithNoReactSpecificPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8749,7 +8749,7 @@ export function GET() {
 			},
 			RuleWithNoRedeclareOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8764,7 +8764,7 @@ export function GET() {
 			},
 			RuleWithNoRedundantAltOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8779,7 +8779,7 @@ export function GET() {
 			},
 			RuleWithNoRedundantRolesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8798,7 +8798,7 @@ export function GET() {
 			},
 			RuleWithNoRedundantUseStrictOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8817,7 +8817,7 @@ export function GET() {
 			},
 			RuleWithNoRenderReturnValueOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8832,7 +8832,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8847,7 +8847,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedGlobalsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8862,7 +8862,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8877,7 +8877,7 @@ export function GET() {
 			},
 			RuleWithNoRestrictedTypesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -8896,7 +8896,7 @@ export function GET() {
 			},
 			RuleWithNoSecretsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8911,7 +8911,7 @@ export function GET() {
 			},
 			RuleWithNoSelfAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8926,7 +8926,7 @@ export function GET() {
 			},
 			RuleWithNoSelfCompareOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8941,7 +8941,7 @@ export function GET() {
 			},
 			RuleWithNoSetterReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8956,7 +8956,7 @@ export function GET() {
 			},
 			RuleWithNoShadowOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8971,7 +8971,7 @@ export function GET() {
 			},
 			RuleWithNoShadowRestrictedNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -8986,7 +8986,7 @@ export function GET() {
 			},
 			RuleWithNoShorthandPropertyOverridesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9003,7 +9003,7 @@ export function GET() {
 			},
 			RuleWithNoShoutyConstantsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9022,7 +9022,7 @@ export function GET() {
 			},
 			RuleWithNoSkippedTestsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9041,7 +9041,7 @@ export function GET() {
 			},
 			RuleWithNoSolidDestructuredPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9056,7 +9056,7 @@ export function GET() {
 			},
 			RuleWithNoSparseArrayOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9075,7 +9075,7 @@ export function GET() {
 			},
 			RuleWithNoStaticElementInteractionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9092,7 +9092,7 @@ export function GET() {
 			},
 			RuleWithNoStaticOnlyClassOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9107,7 +9107,7 @@ export function GET() {
 			},
 			RuleWithNoStringCaseMismatchOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9126,7 +9126,7 @@ export function GET() {
 			},
 			RuleWithNoSubstrOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9145,7 +9145,7 @@ export function GET() {
 			},
 			RuleWithNoSuspiciousSemicolonInJsxOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9162,7 +9162,7 @@ export function GET() {
 			},
 			RuleWithNoSvgWithoutTitleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9177,7 +9177,7 @@ export function GET() {
 			},
 			RuleWithNoSwitchDeclarationsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9196,7 +9196,7 @@ export function GET() {
 			},
 			RuleWithNoTemplateCurlyInStringOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9211,7 +9211,7 @@ export function GET() {
 			},
 			RuleWithNoThenPropertyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9226,7 +9226,7 @@ export function GET() {
 			},
 			RuleWithNoThisInStaticOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9245,7 +9245,7 @@ export function GET() {
 			},
 			RuleWithNoTsIgnoreOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9264,7 +9264,7 @@ export function GET() {
 			},
 			RuleWithNoUnassignedVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9279,7 +9279,7 @@ export function GET() {
 			},
 			RuleWithNoUndeclaredDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9294,7 +9294,7 @@ export function GET() {
 			},
 			RuleWithNoUndeclaredVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9309,7 +9309,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownAtRulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9339,7 +9339,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9354,7 +9354,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownMediaFeatureNameOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9369,7 +9369,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownPropertyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9384,7 +9384,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownPseudoClassOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9399,7 +9399,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownPseudoElementOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9414,7 +9414,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownTypeSelectorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9429,7 +9429,7 @@ export function GET() {
 			},
 			RuleWithNoUnknownUnitOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9444,7 +9444,7 @@ export function GET() {
 			},
 			RuleWithNoUnmatchableAnbSelectorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9459,7 +9459,7 @@ export function GET() {
 			},
 			RuleWithNoUnnecessaryConditionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9474,7 +9474,7 @@ export function GET() {
 			},
 			RuleWithNoUnreachableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9489,7 +9489,7 @@ export function GET() {
 			},
 			RuleWithNoUnreachableSuperOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9504,7 +9504,7 @@ export function GET() {
 			},
 			RuleWithNoUnresolvedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9519,7 +9519,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeDeclarationMergingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9536,7 +9536,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeFinallyOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9551,7 +9551,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeNegationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9570,7 +9570,7 @@ export function GET() {
 			},
 			RuleWithNoUnsafeOptionalChainingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9585,7 +9585,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedExpressionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9600,7 +9600,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedFunctionParametersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9621,7 +9621,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedImportsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9640,7 +9640,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedLabelsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9659,7 +9659,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedPrivateClassMembersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9680,7 +9680,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedTemplateLiteralOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9699,7 +9699,7 @@ export function GET() {
 			},
 			RuleWithNoUnusedVariablesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9718,7 +9718,7 @@ export function GET() {
 			},
 			RuleWithNoUnwantedPolyfillioOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9733,7 +9733,7 @@ export function GET() {
 			},
 			RuleWithNoUselessCatchBindingOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9752,7 +9752,7 @@ export function GET() {
 			},
 			RuleWithNoUselessCatchOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9771,7 +9771,7 @@ export function GET() {
 			},
 			RuleWithNoUselessConstructorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9790,7 +9790,7 @@ export function GET() {
 			},
 			RuleWithNoUselessContinueOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9809,7 +9809,7 @@ export function GET() {
 			},
 			RuleWithNoUselessElseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9828,7 +9828,7 @@ export function GET() {
 			},
 			RuleWithNoUselessEmptyExportOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9847,7 +9847,7 @@ export function GET() {
 			},
 			RuleWithNoUselessEscapeInRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9866,7 +9866,7 @@ export function GET() {
 			},
 			RuleWithNoUselessEscapeInStringOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9885,7 +9885,7 @@ export function GET() {
 			},
 			RuleWithNoUselessFragmentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9904,7 +9904,7 @@ export function GET() {
 			},
 			RuleWithNoUselessLabelOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9923,7 +9923,7 @@ export function GET() {
 			},
 			RuleWithNoUselessLoneBlockStatementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9944,7 +9944,7 @@ export function GET() {
 			},
 			RuleWithNoUselessRegexBackrefsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -9959,7 +9959,7 @@ export function GET() {
 			},
 			RuleWithNoUselessRenameOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9978,7 +9978,7 @@ export function GET() {
 			},
 			RuleWithNoUselessStringConcatOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -9997,7 +9997,7 @@ export function GET() {
 			},
 			RuleWithNoUselessStringRawOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10012,7 +10012,7 @@ export function GET() {
 			},
 			RuleWithNoUselessSwitchCaseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10031,7 +10031,7 @@ export function GET() {
 			},
 			RuleWithNoUselessTernaryOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10050,7 +10050,7 @@ export function GET() {
 			},
 			RuleWithNoUselessThisAliasOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10069,7 +10069,7 @@ export function GET() {
 			},
 			RuleWithNoUselessTypeConstraintOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10088,7 +10088,7 @@ export function GET() {
 			},
 			RuleWithNoUselessUndefinedInitializationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10109,7 +10109,7 @@ export function GET() {
 			},
 			RuleWithNoUselessUndefinedOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10128,7 +10128,7 @@ export function GET() {
 			},
 			RuleWithNoValueAtRuleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10143,7 +10143,7 @@ export function GET() {
 			},
 			RuleWithNoVarOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10162,7 +10162,7 @@ export function GET() {
 			},
 			RuleWithNoVoidElementsWithChildrenOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10183,7 +10183,7 @@ export function GET() {
 			},
 			RuleWithNoVoidOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10198,7 +10198,7 @@ export function GET() {
 			},
 			RuleWithNoVoidTypeReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10213,7 +10213,7 @@ export function GET() {
 			},
 			RuleWithNoVueDataObjectDeclarationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10234,7 +10234,7 @@ export function GET() {
 			},
 			RuleWithNoVueDuplicateKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10249,7 +10249,7 @@ export function GET() {
 			},
 			RuleWithNoVueReservedKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10264,7 +10264,7 @@ export function GET() {
 			},
 			RuleWithNoVueReservedPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10279,7 +10279,7 @@ export function GET() {
 			},
 			RuleWithNoWithOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10294,7 +10294,7 @@ export function GET() {
 			},
 			RuleWithNoYodaExpressionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10313,7 +10313,7 @@ export function GET() {
 			},
 			RuleWithUseAdjacentOverloadSignaturesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10330,7 +10330,7 @@ export function GET() {
 			},
 			RuleWithUseAltTextOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10345,7 +10345,7 @@ export function GET() {
 			},
 			RuleWithUseAnchorContentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10364,7 +10364,7 @@ export function GET() {
 			},
 			RuleWithUseAriaActivedescendantWithTabindexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10387,7 +10387,7 @@ export function GET() {
 			},
 			RuleWithUseAriaPropsForRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10402,7 +10402,7 @@ export function GET() {
 			},
 			RuleWithUseAriaPropsSupportedByRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10419,7 +10419,7 @@ export function GET() {
 			},
 			RuleWithUseArrayLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10438,7 +10438,7 @@ export function GET() {
 			},
 			RuleWithUseArrowFunctionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10457,7 +10457,7 @@ export function GET() {
 			},
 			RuleWithUseAsConstAssertionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10476,7 +10476,7 @@ export function GET() {
 			},
 			RuleWithUseAtIndexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10495,7 +10495,7 @@ export function GET() {
 			},
 			RuleWithUseAwaitOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10510,7 +10510,7 @@ export function GET() {
 			},
 			RuleWithUseBiomeIgnoreFolderOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10529,7 +10529,7 @@ export function GET() {
 			},
 			RuleWithUseBlockStatementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10548,7 +10548,7 @@ export function GET() {
 			},
 			RuleWithUseButtonTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10563,7 +10563,7 @@ export function GET() {
 			},
 			RuleWithUseCollapsedElseIfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10582,7 +10582,7 @@ export function GET() {
 			},
 			RuleWithUseCollapsedIfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10601,7 +10601,7 @@ export function GET() {
 			},
 			RuleWithUseComponentExportOnlyModulesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10618,7 +10618,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentArrayTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10637,7 +10637,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentArrowReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10656,7 +10656,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentBuiltinInstantiationOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10679,7 +10679,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentCurlyBracesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10698,7 +10698,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentMemberAccessibilityOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10715,7 +10715,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentObjectDefinitionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10736,7 +10736,7 @@ export function GET() {
 			},
 			RuleWithUseConsistentTypeDefinitionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10757,7 +10757,7 @@ export function GET() {
 			},
 			RuleWithUseConstOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10776,7 +10776,7 @@ export function GET() {
 			},
 			RuleWithUseDateNowOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10795,7 +10795,7 @@ export function GET() {
 			},
 			RuleWithUseDefaultParameterLastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10814,7 +10814,7 @@ export function GET() {
 			},
 			RuleWithUseDefaultSwitchClauseLastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10831,7 +10831,7 @@ export function GET() {
 			},
 			RuleWithUseDefaultSwitchClauseOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10846,7 +10846,7 @@ export function GET() {
 			},
 			RuleWithUseDeprecatedDateOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10861,7 +10861,7 @@ export function GET() {
 			},
 			RuleWithUseDeprecatedReasonOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10876,7 +10876,7 @@ export function GET() {
 			},
 			RuleWithUseEnumInitializersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10895,7 +10895,7 @@ export function GET() {
 			},
 			RuleWithUseErrorMessageOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10910,7 +10910,7 @@ export function GET() {
 			},
 			RuleWithUseExhaustiveDependenciesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10929,7 +10929,7 @@ export function GET() {
 			},
 			RuleWithUseExhaustiveSwitchCasesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10948,7 +10948,7 @@ export function GET() {
 			},
 			RuleWithUseExplicitLengthCheckOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -10967,7 +10967,7 @@ export function GET() {
 			},
 			RuleWithUseExplicitTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -10982,7 +10982,7 @@ export function GET() {
 			},
 			RuleWithUseExponentiationOperatorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11001,7 +11001,7 @@ export function GET() {
 			},
 			RuleWithUseExportTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11020,7 +11020,7 @@ export function GET() {
 			},
 			RuleWithUseExportsLastOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11035,7 +11035,7 @@ export function GET() {
 			},
 			RuleWithUseFilenamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11050,7 +11050,7 @@ export function GET() {
 			},
 			RuleWithUseFlatMapOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11069,7 +11069,7 @@ export function GET() {
 			},
 			RuleWithUseFocusableInteractiveOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11084,7 +11084,7 @@ export function GET() {
 			},
 			RuleWithUseForOfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11099,7 +11099,7 @@ export function GET() {
 			},
 			RuleWithUseFragmentSyntaxOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11118,7 +11118,7 @@ export function GET() {
 			},
 			RuleWithUseGenericFontNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11133,7 +11133,7 @@ export function GET() {
 			},
 			RuleWithUseGetterReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11148,7 +11148,7 @@ export function GET() {
 			},
 			RuleWithUseGoogleFontDisplayOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11163,7 +11163,7 @@ export function GET() {
 			},
 			RuleWithUseGoogleFontPreconnectOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11182,7 +11182,7 @@ export function GET() {
 			},
 			RuleWithUseGraphqlNamedOperationsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11201,7 +11201,7 @@ export function GET() {
 			},
 			RuleWithUseGraphqlNamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11218,7 +11218,7 @@ export function GET() {
 			},
 			RuleWithUseGroupedAccessorPairsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11233,7 +11233,7 @@ export function GET() {
 			},
 			RuleWithUseGuardForInOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11248,7 +11248,7 @@ export function GET() {
 			},
 			RuleWithUseHeadingContentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11263,7 +11263,7 @@ export function GET() {
 			},
 			RuleWithUseHookAtTopLevelOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11278,7 +11278,7 @@ export function GET() {
 			},
 			RuleWithUseHtmlLangOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11293,7 +11293,7 @@ export function GET() {
 			},
 			RuleWithUseIframeTitleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11308,7 +11308,7 @@ export function GET() {
 			},
 			RuleWithUseImageSizeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11323,7 +11323,7 @@ export function GET() {
 			},
 			RuleWithUseImportExtensionsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11342,7 +11342,7 @@ export function GET() {
 			},
 			RuleWithUseImportTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11361,7 +11361,7 @@ export function GET() {
 			},
 			RuleWithUseIndexOfOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11380,7 +11380,7 @@ export function GET() {
 			},
 			RuleWithUseIsArrayOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11399,7 +11399,7 @@ export function GET() {
 			},
 			RuleWithUseIsNanOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11418,7 +11418,7 @@ export function GET() {
 			},
 			RuleWithUseIterableCallbackReturnOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11433,7 +11433,7 @@ export function GET() {
 			},
 			RuleWithUseJsonImportAttributesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11452,7 +11452,7 @@ export function GET() {
 			},
 			RuleWithUseJsxKeyInIterableOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11467,7 +11467,7 @@ export function GET() {
 			},
 			RuleWithUseKeyWithClickEventsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11482,7 +11482,7 @@ export function GET() {
 			},
 			RuleWithUseKeyWithMouseEventsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11497,7 +11497,7 @@ export function GET() {
 			},
 			RuleWithUseLiteralEnumMembersOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11512,7 +11512,7 @@ export function GET() {
 			},
 			RuleWithUseLiteralKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11531,7 +11531,7 @@ export function GET() {
 			},
 			RuleWithUseMaxParamsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11546,7 +11546,7 @@ export function GET() {
 			},
 			RuleWithUseMediaCaptionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11561,7 +11561,7 @@ export function GET() {
 			},
 			RuleWithUseNamespaceKeywordOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11580,7 +11580,7 @@ export function GET() {
 			},
 			RuleWithUseNamingConventionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11599,7 +11599,7 @@ export function GET() {
 			},
 			RuleWithUseNodeAssertStrictOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11618,7 +11618,7 @@ export function GET() {
 			},
 			RuleWithUseNodejsImportProtocolOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11637,7 +11637,7 @@ export function GET() {
 			},
 			RuleWithUseNumberNamespaceOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11656,7 +11656,7 @@ export function GET() {
 			},
 			RuleWithUseNumberToFixedDigitsArgumentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11677,7 +11677,7 @@ export function GET() {
 			},
 			RuleWithUseNumericLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11696,7 +11696,7 @@ export function GET() {
 			},
 			RuleWithUseNumericSeparatorsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11715,7 +11715,7 @@ export function GET() {
 			},
 			RuleWithUseObjectSpreadOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11734,7 +11734,7 @@ export function GET() {
 			},
 			RuleWithUseOptionalChainOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11753,7 +11753,7 @@ export function GET() {
 			},
 			RuleWithUseParseIntRadixOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11772,7 +11772,7 @@ export function GET() {
 			},
 			RuleWithUseQwikClasslistOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11787,7 +11787,7 @@ export function GET() {
 			},
 			RuleWithUseQwikMethodUsageOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11802,7 +11802,7 @@ export function GET() {
 			},
 			RuleWithUseQwikValidLexicalScopeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11817,7 +11817,7 @@ export function GET() {
 			},
 			RuleWithUseReactFunctionComponentsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11834,7 +11834,7 @@ export function GET() {
 			},
 			RuleWithUseReadonlyClassPropertiesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11855,7 +11855,7 @@ export function GET() {
 			},
 			RuleWithUseRegexLiteralsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11874,7 +11874,7 @@ export function GET() {
 			},
 			RuleWithUseSelfClosingElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11893,7 +11893,7 @@ export function GET() {
 			},
 			RuleWithUseSemanticElementsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -11908,7 +11908,7 @@ export function GET() {
 			},
 			RuleWithUseShorthandAssignOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11927,7 +11927,7 @@ export function GET() {
 			},
 			RuleWithUseShorthandFunctionTypeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11946,7 +11946,7 @@ export function GET() {
 			},
 			RuleWithUseSimpleNumberKeysOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11965,7 +11965,7 @@ export function GET() {
 			},
 			RuleWithUseSimplifiedLogicExpressionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -11986,7 +11986,7 @@ export function GET() {
 			},
 			RuleWithUseSingleJsDocAsteriskOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12005,7 +12005,7 @@ export function GET() {
 			},
 			RuleWithUseSingleVarDeclaratorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12024,7 +12024,7 @@ export function GET() {
 			},
 			RuleWithUseSolidForComponentOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12039,7 +12039,7 @@ export function GET() {
 			},
 			RuleWithUseSortedClassesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12058,7 +12058,7 @@ export function GET() {
 			},
 			RuleWithUseStaticResponseMethodsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12077,7 +12077,7 @@ export function GET() {
 			},
 			RuleWithUseStrictModeOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12096,7 +12096,7 @@ export function GET() {
 			},
 			RuleWithUseSymbolDescriptionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12111,7 +12111,7 @@ export function GET() {
 			},
 			RuleWithUseTemplateOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12130,7 +12130,7 @@ export function GET() {
 			},
 			RuleWithUseThrowNewErrorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12149,7 +12149,7 @@ export function GET() {
 			},
 			RuleWithUseThrowOnlyErrorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12164,7 +12164,7 @@ export function GET() {
 			},
 			RuleWithUseTopLevelRegexOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12179,7 +12179,7 @@ export function GET() {
 			},
 			RuleWithUseTrimStartEndOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12198,7 +12198,7 @@ export function GET() {
 			},
 			RuleWithUseUnifiedTypeSignaturesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12217,7 +12217,7 @@ export function GET() {
 			},
 			RuleWithUseUniqueElementIdsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12232,7 +12232,7 @@ export function GET() {
 			},
 			RuleWithUseValidAnchorOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12247,7 +12247,7 @@ export function GET() {
 			},
 			RuleWithUseValidAriaPropsOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12266,7 +12266,7 @@ export function GET() {
 			},
 			RuleWithUseValidAriaRoleOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12285,7 +12285,7 @@ export function GET() {
 			},
 			RuleWithUseValidAriaValuesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12300,7 +12300,7 @@ export function GET() {
 			},
 			RuleWithUseValidAutocompleteOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12315,7 +12315,7 @@ export function GET() {
 			},
 			RuleWithUseValidForDirectionOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12330,7 +12330,7 @@ export function GET() {
 			},
 			RuleWithUseValidLangOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12345,7 +12345,7 @@ export function GET() {
 			},
 			RuleWithUseValidTypeofOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12364,7 +12364,7 @@ export function GET() {
 			},
 			RuleWithUseVueDefineMacrosOrderOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12383,7 +12383,7 @@ export function GET() {
 			},
 			RuleWithUseVueMultiWordComponentNamesOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",
@@ -12400,7 +12400,7 @@ export function GET() {
 			},
 			RuleWithUseWhileOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					fix: {
 						description: "The kind of the code actions emitted by the rule",
@@ -12419,7 +12419,7 @@ export function GET() {
 			},
 			RuleWithUseYieldOptions: {
 				type: "object",
-				required: ["level", "options"],
+				required: ["level"],
 				properties: {
 					level: {
 						description: "The severity of the emitted diagnostics by the rule",


### PR DESCRIPTION
## Summary

Fix https://github.com/biomejs/biome/discussions/7865

The script that generates our configuration schema diverged between our main repository (biome) and the website one.
This PR fixes it and fixes every schema that have been generated since.

@Netail Thanks for pointing me to this. 