### PR TITLE
feat(use_filenaming_convention): add support for `$` prefix

### DIFF
--- a/src/content/docs/linter/rules/use-filenaming-convention.mdx
+++ b/src/content/docs/linter/rules/use-filenaming-convention.mdx
@@ -44,8 +44,8 @@ By default, the rule ensures that the extensions are either in [`camelCase`](htt
 
 The rule supports the following exceptions:
 
-- The name of the file can start with a dot or a plus sign, be prefixed and suffixed by underscores `_`.
-For example, `.filename.js`, `+filename.js`, `__filename__.js`, or even `.__filename__.js`.
+- The name of the file can start with a dot, a plus sign, or a dollar sign, be prefixed and suffixed by underscores `_`.
+For example, `.filename.js`, `+filename.js`, `$filename.js`, `__filename__.js`, or even `.__filename__.js`.
 
 The convention of prefixing a filename with a plus sign is used by [Sveltekit](https://kit.svelte.dev/docs/routing#page) and [Vike](https://vike.dev/route).
 


### PR DESCRIPTION
## Summary

Adds support for dollar-sign-prefixed filenames, a convention used by TanStack Start: https://tanstack.com/start/latest/docs/framework/react/guide/routing

Relates to https://github.com/biomejs/biome/pull/8007