### PR TITLE
add missing level to noExcessiveCognitiveComplexity

### DIFF
--- a/src/content/docs/linter/rules/no-excessive-cognitive-complexity.mdx
+++ b/src/content/docs/linter/rules/no-excessive-cognitive-complexity.mdx
@@ -78,8 +78,8 @@ Allows specifying the maximum allowed complexity.
 		"rules": {
 			"complexity": {
 				"noExcessiveCognitiveComplexity": {
+					"level": "error",
 					"options": {
-						"level": "error",
 						"maxAllowedComplexity": 15
 					}
 				}


### PR DESCRIPTION
## Summary

Without the `level` property, the `maxAllowedComplexity` have no effect on `noExcessiveCognitiveComplexity`