### PR TITLE
Fix Japanese translation errors

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -494,7 +494,7 @@ export default defineConfig({
 									label: "CSS Rules sources",
 									link: "/linter/css/sources",
 									translations: {
-										ja: "JavaScriptルールのソース",
+										ja: "CSSルールのソース",
 										"zh-CN": "CSS 规则来源",
 										pl: "Źródła reguł CSS",
 										ru: "Источники правил CSS",
@@ -514,7 +514,7 @@ export default defineConfig({
 									label: "JSON Rules sources",
 									link: "/linter/json/sources",
 									translations: {
-										ja: "JavaScriptルールのソース",
+										ja: "JSONルールのソース",
 										"zh-CN": "JSON 规则来源",
 										pl: "Źródła reguł JSON",
 										ru: "Источники правил JSON",


### PR DESCRIPTION
## Summary

I fixed an error in the wording regarding rules sources.
<img width="251" height="224" alt="image" src="https://github.com/user-attachments/assets/f69fb75c-01c6-4ddf-8e88-b6637b21fa0e" />
JavaScript characters appear where CSS and JSON should be. The links function correctly, but only the display is incorrect.