### PR TITLE
docs: add a note about `indentWidth` being ignored on `indentStyle: "tab"`

### DIFF
--- a/src/content/docs/reference/configuration.mdx
+++ b/src/content/docs/reference/configuration.mdx
@@ -600,6 +600,10 @@ The style of the indentation. It can be `"tab"` or `"space"`.
 
 How big the indentation should be.
 
+:::note
+This property is ignored when `indentStyle` is set to `tab`.
+:::
+
 > Default: `2`
 
 ### `formatter.lineEnding`


### PR DESCRIPTION
## Summary
Coming from `prettier`, I found it confusing that `indentWidth` is ignored when `indentStyle` is set to `tab`. This information in docs would definitely help me figure it out faster 😄