### PR TITLE
fix: Update Biome ```$schema``` version from ```2.0.5``` to ```2.3.11``` in document

### DIFF
--- a/src/content/docs/fr/guides/configure-biome.mdx
+++ b/src/content/docs/fr/guides/configure-biome.mdx
@@ -26,7 +26,7 @@ Vous pouvez désactiver un ou plusieurs d’entre eux en utilisant la propriét�
 
 ```json title="biome.json"
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.5/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.3.11/schema.json",
   "formatter": {
     "enabled": false
   },

--- a/src/content/docs/guides/configure-biome.mdx
+++ b/src/content/docs/guides/configure-biome.mdx
@@ -29,7 +29,7 @@ or several of them using the `<tool>.enabled` field:
 
 ```json title="biome.json"
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.5/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.3.11/schema.json",
   "formatter": {
     "enabled": false
   },

--- a/src/content/docs/ja/guides/configure-biome.mdx
+++ b/src/content/docs/ja/guides/configure-biome.mdx
@@ -25,7 +25,7 @@ Biomeはツールチェーンであるため、設定は提供されるツール
 
 ```json title="biome.json"
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.5/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.3.11/schema.json",
   "formatter": {
     "enabled": false
   },

--- a/src/content/docs/ja/reference/configuration.mdx
+++ b/src/content/docs/ja/reference/configuration.mdx
@@ -26,7 +26,7 @@ JSONスキーマファイルへのパスを指定できます。
 
 ```json title="biome.json"
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.5/schema.json"
+  "$schema": "https://biomejs.dev/schemas/2.3.11/schema.json"
 }
 ```
 

--- a/src/content/docs/pl/guides/configure-biome.mdx
+++ b/src/content/docs/pl/guides/configure-biome.mdx
@@ -26,7 +26,7 @@ lub kilka z nich używając pola `<tool>.enabled`:
 
 ```json title="biome.json"
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.5/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.3.11/schema.json",
   "formatter": {
     "enabled": false
   },

--- a/src/content/docs/pl/reference/configuration.mdx
+++ b/src/content/docs/pl/reference/configuration.mdx
@@ -25,7 +25,7 @@ opublikowanego na tej stronie:
 
 ```json title="biome.json"
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.5/schema.json"
+  "$schema": "https://biomejs.dev/schemas/2.3.11/schema.json"
 }
 ```
 

--- a/src/content/docs/pt-BR/guides/configure-biome.mdx
+++ b/src/content/docs/pt-BR/guides/configure-biome.mdx
@@ -25,7 +25,7 @@ ou várias delas usando o campo `<ferramenta>.enabled`:
 
 ```json title="biome.json"
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.5/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.3.11/schema.json",
   "formatter": {
     "enabled": false
   },

--- a/src/content/docs/reference/configuration.mdx
+++ b/src/content/docs/reference/configuration.mdx
@@ -25,7 +25,7 @@ published on this site:
 
 ```json title="biome.json"
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.5/schema.json"
+  "$schema": "https://biomejs.dev/schemas/2.3.11/schema.json"
 }
 ```
 

--- a/src/content/docs/zh-CN/guides/configure-biome.mdx
+++ b/src/content/docs/zh-CN/guides/configure-biome.mdx
@@ -25,7 +25,7 @@ Biome 配置文件命名为 `biome.json` 或 `biome.jsonc`。通常放置在项�
 
 ```json title="biome.json"
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.5/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.3.11/schema.json",
   "formatter": {
     "enabled": false
   },

--- a/src/content/docs/zh-CN/guides/getting-started.mdx
+++ b/src/content/docs/zh-CN/guides/getting-started.mdx
@@ -41,7 +41,7 @@ import PackageManagerCommand from "@/components/PackageManagerCommand.astro";
 
 ```json title="biome.json"
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.5/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.3.11/schema.json",
   "organizeImports": {
     "enabled": false
   },

--- a/src/content/docs/zh-CN/reference/configuration.mdx
+++ b/src/content/docs/zh-CN/reference/configuration.mdx
@@ -25,7 +25,7 @@ description: 如何使用biome.json自定义和配置Biome。
 
 ```json title="biome.json"
 {
-  "$schema": "https://biomejs.dev/schemas/2.0.5/schema.json"
+  "$schema": "https://biomejs.dev/schemas/2.3.11/schema.json"
 }
 ```
 


### PR DESCRIPTION
## Summary

The documentation currently references the JSON schema version `2.0.5`, but the latest Biome release installs version `2.3.11`.

This PR updates the `$schema` URL in the examples to match the currently published version:

```json
{
  "$schema": "https://biomejs.dev/schemas/2.3.11/schema.json"
}
```
