### PR TITLE
docs: fix EN typos for `--staged` command

### DIFF
--- a/src/content/docs/guides/integrate-in-vcs.mdx
+++ b/src/content/docs/guides/integrate-in-vcs.mdx
@@ -75,4 +75,4 @@ To limit Biome to only processing files slated for committing, pass the `--stage
 biome check --staged
 ```
 
-The `--staged` option is not available on the `ci` command as you are usually not expected to commit changes during CI.
+The `--staged` option is not available in the `ci` command, as you are usually not expected to commit changes during CI.


### PR DESCRIPTION
"check the formatting and lints"

## Summary

Fixes small typos and a bit of verbosity in the decription.
Mostly the typos though.