### PR TITLE
fix: remove duplicated code in biome.json code blocks

### DIFF
--- a/codegen/src/lintdoc.rs
+++ b/codegen/src/lintdoc.rs
@@ -1294,7 +1294,7 @@ fn write_documentation(
                 let mut hide_line = false;
 
                 if let Some((test, block)) = &mut language {
-                    if test.options == OptionsParsingMode::RuleOptionsOnly {
+                    if test.options != OptionsParsingMode::NoOptions {
                         hide_line = true;
                     }
                     if let Some(inner_text) = text.strip_prefix("# ") {

--- a/src/content/docs/assist/actions/organize-imports.mdx
+++ b/src/content/docs/assist/actions/organize-imports.mdx
@@ -274,23 +274,6 @@ Given the following configuration...
 
 ```json title='biome.json'
 {
-    "assist": {
-        "actions": {
-            "source": {
-                "organizeImports": {
-                    "level": "on",
-                    "options": {
-                        "groups": [
-                            ":URL:",
-                            ":NODE:"
-                        ]
-                    }
-                }
-            }
-        }
-    }
-}
-{
 	"assist": {
 		"actions": {
 			"source": {


### PR DESCRIPTION
## Summary

Closes #3366

Fixed the codegen emits `biome.json` code blocks twice if the `full_options` flag is used in the fence.