### PR TITLE
docs: Clarify Biome's ignore comment functionality

### DIFF
--- a/src/content/docs/formatter/index.mdx
+++ b/src/content/docs/formatter/index.mdx
@@ -126,4 +126,4 @@ const expr =
 ```
 
 Biome supports the comment `// biome-ignore-all` for suppressing a lint rule or the formatter in an entire file.
-However, you can [ignore a file using the Biome configuration file](/guides/configure-biome/#ignore-files).
+You can also [ignore a file using the Biome configuration file](/guides/configure-biome/#ignore-files).


### PR DESCRIPTION
Updated documentation to clarify Biome's support for ignoring files to keep up to date with v2.

## Summary

The Formatter's introduction in the documentation states Biome does not provide a comment to ignore the whole file. A behavior which was implemented on [Biome v2](https://next.biomejs.dev/blog/biome-v2/#improved-suppressions).