### PR TITLE
docs: add missing bracket in big-projects guide

### DIFF
--- a/src/content/docs/guides/big-projects.mdx
+++ b/src/content/docs/guides/big-projects.mdx
@@ -117,7 +117,8 @@ project in the following way.
     -   "root": false,
         "extends": "//",
         "formatter": {
-        "enabled": false
+          "enabled": false
+        }
     }
     ```
 3. Now, let's suppose we have a new package in `packages/analytics` that is

--- a/src/content/docs/pl/guides/big-projects.mdx
+++ b/src/content/docs/pl/guides/big-projects.mdx
@@ -117,7 +117,8 @@ projekt w następujący sposób.
     -   "root": false,
         "extends": "//",
         "formatter": {
-        "enabled": false
+            "enabled": false
+        }
     }
     ```
 3. Teraz załóżmy, że mamy nowy pakiet w `packages/analytics`, który jest

--- a/src/content/docs/pt-BR/guides/big-projects.mdx
+++ b/src/content/docs/pt-BR/guides/big-projects.mdx
@@ -93,7 +93,8 @@ Desde a v2, o Biome suporta monorepos nativamente, e você precisará configurar
     -   "root": false,
         "extends": "//",
         "formatter": {
-        "enabled": false
+            "enabled": false
+        }
     }
     ```
 3. Agora, vamos supor que temos um novo pacote em `packages/analytics` que é mantido por uma equipe diferente. Essa equipe segue padrões de codificação totalmente diferentes, então eles _não_ querem herdar opções da configuração raiz. Para eles, basta omitir `"extends": "//"` do arquivo de configuração e alterar as opções de formatação:


### PR DESCRIPTION


## Summary

Update a minor typo in one of the config file code blocks. The `"formatter"` object was missing a closing bracket and indentation.

I fixed this on the en, pl, and pt-BR pages.