### PR TITLE
feat: improve assist docs

### DIFF
--- a/codegen/src/lintdoc.rs
+++ b/codegen/src/lintdoc.rs
@@ -793,26 +793,28 @@ fn generate_rule_content(rule_content: RuleContent) -> Result<(Vec<u8>, String, 
         }
     }
 
-    match meta.severity {
-        Severity::Information => {
-            writeln!(
-                content,
-                "- The default severity of this rule is [**information**](/reference/diagnostics#information)."
-            )?;
+    if rule_category == RuleCategory::Lint {
+        match meta.severity {
+            Severity::Information => {
+                writeln!(
+                    content,
+                    "- The default severity of this rule is [**information**](/reference/diagnostics#information)."
+                )?;
+            }
+            Severity::Warning => {
+                writeln!(
+                    content,
+                    "- The default severity of this rule is [**warning**](/reference/diagnostics#warning)."
+                )?;
+            }
+            Severity::Error => {
+                writeln!(
+                    content,
+                    "- The default severity of this rule is [**error**](/reference/diagnostics#error)."
+                )?;
+            }
+            Severity::Hint | Severity::Fatal => panic!("Unsupported severity {}", meta.severity),
         }
-        Severity::Warning => {
-            writeln!(
-                content,
-                "- The default severity of this rule is [**warning**](/reference/diagnostics#warning)."
-            )?;
-        }
-        Severity::Error => {
-            writeln!(
-                content,
-                "- The default severity of this rule is [**error**](/reference/diagnostics#error)."
-            )?;
-        }
-        Severity::Hint | Severity::Fatal => panic!("Unsupported severity {}", meta.severity),
     }
 
     if !meta.domains.is_empty() {

--- a/src/content/docs/assist/actions/organize-imports.mdx
+++ b/src/content/docs/assist/actions/organize-imports.mdx
@@ -14,7 +14,6 @@ import EditorAction from "@/components/EditorAction.astro";
 - Rule available since: `v1.0.0`
 - Diagnostic Category: [`assist/source/organizeImports`](/reference/diagnostics#diagnostic-category)
 - This action is **recommended**.
-- The default severity of this rule is [**information**](/reference/diagnostics#information).
 ## How to enable in your editor
 <EditorAction includeFixAll action="source.organizeImports.biome" />
 ## How to configure

--- a/src/content/docs/assist/actions/use-sorted-attributes.mdx
+++ b/src/content/docs/assist/actions/use-sorted-attributes.mdx
@@ -13,7 +13,6 @@ import EditorAction from "@/components/EditorAction.astro";
 ## Summary
 - Rule available since: `v2.0.0`
 - Diagnostic Category: [`assist/source/useSortedAttributes`](/reference/diagnostics#diagnostic-category)
-- The default severity of this rule is [**information**](/reference/diagnostics#information).
 - Sources: 
   - Same as [`react/jsx-sort-props`](https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-sort-props.md)
 

--- a/src/content/docs/assist/actions/use-sorted-keys.mdx
+++ b/src/content/docs/assist/actions/use-sorted-keys.mdx
@@ -13,7 +13,6 @@ import EditorAction from "@/components/EditorAction.astro";
 ## Summary
 - Rule available since: `v1.9.0`
 - Diagnostic Category: [`assist/source/useSortedKeys`](/reference/diagnostics#diagnostic-category)
-- The default severity of this rule is [**information**](/reference/diagnostics#information).
 ## How to enable in your editor
 <EditorAction includeFixAll action="source.action.useSortedKeys.biome" />
 ## How to configure
@@ -133,7 +132,6 @@ Following will apply the lexicographic sort order.
 ## Summary
 - Rule available since: `v2.0.0`
 - Diagnostic Category: [`assist/source/useSortedKeys`](/reference/diagnostics#diagnostic-category)
-- The default severity of this rule is [**information**](/reference/diagnostics#information).
 - Sources: 
   - Inspired from [`perfectionist/sort-objects`](https://perfectionist.dev/rules/sort-objects)
 

--- a/src/content/docs/assist/actions/use-sorted-properties.mdx
+++ b/src/content/docs/assist/actions/use-sorted-properties.mdx
@@ -13,7 +13,6 @@ import EditorAction from "@/components/EditorAction.astro";
 ## Summary
 - Rule available since: `v2.0.0`
 - Diagnostic Category: [`assist/source/useSortedProperties`](/reference/diagnostics#diagnostic-category)
-- The default severity of this rule is [**information**](/reference/diagnostics#information).
 ## How to enable in your editor
 <EditorAction includeFixAll action="source.action.useSortedProperties.biome" />
 ## How to configure

--- a/src/content/docs/assist/index.mdx
+++ b/src/content/docs/assist/index.mdx
@@ -52,6 +52,14 @@ However, the `check` is meant for running multiple tools at once, so if you want
 
 <PackageManagerBiomeCommand command="check --formatter-enabled=false --linter-enabled=false" />
 
+### Don't enforce assist
+
+By default, Biome enforces assists when running the `check` command. If you wish *to not enforce assist*, you can use the `--enforce-assist` CLI flag to `false`. This way, Biome won't emit a diagnostic error if some actions haven't been applied:
+
+```shell
+biome check --enforce-assist=false
+```
+
 ## Suppression assist actions
 
 You can refer to the [suppression page](/analyzer/suppressions).

--- a/src/content/docs/reference/configuration.mdx
+++ b/src/content/docs/reference/configuration.mdx
@@ -1344,6 +1344,11 @@ Breaking changes will be reduced to a minimum, however the introduction of fixes
 the behavior of the tools.
 :::
 
+### `html.experimentalFullSupportEnabled`
+
+When enabled, Biome enables full support for HTML-ish languages. Parsing, formatting and linting of
+embedded languages inside these files are consistent.
+
 ### `html.parser.interpolation`
 
 Enables the parsing of double text expressions such as `{{ expression }}` inside `.html` files.


### PR DESCRIPTION
## Summary

- Showing the severity in actions doesn't make sense, because users can't tune it
- Added docs for `--enforce-assist` in the Assist page
- Added missing `experimentalFullSupportEnabled` to the docs 