### PR TITLE
docs: add delimiterSpacing toggle and global option docs

### DIFF
--- a/src/content/docs/formatter/index.mdx
+++ b/src/content/docs/formatter/index.mdx
@@ -67,6 +67,7 @@ The following defaults are applied:
       "arrowParentheses":"always",
       "bracketSameLine": false,
       "bracketSpacing": true,
+      "delimiterSpacing": false,
       "jsxQuoteStyle": "double",
       "quoteProperties": "asNeeded",
       "semicolons": "always",

--- a/src/content/docs/reference/configuration.mdx
+++ b/src/content/docs/reference/configuration.mdx
@@ -677,6 +677,14 @@ Choose whether spaces should be added between brackets and inner values.
 
 > Default: `true`
 
+### `formatter.delimiterSpacing`
+
+Whether to insert spaces inside delimiters. Affects parentheses `()`, square brackets `[]`, TypeScript angle brackets `<>`, and JSX curly braces `{}`.
+
+This option is available for JavaScript, JSON, and CSS. It is not available for GraphQL.
+
+> Default: `false`
+
 ### `formatter.expand`
 
 Whether to expand arrays and objects on multiple lines.
@@ -886,6 +894,14 @@ Choose whether the ending `>` of a multi-line JSX element should be on the last 
 Choose whether spaces should be added between brackets and inner values.
 
 > Default: `true`
+
+### `javascript.formatter.delimiterSpacing`
+
+Whether to insert spaces inside delimiters. Affects parentheses `()`, square brackets `[]`, TypeScript angle brackets `<>`, and JSX curly braces `{}`.
+
+This option is available for JavaScript, JSON, and CSS. It is not available for GraphQL.
+
+> Default: `false`
 
 ### `javascript.formatter.attributePosition`
 
@@ -1128,6 +1144,12 @@ Choose whether spaces should be added between brackets and inner values.
 
 > Default: `true`
 
+### `json.formatter.delimiterSpacing`
+
+Whether to insert spaces inside square brackets `[]`.
+
+> Default: `false`
+
 ### `json.formatter.expand`
 
 Whether to expand arrays and objects on multiple lines.
@@ -1270,6 +1292,12 @@ The type of quote used when representing string literals. It can be `"single"` o
 
 > Default: `"double"`
 
+### `css.formatter.delimiterSpacing`
+
+Whether to insert spaces inside delimiters. Affects parentheses `()` and square brackets `[]`.
+
+> Default: `false`
+
 ### `css.formatter.trailingNewline`
 
 Whether to add a trailing newline at the end of the file.
@@ -1284,7 +1312,6 @@ Setting this option to `false` is **highly discouraged** because it could cause 
 
 Disable trailing newline at your own risk.
 :::
-
 
 ### `css.linter.enabled`
 

--- a/src/content/docs/reference/configuration.mdx
+++ b/src/content/docs/reference/configuration.mdx
@@ -679,9 +679,7 @@ Choose whether spaces should be added between brackets and inner values.
 
 ### `formatter.delimiterSpacing`
 
-Whether to insert spaces inside delimiters. Affects parentheses `()`, square brackets `[]`, TypeScript angle brackets `<>`, and JSX curly braces `{}`.
-
-This option is available for JavaScript, JSON, and CSS. It is not available for GraphQL.
+Whether to insert spaces inside delimiters (after the opening delimiter and before the closing delimiter). Empty delimiters are not affected, and no space is added before the opening delimiter.
 
 > Default: `false`
 
@@ -897,9 +895,9 @@ Choose whether spaces should be added between brackets and inner values.
 
 ### `javascript.formatter.delimiterSpacing`
 
-Whether to insert spaces inside delimiters. Affects parentheses `()`, square brackets `[]`, TypeScript angle brackets `<>`, and JSX curly braces `{}`.
+Whether to insert spaces inside delimiters (after the opening delimiter and before the closing delimiter). Empty delimiters are not affected, and no space is added before the opening delimiter.
 
-This option is available for JavaScript, JSON, and CSS. It is not available for GraphQL.
+For JavaScript, affects parentheses (e.g., `foo( a, b )`), square brackets (e.g., `[ a, b ]`), template literal interpolations (e.g., `${ expr }`), TypeScript angle brackets (e.g., `foo< T >()`), JSX expression braces (e.g., `{ value }`), and the logical NOT operator (e.g., `! x`).
 
 > Default: `false`
 
@@ -1146,7 +1144,7 @@ Choose whether spaces should be added between brackets and inner values.
 
 ### `json.formatter.delimiterSpacing`
 
-Whether to insert spaces inside square brackets `[]`.
+Whether to insert spaces inside delimiters (after the opening delimiter and before the closing delimiter). Empty delimiters are not affected, and no space is added before the opening delimiter. For JSON, affects square brackets (e.g., `[ 1, 2, 3 ]`).
 
 > Default: `false`
 
@@ -1294,7 +1292,7 @@ The type of quote used when representing string literals. It can be `"single"` o
 
 ### `css.formatter.delimiterSpacing`
 
-Whether to insert spaces inside delimiters. Affects parentheses `()` and square brackets `[]`.
+Whether to insert spaces inside delimiters (after the opening delimiter and before the closing delimiter). Empty delimiters are not affected, and no space is added before the opening delimiter. For CSS, affects parentheses (e.g., `rgb( 0, 0, 0 )`) and square brackets (e.g., `[ data-attr ]`).
 
 > Default: `false`
 

--- a/src/playground/PlaygroundLoader.tsx
+++ b/src/playground/PlaygroundLoader.tsx
@@ -436,6 +436,9 @@ function initState(
 			bracketSpacing:
 				searchParams.get("bracketSpacing") === "true" ||
 				defaultPlaygroundState.settings.bracketSpacing,
+			delimiterSpacing:
+				searchParams.get("delimiterSpacing") === "true" ||
+				defaultPlaygroundState.settings.delimiterSpacing,
 			bracketSameLine:
 				searchParams.get("bracketSameLine") === "true" ||
 				defaultPlaygroundState.settings.bracketSameLine,

--- a/src/playground/PlaygroundLoader.tsx
+++ b/src/playground/PlaygroundLoader.tsx
@@ -399,6 +399,7 @@ function initState(
 			lineWidth: Number.parseInt(
 				searchParams.get("lineWidth") ??
 					String(defaultPlaygroundState.settings.lineWidth),
+				10,
 			),
 			indentStyle:
 				(searchParams.get("indentStyle") as IndentStyle) ??
@@ -420,6 +421,7 @@ function initState(
 			indentWidth: Number.parseInt(
 				searchParams.get("indentWidth") ??
 					String(defaultPlaygroundState.settings.indentWidth),
+				10,
 			),
 			semicolons:
 				(searchParams.get("semicolons") as Semicolons) ??
@@ -436,9 +438,6 @@ function initState(
 			bracketSpacing:
 				searchParams.get("bracketSpacing") === "true" ||
 				defaultPlaygroundState.settings.bracketSpacing,
-			delimiterSpacing:
-				searchParams.get("delimiterSpacing") === "true" ||
-				defaultPlaygroundState.settings.delimiterSpacing,
 			bracketSameLine:
 				searchParams.get("bracketSameLine") === "true" ||
 				defaultPlaygroundState.settings.bracketSameLine,

--- a/src/playground/tabs/SettingsTab.tsx
+++ b/src/playground/tabs/SettingsTab.tsx
@@ -60,6 +60,7 @@ export default function SettingsTab({
 			arrowParentheses,
 			operatorLinebreak,
 			bracketSpacing,
+			delimiterSpacing,
 			bracketSameLine,
 			expand,
 			indentScriptAndStyle,
@@ -126,6 +127,10 @@ export default function SettingsTab({
 	const setBracketSpacing = createPlaygroundSettingsSetter(
 		setPlaygroundState,
 		"bracketSpacing",
+	);
+	const setDelimiterSpacing = createPlaygroundSettingsSetter(
+		setPlaygroundState,
+		"delimiterSpacing",
 	);
 	const setBracketSameLine = createPlaygroundSettingsSetter(
 		setPlaygroundState,
@@ -358,6 +363,8 @@ export default function SettingsTab({
 				setAttributePosition={setAttributePosition}
 				bracketSpacing={bracketSpacing}
 				setBracketSpacing={setBracketSpacing}
+				delimiterSpacing={delimiterSpacing}
+				setDelimiterSpacing={setDelimiterSpacing}
 				bracketSameLine={bracketSameLine}
 				setBracketSameLine={setBracketSameLine}
 				expand={expand}
@@ -782,6 +789,8 @@ function FormatterSettings({
 	setAttributePosition,
 	bracketSpacing,
 	setBracketSpacing,
+	delimiterSpacing,
+	setDelimiterSpacing,
 	bracketSameLine,
 	setBracketSameLine,
 	expand,
@@ -815,6 +824,8 @@ function FormatterSettings({
 	setAttributePosition: (value: AttributePosition) => void;
 	bracketSpacing: boolean;
 	setBracketSpacing: (value: boolean) => void;
+	delimiterSpacing: boolean;
+	setDelimiterSpacing: (value: boolean) => void;
 	bracketSameLine: boolean;
 	setBracketSameLine: (value: boolean) => void;
 	expand: Expand;
@@ -835,6 +846,7 @@ function FormatterSettings({
 	const operatorLinebreakId = useId();
 	const attributePositionId = useId();
 	const bracketSpacingId = useId();
+	const delimiterSpacingId = useId();
 	const bracketSameLineId = useId();
 	const expandId = useId();
 	const indentScriptAndStyleId = useId();
@@ -990,6 +1002,16 @@ function FormatterSettings({
 						type="checkbox"
 						checked={bracketSpacing}
 						onChange={(e) => setBracketSpacing(e.target.checked)}
+					/>
+				</div>
+				<div className="field-row">
+					<label htmlFor={delimiterSpacingId}>Delimiter Spacing</label>
+					<input
+						id={delimiterSpacingId}
+						name="delimiterSpacing"
+						type="checkbox"
+						checked={delimiterSpacing}
+						onChange={(e) => setDelimiterSpacing(e.target.checked)}
 					/>
 				</div>
 				<div className="field-row">

--- a/src/playground/tabs/SettingsTab.tsx
+++ b/src/playground/tabs/SettingsTab.tsx
@@ -60,7 +60,6 @@ export default function SettingsTab({
 			arrowParentheses,
 			operatorLinebreak,
 			bracketSpacing,
-			delimiterSpacing,
 			bracketSameLine,
 			expand,
 			indentScriptAndStyle,
@@ -127,10 +126,6 @@ export default function SettingsTab({
 	const setBracketSpacing = createPlaygroundSettingsSetter(
 		setPlaygroundState,
 		"bracketSpacing",
-	);
-	const setDelimiterSpacing = createPlaygroundSettingsSetter(
-		setPlaygroundState,
-		"delimiterSpacing",
 	);
 	const setBracketSameLine = createPlaygroundSettingsSetter(
 		setPlaygroundState,
@@ -363,8 +358,6 @@ export default function SettingsTab({
 				setAttributePosition={setAttributePosition}
 				bracketSpacing={bracketSpacing}
 				setBracketSpacing={setBracketSpacing}
-				delimiterSpacing={delimiterSpacing}
-				setDelimiterSpacing={setDelimiterSpacing}
 				bracketSameLine={bracketSameLine}
 				setBracketSameLine={setBracketSameLine}
 				expand={expand}
@@ -789,8 +782,6 @@ function FormatterSettings({
 	setAttributePosition,
 	bracketSpacing,
 	setBracketSpacing,
-	delimiterSpacing,
-	setDelimiterSpacing,
 	bracketSameLine,
 	setBracketSameLine,
 	expand,
@@ -824,8 +815,6 @@ function FormatterSettings({
 	setAttributePosition: (value: AttributePosition) => void;
 	bracketSpacing: boolean;
 	setBracketSpacing: (value: boolean) => void;
-	delimiterSpacing: boolean;
-	setDelimiterSpacing: (value: boolean) => void;
 	bracketSameLine: boolean;
 	setBracketSameLine: (value: boolean) => void;
 	expand: Expand;
@@ -846,7 +835,6 @@ function FormatterSettings({
 	const operatorLinebreakId = useId();
 	const attributePositionId = useId();
 	const bracketSpacingId = useId();
-	const delimiterSpacingId = useId();
 	const bracketSameLineId = useId();
 	const expandId = useId();
 	const indentScriptAndStyleId = useId();
@@ -1002,16 +990,6 @@ function FormatterSettings({
 						type="checkbox"
 						checked={bracketSpacing}
 						onChange={(e) => setBracketSpacing(e.target.checked)}
-					/>
-				</div>
-				<div className="field-row">
-					<label htmlFor={delimiterSpacingId}>Delimiter Spacing</label>
-					<input
-						id={delimiterSpacingId}
-						name="delimiterSpacing"
-						type="checkbox"
-						checked={delimiterSpacing}
-						onChange={(e) => setDelimiterSpacing(e.target.checked)}
 					/>
 				</div>
 				<div className="field-row">
@@ -1296,7 +1274,7 @@ function LineWidthInput({
 						id={lineWidthId}
 						value={lineWidth}
 						onChange={(e) => {
-							setLineWidth(Number.parseInt(e.target.value));
+							setLineWidth(Number.parseInt(e.target.value, 10));
 						}}
 					/>
 				)}

--- a/src/playground/types.ts
+++ b/src/playground/types.ts
@@ -186,6 +186,7 @@ export interface PlaygroundSettings {
 	operatorLinebreak: OperatorLinebreak;
 	attributePosition: AttributePosition;
 	bracketSpacing: boolean;
+	delimiterSpacing: boolean;
 	bracketSameLine: boolean;
 	expand: Expand;
 	lintRules: LintRule;
@@ -243,6 +244,7 @@ export const defaultPlaygroundState: PlaygroundState = {
 		operatorLinebreak: OperatorLinebreak.After,
 		attributePosition: AttributePosition.Auto,
 		bracketSpacing: true,
+		delimiterSpacing: false,
 		bracketSameLine: false,
 		expand: Expand.Auto,
 		lintRules: LINT_RULES.recommended,

--- a/src/playground/types.ts
+++ b/src/playground/types.ts
@@ -186,7 +186,6 @@ export interface PlaygroundSettings {
 	operatorLinebreak: OperatorLinebreak;
 	attributePosition: AttributePosition;
 	bracketSpacing: boolean;
-	delimiterSpacing: boolean;
 	bracketSameLine: boolean;
 	expand: Expand;
 	lintRules: LintRule;
@@ -244,7 +243,6 @@ export const defaultPlaygroundState: PlaygroundState = {
 		operatorLinebreak: OperatorLinebreak.After,
 		attributePosition: AttributePosition.Auto,
 		bracketSpacing: true,
-		delimiterSpacing: false,
 		bracketSameLine: false,
 		expand: Expand.Auto,
 		lintRules: LINT_RULES.recommended,

--- a/src/playground/workers/biomeWorker.ts
+++ b/src/playground/workers/biomeWorker.ts
@@ -128,6 +128,7 @@ self.addEventListener("message", async (e) => {
 				arrowParentheses,
 				operatorLinebreak,
 				bracketSpacing,
+				delimiterSpacing,
 				bracketSameLine,
 				expand,
 				indentScriptAndStyle,
@@ -192,6 +193,7 @@ self.addEventListener("message", async (e) => {
 								? "before"
 								: "after",
 						bracketSpacing,
+						delimiterSpacing,
 						bracketSameLine,
 						attributePosition:
 							attributePosition === AttributePosition.Auto
@@ -206,6 +208,7 @@ self.addEventListener("message", async (e) => {
 				css: {
 					formatter: {
 						quoteStyle: quoteStyle === QuoteStyle.Double ? "double" : "single",
+						delimiterSpacing,
 					},
 					parser: {
 						allowWrongLineComments: true,
@@ -214,6 +217,9 @@ self.addEventListener("message", async (e) => {
 					},
 				},
 				json: {
+					formatter: {
+						delimiterSpacing,
+					},
 					parser: {
 						allowComments,
 					},

--- a/src/playground/workers/biomeWorker.ts
+++ b/src/playground/workers/biomeWorker.ts
@@ -128,7 +128,6 @@ self.addEventListener("message", async (e) => {
 				arrowParentheses,
 				operatorLinebreak,
 				bracketSpacing,
-				delimiterSpacing,
 				bracketSameLine,
 				expand,
 				indentScriptAndStyle,
@@ -193,7 +192,6 @@ self.addEventListener("message", async (e) => {
 								? "before"
 								: "after",
 						bracketSpacing,
-						delimiterSpacing,
 						bracketSameLine,
 						attributePosition:
 							attributePosition === AttributePosition.Auto
@@ -208,7 +206,6 @@ self.addEventListener("message", async (e) => {
 				css: {
 					formatter: {
 						quoteStyle: quoteStyle === QuoteStyle.Double ? "double" : "single",
-						delimiterSpacing,
 					},
 					parser: {
 						allowWrongLineComments: true,
@@ -217,9 +214,7 @@ self.addEventListener("message", async (e) => {
 					},
 				},
 				json: {
-					formatter: {
-						delimiterSpacing,
-					},
+					formatter: {},
 					parser: {
 						allowComments,
 					},


### PR DESCRIPTION
## Summary

The docs and playground integration for the delimiterSpacing option PRs:

- https://github.com/biomejs/biome/pull/9718
- https://github.com/biomejs/biome/pull/9719
- https://github.com/biomejs/biome/pull/9720 
- https://github.com/biomejs/biome/pull/9721
- https://github.com/biomejs/biome/pull/9722
- https://github.com/biomejs/biome/pull/9723