### PR TITLE
docs: add SVG to language support page

### DIFF
--- a/src/content/docs/internals/language-support.mdx
+++ b/src/content/docs/internals/language-support.mdx
@@ -18,6 +18,7 @@ Legend:
 | JSON                                                     | <span aria-label="Supported" role="img">✅</span>     | <span aria-label="Supported" role="img">✅</span>        | <span aria-label="Supported" role="img">✅</span>        | <span aria-label="Supported" role="img">✅</span>        |
 | JSONC                                                    | <span aria-label="Supported" role="img">✅</span>     | <span aria-label="Supported" role="img">✅</span>        | <span aria-label="Supported" role="img">✅</span>        | <span aria-label="Supported" role="img">✅</span>|
 | HTML*                                                     | <span aria-label="Supported" role="img">✅</span>     | <span aria-label="Supported" role="img">✅</span>        | <span aria-label="Supported" role="img">✅</span>        | <span aria-label="Supported" role="img">✅</span>        |
+| [SVG](#svg-support)                                      | <span aria-label="Supported" role="img">✅</span>     | <span aria-label="Supported" role="img">✅</span>        | <span aria-label="Supported" role="img">✅</span>        | <span aria-label="Supported" role="img">✅</span>        |
 | [Vue](#html-super-languages-support)                     | <span aria-label="Experimental" role="img">🟡</span> | <span aria-label="Experimental" role="img">🟡</span>    | <span aria-label="Experimental" role="img">🟡</span>    | <span aria-label="Experimental" role="img">🟡</span>    |
 | [Svelte](#html-super-languages-support)                  | <span aria-label="Experimental" role="img">🟡</span> | <span aria-label="Experimental" role="img">🟡</span>    | <span aria-label="Experimental" role="img">🟡</span>    | <span aria-label="Experimental" role="img">🟡</span>    |
 | [Astro](#html-super-languages-support)                   | <span aria-label="Experimental" role="img">🟡</span> | <span aria-label="Experimental" role="img">🟡</span>    | <span aria-label="Experimental" role="img">🟡</span>    | <span aria-label="Experimental" role="img">🟡</span>    |
@@ -70,6 +71,10 @@ For files with an extension name of `.jsonc` or those identified as `jsonc` acco
 Please note, some well-known files like `tsconfig.json` and `.babelrc` don't use the `.jsonc` extension but still allow comments and trailing commas. While others, such as `.eslintrc.json`, only allow comments. Biome is able to identify these files and adjusts the `json.parser.allowTrailingCommas` option accordingly to ensure they are correctly parsed.
 
 [This section](/guides/configure-biome#well-known-files) gives the full list of well-known files that Biome can recognize.
+
+## SVG support
+
+Biome treats `.svg` files as HTML, enabling parsing, formatting, and linting for standalone SVG files. For example, the [`noSvgWithoutTitle`](/linter/rules/no-svg-without-title/) accessibility rule can be applied directly to `.svg` files.
 
 ## HTML super languages support
 


### PR DESCRIPTION
> This PR was written with AI assistance (Claude Code).

## Summary

Add SVG to the language support documentation page.

## Description

- Added SVG as a row in the supported languages table with full support for parsing, formatting, and linting.
- Added a short "SVG support" section explaining that Biome treats `.svg` files as HTML.

## Related

Related to biomejs/biome#9604 and biomejs/biome#9608.