### PR TITLE
docs: clarify plugin path resolution for extended configs

### DIFF
--- a/src/content/docs/guides/big-projects.mdx
+++ b/src/content/docs/guides/big-projects.mdx
@@ -179,6 +179,9 @@ which the `biome.json`/`biome.jsonc` file resides. When using the `extends`
 field, this means that paths in a shared configuration are interpreted from the
 location of the configuration that is extending it, and not from the folder
 of the file being extended.
+There is one exception: `plugins` entries that start with `./` or `../` are
+resolved relative to the configuration file where they are declared, even if
+that file is pulled in via `extends`.
 
 For example, let's assume a project that contains two directories `backend/` and
 `frontend/`, each having their own `biome.json` that both extend a `common.json`

--- a/src/content/docs/guides/configure-biome.mdx
+++ b/src/content/docs/guides/configure-biome.mdx
@@ -161,8 +161,11 @@ You can explicitly list the files to be processed using
 `src/**/*.js`. Negated patterns starting with `!` can be used to exclude files.
 
 Paths and globs inside Biome's configuration file are resolved relative to the
-folder the configuration file is in. An exception to this is when a
-configuration file is [extended](/reference/configuration/#extends) by another.
+folder the configuration file is in. When a configuration file is
+[extended](/reference/configuration/#extends), paths inside the extended file
+resolve relative to the extending config, except `plugins` entries that start
+with `./` or `../`, which resolve relative to the config where they are
+declared.
 
 `files.includes` applies to all of Biome's tools, meaning the files specified
 here are processed by the linter, the formatter and the assist, unless specified

--- a/src/content/docs/linter/plugins.mdx
+++ b/src/content/docs/linter/plugins.mdx
@@ -29,6 +29,17 @@ the following configuration:
 }
 ```
 
+## Plugin paths
+
+Plugin entries support a few path styles:
+
+- Paths starting with `./` or `../` are treated as relative paths and are
+resolved from the configuration file where they are declared (even if that
+configuration file is referenced via `extends`).
+- Scoped package specifiers (starting with `@`) are resolved via
+  `package.json` resolution (for example, from `node_modules` or workspaces).
+- Other strings are treated as paths relative to the entry configuration file.
+
 The plugin will now be enabled on all supported files the linter runs on. You
 can see its results when running `biome lint` or `biome check`. For example:
 

--- a/src/content/docs/reference/configuration.mdx
+++ b/src/content/docs/reference/configuration.mdx
@@ -41,6 +41,10 @@ The order of paths to extend goes from least relevant to most relevant.
 Since v2, this option accepts a string that must match the value `"//"`, which can be used
 when setting up [monorepos](/guides/big-projects#monorepo)
 
+Most relative paths inside a configuration file are resolved relative to the extending config. There is one exception:
+`plugins`. Plugin path entries starting with `./` or `../` are resolved relative to the configuration file where they
+are declared, even if that file is pulled in via `extends`. See [Linter Plugins](/linter/plugins) for details.
+
 ## `root`
 
 Whether this configuration should be treated as a root. By default, any configuration file is considered a root by default.


### PR DESCRIPTION
> [!NOTE]
> I had Codex help me understand the existing documentation and where documentation w.r..t `plugins`, file path resolution, etc are.

## Summary
Document plugin path resolution for extended configs, including the `./` and `../` exception.

## Context
Docs for biomejs/biome#9233.