### PR TITLE
feat(playground): add JSON editor for Playground settings

### DIFF
--- a/src/playground/buildBiomeConfiguration.ts
+++ b/src/playground/buildBiomeConfiguration.ts
@@ -25,9 +25,15 @@ function getBiomeIndentStyle(indentStyle: PlaygroundSettings["indentStyle"]) {
 }
 
 function getPlaygroundIndentStyle(indentStyle: IndentStyle | undefined) {
-	return indentStyle === IndentStyle.Space
-		? IndentStyle.Space
-		: defaultPlaygroundState.settings.indentStyle;
+	if (indentStyle === IndentStyle.Space) {
+		return IndentStyle.Space;
+	}
+
+	if (indentStyle === IndentStyle.Tab) {
+		return IndentStyle.Tab;
+	}
+
+	return undefined;
 }
 
 function getBiomeAttributePosition(
@@ -41,9 +47,15 @@ function getBiomeAttributePosition(
 function getPlaygroundAttributePosition(
 	attributePosition: AttributePosition | undefined,
 ) {
-	return attributePosition === AttributePosition.Multiline
-		? AttributePosition.Multiline
-		: defaultPlaygroundState.settings.attributePosition;
+	if (attributePosition === AttributePosition.Multiline) {
+		return AttributePosition.Multiline;
+	}
+
+	if (attributePosition === AttributePosition.Auto) {
+		return AttributePosition.Auto;
+	}
+
+	return undefined;
 }
 
 function getBiomeExpand(expand: PlaygroundSettings["expand"]) {
@@ -63,8 +75,10 @@ function getPlaygroundExpand(expand: Expand | undefined) {
 			return Expand.Always;
 		case Expand.Never:
 			return Expand.Never;
+		case Expand.Auto:
+			return Expand.Auto;
 		default:
-			return defaultPlaygroundState.settings.expand;
+			return undefined;
 	}
 }
 
@@ -95,9 +109,15 @@ function getBiomeQuoteProperties(
 function getPlaygroundQuoteProperties(
 	quoteProperties: "preserve" | "asNeeded" | undefined,
 ) {
-	return quoteProperties === QuoteProperties.Preserve
-		? QuoteProperties.Preserve
-		: defaultPlaygroundState.settings.quoteProperties;
+	if (quoteProperties === "preserve") {
+		return QuoteProperties.Preserve;
+	}
+
+	if (quoteProperties === "asNeeded") {
+		return QuoteProperties.AsNeeded;
+	}
+
+	return undefined;
 }
 
 function getBiomeSemicolons(semicolons: PlaygroundSettings["semicolons"]) {
@@ -107,9 +127,15 @@ function getBiomeSemicolons(semicolons: PlaygroundSettings["semicolons"]) {
 function getPlaygroundSemicolons(
 	semicolons: "always" | "asNeeded" | undefined,
 ) {
-	return semicolons === "asNeeded"
-		? Semicolons.AsNeeded
-		: defaultPlaygroundState.settings.semicolons;
+	if (semicolons === "asNeeded") {
+		return Semicolons.AsNeeded;
+	}
+
+	if (semicolons === "always") {
+		return Semicolons.Always;
+	}
+
+	return undefined;
 }
 
 function getBiomeArrowParentheses(
@@ -121,9 +147,15 @@ function getBiomeArrowParentheses(
 function getPlaygroundArrowParentheses(
 	arrowParentheses: "always" | "asNeeded" | undefined,
 ) {
-	return arrowParentheses === "asNeeded"
-		? ArrowParentheses.AsNeeded
-		: defaultPlaygroundState.settings.arrowParentheses;
+	if (arrowParentheses === "asNeeded") {
+		return ArrowParentheses.AsNeeded;
+	}
+
+	if (arrowParentheses === "always") {
+		return ArrowParentheses.Always;
+	}
+
+	return undefined;
 }
 
 function getBiomeOperatorLinebreak(
@@ -137,9 +169,15 @@ function getBiomeOperatorLinebreak(
 function getPlaygroundOperatorLinebreak(
 	operatorLinebreak: OperatorLinebreak | undefined,
 ) {
-	return operatorLinebreak === OperatorLinebreak.Before
-		? OperatorLinebreak.Before
-		: defaultPlaygroundState.settings.operatorLinebreak;
+	if (operatorLinebreak === OperatorLinebreak.Before) {
+		return OperatorLinebreak.Before;
+	}
+
+	if (operatorLinebreak === OperatorLinebreak.After) {
+		return OperatorLinebreak.After;
+	}
+
+	return undefined;
 }
 
 function getLintRuleGroup(
@@ -196,7 +234,7 @@ function getLintRulesConfiguration(
 
 function getPlaygroundLintRules(linterRules: LinterRules | undefined) {
 	if (!linterRules || typeof linterRules !== "object") {
-		return defaultPlaygroundState.settings.lintRules;
+		return undefined;
 	}
 
 	const rules = linterRules as Record<string, unknown>;
@@ -239,7 +277,7 @@ function getPlaygroundLintRules(linterRules: LinterRules | undefined) {
 		return LINT_RULES.recommended;
 	}
 
-	return defaultPlaygroundState.settings.lintRules;
+	return undefined;
 }
 
 export function buildBiomeConfiguration(
@@ -360,7 +398,8 @@ export function parseBiomeConfiguration(
 	return {
 		...defaults,
 		lineWidth: formatter?.lineWidth ?? defaults.lineWidth,
-		indentStyle: getPlaygroundIndentStyle(formatter?.indentStyle),
+		indentStyle:
+			getPlaygroundIndentStyle(formatter?.indentStyle) ?? defaults.indentStyle,
 		indentWidth: formatter?.indentWidth ?? defaults.indentWidth,
 		quoteStyle:
 			getPlaygroundQuoteStyle(javascriptFormatter?.quoteStyle) ??
@@ -369,31 +408,30 @@ export function parseBiomeConfiguration(
 		jsxQuoteStyle:
 			getPlaygroundQuoteStyle(javascriptFormatter?.jsxQuoteStyle) ??
 			defaults.jsxQuoteStyle,
-		quoteProperties: getPlaygroundQuoteProperties(
-			javascriptFormatter?.quoteProperties,
-		),
+		quoteProperties:
+			getPlaygroundQuoteProperties(javascriptFormatter?.quoteProperties) ??
+			defaults.quoteProperties,
 		trailingCommas:
 			javascriptFormatter?.trailingCommas ?? defaults.trailingCommas,
-		semicolons: getPlaygroundSemicolons(javascriptFormatter?.semicolons),
-		arrowParentheses: getPlaygroundArrowParentheses(
-			javascriptFormatter?.arrowParentheses,
-		),
-		operatorLinebreak: getPlaygroundOperatorLinebreak(
-			javascriptFormatter?.operatorLinebreak,
-		),
+		semicolons:
+			getPlaygroundSemicolons(javascriptFormatter?.semicolons) ??
+			defaults.semicolons,
+		arrowParentheses:
+			getPlaygroundArrowParentheses(javascriptFormatter?.arrowParentheses) ??
+			defaults.arrowParentheses,
+		operatorLinebreak:
+			getPlaygroundOperatorLinebreak(javascriptFormatter?.operatorLinebreak) ??
+			defaults.operatorLinebreak,
 		attributePosition:
-			getPlaygroundAttributePosition(formatter?.attributePosition) ===
-				AttributePosition.Multiline ||
-			getPlaygroundAttributePosition(javascriptFormatter?.attributePosition) ===
-				AttributePosition.Multiline
-				? AttributePosition.Multiline
-				: defaults.attributePosition,
+			getPlaygroundAttributePosition(javascriptFormatter?.attributePosition) ??
+			getPlaygroundAttributePosition(formatter?.attributePosition) ??
+			defaults.attributePosition,
 		bracketSpacing:
 			javascriptFormatter?.bracketSpacing ?? defaults.bracketSpacing,
 		bracketSameLine:
 			javascriptFormatter?.bracketSameLine ?? defaults.bracketSameLine,
-		expand: getPlaygroundExpand(formatter?.expand),
-		lintRules: getPlaygroundLintRules(linter?.rules),
+		expand: getPlaygroundExpand(formatter?.expand) ?? defaults.expand,
+		lintRules: getPlaygroundLintRules(linter?.rules) ?? defaults.lintRules,
 		enabledLinting: linter?.enabled ?? defaults.enabledLinting,
 		analyzerFixMode: defaults.analyzerFixMode,
 		enabledAssist: assist?.enabled ?? defaults.enabledAssist,

--- a/src/playground/buildBiomeConfiguration.ts
+++ b/src/playground/buildBiomeConfiguration.ts
@@ -248,8 +248,9 @@ export function buildBiomeConfiguration(
 
 export function parseBiomeConfiguration(
 	configuration: Configuration,
+	currentSettings: PlaygroundSettings = defaultPlaygroundState.settings,
 ): PlaygroundSettings {
-	const defaults = defaultPlaygroundState.settings;
+	const defaults = currentSettings;
 	const formatter = configuration.formatter;
 	const javascript = configuration.javascript;
 	const javascriptFormatter = javascript?.formatter;

--- a/src/playground/buildBiomeConfiguration.ts
+++ b/src/playground/buildBiomeConfiguration.ts
@@ -1,0 +1,299 @@
+import type { Configuration } from "@biomejs/wasm-web";
+import { LINT_RULES } from "@/playground/generated/lintRules.ts";
+import {
+	ArrowParentheses,
+	AttributePosition,
+	defaultPlaygroundState,
+	Expand,
+	IndentStyle,
+	OperatorLinebreak,
+	type PlaygroundSettings,
+	QuoteProperties,
+	QuoteStyle,
+	Semicolons,
+} from "@/playground/types";
+
+type LinterRules = NonNullable<NonNullable<Configuration["linter"]>["rules"]>;
+
+function getBiomeIndentStyle(indentStyle: PlaygroundSettings["indentStyle"]) {
+	return indentStyle === IndentStyle.Tab ? "tab" : "space";
+}
+
+function getBiomeAttributePosition(
+	attributePosition: PlaygroundSettings["attributePosition"],
+) {
+	return attributePosition === AttributePosition.Auto ? "auto" : "multiline";
+}
+
+function getBiomeExpand(expand: PlaygroundSettings["expand"]) {
+	switch (expand) {
+		case Expand.Always:
+			return "always";
+		case Expand.Never:
+			return "never";
+		default:
+			return "auto";
+	}
+}
+
+function getBiomeQuoteStyle(quoteStyle: PlaygroundSettings["quoteStyle"]) {
+	return quoteStyle === QuoteStyle.Double ? "double" : "single";
+}
+
+function getLintRulesConfiguration(
+	lintRules: PlaygroundSettings["lintRules"],
+): LinterRules {
+	switch (lintRules) {
+		case LINT_RULES.recommended:
+			return {
+				nursery: {
+					recommended: false,
+				},
+			};
+		case LINT_RULES.all:
+			return {
+				a11y: "on",
+				nursery: "on",
+				complexity: "on",
+				correctness: "on",
+				performance: "on",
+				security: "on",
+				style: "on",
+				suspicious: "on",
+			};
+		default:
+			return {
+				recommended: false,
+			};
+	}
+}
+
+function getPlaygroundLintRules(linterRules: LinterRules | undefined) {
+	if (!linterRules || typeof linterRules !== "object") {
+		return defaultPlaygroundState.settings.lintRules;
+	}
+
+	const rules = linterRules as Record<string, unknown>;
+	const enabledGroups = [
+		rules.a11y,
+		rules.nursery,
+		rules.complexity,
+		rules.correctness,
+		rules.performance,
+		rules.security,
+		rules.style,
+		rules.suspicious,
+	];
+
+	if (enabledGroups.every((value) => value === "on")) {
+		return LINT_RULES.all;
+	}
+
+	if (
+		"nursery" in rules &&
+		typeof rules.nursery === "object" &&
+		rules.nursery !== null &&
+		"recommended" in rules.nursery &&
+		(rules.nursery as { recommended?: unknown }).recommended === false
+	) {
+		return LINT_RULES.recommended;
+	}
+
+	return defaultPlaygroundState.settings.lintRules;
+}
+
+export function buildBiomeConfiguration(
+	settings: PlaygroundSettings,
+): Configuration {
+	const {
+		lineWidth,
+		indentStyle,
+		indentWidth,
+		quoteStyle,
+		jsxQuoteStyle,
+		quoteProperties,
+		lintRules,
+		enabledLinting,
+		trailingCommas,
+		semicolons,
+		arrowParentheses,
+		operatorLinebreak,
+		bracketSpacing,
+		bracketSameLine,
+		expand,
+		indentScriptAndStyle,
+		whitespaceSensitivity,
+		enabledAssist,
+		unsafeParameterDecoratorsEnabled,
+		allowComments,
+		attributePosition,
+		ruleDomains,
+		experimentalEmbeddedSnippetsEnabled,
+		experimentalFullSupportEnabled,
+		cssModules,
+		tailwindDirectives,
+	} = settings;
+
+	const configuration: Configuration = {
+		formatter: {
+			enabled: true,
+			formatWithErrors: true,
+			lineWidth,
+			indentStyle: getBiomeIndentStyle(indentStyle),
+			indentWidth,
+			attributePosition: getBiomeAttributePosition(attributePosition),
+			expand: getBiomeExpand(expand),
+		},
+		linter: {
+			enabled: enabledLinting,
+			domains: ruleDomains,
+			rules: getLintRulesConfiguration(lintRules),
+		},
+		assist: {
+			enabled: enabledAssist,
+		},
+		javascript: {
+			formatter: {
+				quoteStyle: getBiomeQuoteStyle(quoteStyle),
+				jsxQuoteStyle: getBiomeQuoteStyle(jsxQuoteStyle),
+				quoteProperties:
+					quoteProperties === QuoteProperties.Preserve
+						? "preserve"
+						: "asNeeded",
+				trailingCommas,
+				semicolons: semicolons === Semicolons.Always ? "always" : "asNeeded",
+				arrowParentheses:
+					arrowParentheses === ArrowParentheses.Always ? "always" : "asNeeded",
+				operatorLinebreak:
+					operatorLinebreak === OperatorLinebreak.Before ? "before" : "after",
+				bracketSpacing,
+				bracketSameLine,
+				attributePosition: getBiomeAttributePosition(attributePosition),
+			},
+			parser: {
+				unsafeParameterDecoratorsEnabled,
+			},
+			experimentalEmbeddedSnippetsEnabled,
+		},
+		css: {
+			formatter: {
+				quoteStyle: getBiomeQuoteStyle(quoteStyle),
+			},
+			parser: {
+				allowWrongLineComments: true,
+				cssModules,
+				tailwindDirectives,
+			},
+		},
+		json: {
+			parser: {
+				allowComments,
+			},
+		},
+		html: {
+			formatter: {
+				enabled: true,
+				indentScriptAndStyle,
+				whitespaceSensitivity,
+			},
+			experimentalFullSupportEnabled,
+		},
+	};
+
+	return configuration;
+}
+
+export function parseBiomeConfiguration(
+	configuration: Configuration,
+): PlaygroundSettings {
+	const defaults = defaultPlaygroundState.settings;
+	const formatter = configuration.formatter;
+	const javascript = configuration.javascript;
+	const javascriptFormatter = javascript?.formatter;
+	const javascriptParser = javascript?.parser;
+	const css = configuration.css;
+	const cssFormatter = css?.formatter;
+	const cssParser = css?.parser;
+	const json = configuration.json;
+	const jsonParser = json?.parser;
+	const html = configuration.html;
+	const htmlFormatter = html?.formatter;
+	const linter = configuration.linter;
+	const assist = configuration.assist;
+
+	return {
+		...defaults,
+		lineWidth: formatter?.lineWidth ?? defaults.lineWidth,
+		indentStyle:
+			formatter?.indentStyle === "space"
+				? IndentStyle.Space
+				: defaults.indentStyle,
+		indentWidth: formatter?.indentWidth ?? defaults.indentWidth,
+		quoteStyle:
+			javascriptFormatter?.quoteStyle === "single"
+				? QuoteStyle.Single
+				: cssFormatter?.quoteStyle === "single"
+					? QuoteStyle.Single
+					: defaults.quoteStyle,
+		jsxQuoteStyle:
+			javascriptFormatter?.jsxQuoteStyle === "single"
+				? QuoteStyle.Single
+				: defaults.jsxQuoteStyle,
+		quoteProperties:
+			javascriptFormatter?.quoteProperties === "preserve"
+				? QuoteProperties.Preserve
+				: defaults.quoteProperties,
+		trailingCommas:
+			javascriptFormatter?.trailingCommas ?? defaults.trailingCommas,
+		semicolons:
+			javascriptFormatter?.semicolons === "asNeeded"
+				? Semicolons.AsNeeded
+				: defaults.semicolons,
+		arrowParentheses:
+			javascriptFormatter?.arrowParentheses === "asNeeded"
+				? ArrowParentheses.AsNeeded
+				: defaults.arrowParentheses,
+		operatorLinebreak:
+			javascriptFormatter?.operatorLinebreak === "before"
+				? OperatorLinebreak.Before
+				: defaults.operatorLinebreak,
+		attributePosition:
+			formatter?.attributePosition === "multiline" ||
+			javascriptFormatter?.attributePosition === "multiline"
+				? AttributePosition.Multiline
+				: defaults.attributePosition,
+		bracketSpacing:
+			javascriptFormatter?.bracketSpacing ?? defaults.bracketSpacing,
+		bracketSameLine:
+			javascriptFormatter?.bracketSameLine ?? defaults.bracketSameLine,
+		expand:
+			formatter?.expand === "always"
+				? Expand.Always
+				: formatter?.expand === "never"
+					? Expand.Never
+					: defaults.expand,
+		lintRules: getPlaygroundLintRules(linter?.rules),
+		enabledLinting: linter?.enabled ?? defaults.enabledLinting,
+		analyzerFixMode: defaults.analyzerFixMode,
+		enabledAssist: assist?.enabled ?? defaults.enabledAssist,
+		unsafeParameterDecoratorsEnabled:
+			javascriptParser?.unsafeParameterDecoratorsEnabled ??
+			defaults.unsafeParameterDecoratorsEnabled,
+		allowComments: jsonParser?.allowComments ?? defaults.allowComments,
+		ruleDomains: linter?.domains ?? defaults.ruleDomains,
+		indentScriptAndStyle:
+			htmlFormatter?.indentScriptAndStyle ?? defaults.indentScriptAndStyle,
+		whitespaceSensitivity:
+			htmlFormatter?.whitespaceSensitivity ?? defaults.whitespaceSensitivity,
+		experimentalEmbeddedSnippetsEnabled:
+			javascript?.experimentalEmbeddedSnippetsEnabled ??
+			defaults.experimentalEmbeddedSnippetsEnabled,
+		experimentalFullSupportEnabled:
+			html?.experimentalFullSupportEnabled ??
+			defaults.experimentalFullSupportEnabled,
+		cssModules: cssParser?.cssModules ?? defaults.cssModules,
+		tailwindDirectives:
+			cssParser?.tailwindDirectives ?? defaults.tailwindDirectives,
+		gritTargetLanguage: defaults.gritTargetLanguage,
+	};
+}

--- a/src/playground/buildBiomeConfiguration.ts
+++ b/src/playground/buildBiomeConfiguration.ts
@@ -21,28 +21,125 @@ const LINT_RULE_GROUPS = Object.entries(LINT_RULES).filter((entry) => {
 }) as Array<[LintRuleGroup, Record<string, string>]>;
 
 function getBiomeIndentStyle(indentStyle: PlaygroundSettings["indentStyle"]) {
-	return indentStyle === IndentStyle.Tab ? "tab" : "space";
+	return indentStyle === IndentStyle.Tab ? IndentStyle.Tab : IndentStyle.Space;
+}
+
+function getPlaygroundIndentStyle(indentStyle: IndentStyle | undefined) {
+	return indentStyle === IndentStyle.Space
+		? IndentStyle.Space
+		: defaultPlaygroundState.settings.indentStyle;
 }
 
 function getBiomeAttributePosition(
 	attributePosition: PlaygroundSettings["attributePosition"],
 ) {
-	return attributePosition === AttributePosition.Auto ? "auto" : "multiline";
+	return attributePosition === AttributePosition.Auto
+		? AttributePosition.Auto
+		: AttributePosition.Multiline;
+}
+
+function getPlaygroundAttributePosition(
+	attributePosition: AttributePosition | undefined,
+) {
+	return attributePosition === AttributePosition.Multiline
+		? AttributePosition.Multiline
+		: defaultPlaygroundState.settings.attributePosition;
 }
 
 function getBiomeExpand(expand: PlaygroundSettings["expand"]) {
 	switch (expand) {
 		case Expand.Always:
-			return "always";
+			return Expand.Always;
 		case Expand.Never:
-			return "never";
+			return Expand.Never;
 		default:
-			return "auto";
+			return Expand.Auto;
+	}
+}
+
+function getPlaygroundExpand(expand: Expand | undefined) {
+	switch (expand) {
+		case Expand.Always:
+			return Expand.Always;
+		case Expand.Never:
+			return Expand.Never;
+		default:
+			return defaultPlaygroundState.settings.expand;
 	}
 }
 
 function getBiomeQuoteStyle(quoteStyle: PlaygroundSettings["quoteStyle"]) {
-	return quoteStyle === QuoteStyle.Double ? "double" : "single";
+	return quoteStyle === QuoteStyle.Double
+		? QuoteStyle.Double
+		: QuoteStyle.Single;
+}
+
+function getPlaygroundQuoteStyle(quoteStyle: QuoteStyle | undefined) {
+	if (quoteStyle === QuoteStyle.Single) {
+		return QuoteStyle.Single;
+	}
+
+	if (quoteStyle === QuoteStyle.Double) {
+		return QuoteStyle.Double;
+	}
+
+	return undefined;
+}
+
+function getBiomeQuoteProperties(
+	quoteProperties: PlaygroundSettings["quoteProperties"],
+) {
+	return quoteProperties === QuoteProperties.Preserve ? "preserve" : "asNeeded";
+}
+
+function getPlaygroundQuoteProperties(
+	quoteProperties: "preserve" | "asNeeded" | undefined,
+) {
+	return quoteProperties === QuoteProperties.Preserve
+		? QuoteProperties.Preserve
+		: defaultPlaygroundState.settings.quoteProperties;
+}
+
+function getBiomeSemicolons(semicolons: PlaygroundSettings["semicolons"]) {
+	return semicolons === Semicolons.Always ? "always" : "asNeeded";
+}
+
+function getPlaygroundSemicolons(
+	semicolons: "always" | "asNeeded" | undefined,
+) {
+	return semicolons === "asNeeded"
+		? Semicolons.AsNeeded
+		: defaultPlaygroundState.settings.semicolons;
+}
+
+function getBiomeArrowParentheses(
+	arrowParentheses: PlaygroundSettings["arrowParentheses"],
+) {
+	return arrowParentheses === ArrowParentheses.Always ? "always" : "asNeeded";
+}
+
+function getPlaygroundArrowParentheses(
+	arrowParentheses: "always" | "asNeeded" | undefined,
+) {
+	return arrowParentheses === "asNeeded"
+		? ArrowParentheses.AsNeeded
+		: defaultPlaygroundState.settings.arrowParentheses;
+}
+
+function getBiomeOperatorLinebreak(
+	operatorLinebreak: PlaygroundSettings["operatorLinebreak"],
+) {
+	return operatorLinebreak === OperatorLinebreak.Before
+		? OperatorLinebreak.Before
+		: OperatorLinebreak.After;
+}
+
+function getPlaygroundOperatorLinebreak(
+	operatorLinebreak: OperatorLinebreak | undefined,
+) {
+	return operatorLinebreak === OperatorLinebreak.Before
+		? OperatorLinebreak.Before
+		: defaultPlaygroundState.settings.operatorLinebreak;
 }
 
 function getLintRuleGroup(
@@ -199,16 +296,11 @@ export function buildBiomeConfiguration(
 			formatter: {
 				quoteStyle: getBiomeQuoteStyle(quoteStyle),
 				jsxQuoteStyle: getBiomeQuoteStyle(jsxQuoteStyle),
-				quoteProperties:
-					quoteProperties === QuoteProperties.Preserve
-						? "preserve"
-						: "asNeeded",
+				quoteProperties: getBiomeQuoteProperties(quoteProperties),
 				trailingCommas,
-				semicolons: semicolons === Semicolons.Always ? "always" : "asNeeded",
-				arrowParentheses:
-					arrowParentheses === ArrowParentheses.Always ? "always" : "asNeeded",
-				operatorLinebreak:
-					operatorLinebreak === OperatorLinebreak.Before ? "before" : "after",
+				semicolons: getBiomeSemicolons(semicolons),
+				arrowParentheses: getBiomeArrowParentheses(arrowParentheses),
+				operatorLinebreak: getBiomeOperatorLinebreak(operatorLinebreak),
 				bracketSpacing,
 				bracketSameLine,
 				attributePosition: getBiomeAttributePosition(attributePosition),
@@ -268,54 +360,39 @@ export function parseBiomeConfiguration(
 	return {
 		...defaults,
 		lineWidth: formatter?.lineWidth ?? defaults.lineWidth,
-		indentStyle:
-			formatter?.indentStyle === "space"
-				? IndentStyle.Space
-				: defaults.indentStyle,
+		indentStyle: getPlaygroundIndentStyle(formatter?.indentStyle),
 		indentWidth: formatter?.indentWidth ?? defaults.indentWidth,
 		quoteStyle:
-			javascriptFormatter?.quoteStyle === "single"
-				? QuoteStyle.Single
-				: cssFormatter?.quoteStyle === "single"
-					? QuoteStyle.Single
-					: defaults.quoteStyle,
+			getPlaygroundQuoteStyle(javascriptFormatter?.quoteStyle) ??
+			getPlaygroundQuoteStyle(cssFormatter?.quoteStyle) ??
+			defaults.quoteStyle,
 		jsxQuoteStyle:
-			javascriptFormatter?.jsxQuoteStyle === "single"
-				? QuoteStyle.Single
-				: defaults.jsxQuoteStyle,
-		quoteProperties:
-			javascriptFormatter?.quoteProperties === "preserve"
-				? QuoteProperties.Preserve
-				: defaults.quoteProperties,
+			getPlaygroundQuoteStyle(javascriptFormatter?.jsxQuoteStyle) ??
+			defaults.jsxQuoteStyle,
+		quoteProperties: getPlaygroundQuoteProperties(
+			javascriptFormatter?.quoteProperties,
+		),
 		trailingCommas:
 			javascriptFormatter?.trailingCommas ?? defaults.trailingCommas,
-		semicolons:
-			javascriptFormatter?.semicolons === "asNeeded"
-				? Semicolons.AsNeeded
-				: defaults.semicolons,
-		arrowParentheses:
-			javascriptFormatter?.arrowParentheses === "asNeeded"
-				? ArrowParentheses.AsNeeded
-				: defaults.arrowParentheses,
-		operatorLinebreak:
-			javascriptFormatter?.operatorLinebreak === "before"
-				? OperatorLinebreak.Before
-				: defaults.operatorLinebreak,
+		semicolons: getPlaygroundSemicolons(javascriptFormatter?.semicolons),
+		arrowParentheses: getPlaygroundArrowParentheses(
+			javascriptFormatter?.arrowParentheses,
+		),
+		operatorLinebreak: getPlaygroundOperatorLinebreak(
+			javascriptFormatter?.operatorLinebreak,
+		),
 		attributePosition:
-			formatter?.attributePosition === "multiline" ||
-			javascriptFormatter?.attributePosition === "multiline"
+			getPlaygroundAttributePosition(formatter?.attributePosition) ===
+				AttributePosition.Multiline ||
+			getPlaygroundAttributePosition(javascriptFormatter?.attributePosition) ===
+				AttributePosition.Multiline
 				? AttributePosition.Multiline
 				: defaults.attributePosition,
 		bracketSpacing:
 			javascriptFormatter?.bracketSpacing ?? defaults.bracketSpacing,
 		bracketSameLine:
 			javascriptFormatter?.bracketSameLine ?? defaults.bracketSameLine,
-		expand:
-			formatter?.expand === "always"
-				? Expand.Always
-				: formatter?.expand === "never"
-					? Expand.Never
-					: defaults.expand,
+		expand: getPlaygroundExpand(formatter?.expand),
 		lintRules: getPlaygroundLintRules(linter?.rules),
 		enabledLinting: linter?.enabled ?? defaults.enabledLinting,
 		analyzerFixMode: defaults.analyzerFixMode,

--- a/src/playground/buildBiomeConfiguration.ts
+++ b/src/playground/buildBiomeConfiguration.ts
@@ -14,6 +14,11 @@ import {
 } from "@/playground/types";
 
 type LinterRules = NonNullable<NonNullable<Configuration["linter"]>["rules"]>;
+type LintRuleGroup = Exclude<keyof typeof LINT_RULES, "recommended" | "all">;
+
+const LINT_RULE_GROUPS = Object.entries(LINT_RULES).filter((entry) => {
+	return typeof entry[1] === "object";
+}) as Array<[LintRuleGroup, Record<string, string>]>;
 
 function getBiomeIndentStyle(indentStyle: PlaygroundSettings["indentStyle"]) {
 	return indentStyle === IndentStyle.Tab ? "tab" : "space";
@@ -40,6 +45,18 @@ function getBiomeQuoteStyle(quoteStyle: PlaygroundSettings["quoteStyle"]) {
 	return quoteStyle === QuoteStyle.Double ? "double" : "single";
 }
 
+function getLintRuleGroup(
+	lintRule: PlaygroundSettings["lintRules"],
+): LintRuleGroup | undefined {
+	for (const [groupName, rules] of LINT_RULE_GROUPS) {
+		if (lintRule in rules) {
+			return groupName;
+		}
+	}
+
+	return undefined;
+}
+
 function getLintRulesConfiguration(
 	lintRules: PlaygroundSettings["lintRules"],
 ): LinterRules {
@@ -61,10 +78,22 @@ function getLintRulesConfiguration(
 				style: "on",
 				suspicious: "on",
 			};
-		default:
+		default: {
+			const lintRuleGroup = getLintRuleGroup(lintRules);
+
+			if (lintRuleGroup !== undefined) {
+				return {
+					recommended: false,
+					[lintRuleGroup]: {
+						[lintRules]: "on",
+					},
+				} as LinterRules;
+			}
+
 			return {
 				recommended: false,
 			};
+		}
 	}
 }
 
@@ -84,6 +113,20 @@ function getPlaygroundLintRules(linterRules: LinterRules | undefined) {
 		rules.style,
 		rules.suspicious,
 	];
+
+	for (const [groupName, groupRules] of LINT_RULE_GROUPS) {
+		const groupConfiguration = rules[groupName];
+
+		if (!groupConfiguration || typeof groupConfiguration !== "object") {
+			continue;
+		}
+
+		for (const lintRule of Object.keys(groupRules)) {
+			if ((groupConfiguration as Record<string, unknown>)[lintRule] === "on") {
+				return lintRule as PlaygroundSettings["lintRules"];
+			}
+		}
+	}
 
 	if (enabledGroups.every((value) => value === "on")) {
 		return LINT_RULES.all;

--- a/src/playground/components/SettingsJsonEditorModal.tsx
+++ b/src/playground/components/SettingsJsonEditorModal.tsx
@@ -31,18 +31,21 @@ export default function SettingsJsonEditorModal({
 	onClose,
 }: SettingsJsonEditorModalProps) {
 	const dialogRef = useRef<HTMLDialogElement>(null);
+	const wasOpenRef = useRef(false);
 	const [jsonValue, setJsonValue] = useState("");
 	const [jsonError, setJsonError] = useState<string | null>(null);
 	const [copyStatus, setCopyStatus] = useState<"idle" | "copied">("idle");
 
 	useEffect(() => {
-		if (isOpen) {
+		if (isOpen && !wasOpenRef.current) {
 			setJsonValue(
 				JSON.stringify(createEditableConfiguration(settings), null, 2),
 			);
 			setJsonError(null);
 			setCopyStatus("idle");
 		}
+
+		wasOpenRef.current = isOpen;
 	}, [isOpen, settings]);
 
 	useEffect(() => {

--- a/src/playground/components/SettingsJsonEditorModal.tsx
+++ b/src/playground/components/SettingsJsonEditorModal.tsx
@@ -31,6 +31,7 @@ export default function SettingsJsonEditorModal({
 	onClose,
 }: SettingsJsonEditorModalProps) {
 	const dialogRef = useRef<HTMLDialogElement>(null);
+	const copyStatusTimeoutRef = useRef<number | null>(null);
 	const wasOpenRef = useRef(false);
 	const [configurationAsJson, setConfigurationAsJson] = useState(() =>
 		JSON.stringify(createEditableConfiguration(settings), null, 2),
@@ -39,50 +40,57 @@ export default function SettingsJsonEditorModal({
 	const [copyStatus, setCopyStatus] = useState<"idle" | "copied">("idle");
 
 	useEffect(() => {
+		return () => {
+			if (copyStatusTimeoutRef.current !== null) {
+				window.clearTimeout(copyStatusTimeoutRef.current);
+			}
+		};
+	}, []);
+
+	useEffect(() => {
+		const dialog = dialogRef.current;
+
 		if (isOpen && !wasOpenRef.current) {
 			setConfigurationAsJson(
 				JSON.stringify(createEditableConfiguration(settings), null, 2),
 			);
 			setJsonError(null);
+			if (copyStatusTimeoutRef.current !== null) {
+				window.clearTimeout(copyStatusTimeoutRef.current);
+				copyStatusTimeoutRef.current = null;
+			}
 			setCopyStatus("idle");
 		}
 
-		wasOpenRef.current = isOpen;
-	}, [isOpen, settings]);
-
-	useEffect(() => {
 		if (!isOpen) {
-			if (dialogRef.current?.open) {
-				dialogRef.current.close();
+			if (dialog?.open) {
+				dialog.close();
 			}
+			wasOpenRef.current = isOpen;
 			return;
 		}
 
-		const dialog = dialogRef.current;
 		if (dialog === null || dialog.open) {
+			wasOpenRef.current = isOpen;
 			return;
 		}
 
 		dialog.showModal();
-	}, [isOpen]);
-
-	useEffect(() => {
-		if (copyStatus !== "copied") {
-			return;
-		}
-
-		const timeoutId = window.setTimeout(() => {
-			setCopyStatus("idle");
-		}, 2000);
-
-		return () => {
-			window.clearTimeout(timeoutId);
-		};
-	}, [copyStatus]);
+		wasOpenRef.current = isOpen;
+	}, [isOpen, settings]);
 
 	async function copyJsonSettings() {
 		await navigator.clipboard.writeText(configurationAsJson);
+
+		if (copyStatusTimeoutRef.current !== null) {
+			window.clearTimeout(copyStatusTimeoutRef.current);
+		}
+
 		setCopyStatus("copied");
+		copyStatusTimeoutRef.current = window.setTimeout(() => {
+			setCopyStatus("idle");
+			copyStatusTimeoutRef.current = null;
+		}, 2000);
 	}
 
 	function applyJsonSettings() {

--- a/src/playground/components/SettingsJsonEditorModal.tsx
+++ b/src/playground/components/SettingsJsonEditorModal.tsx
@@ -1,0 +1,171 @@
+import type { Configuration } from "@biomejs/wasm-web";
+import { json } from "@codemirror/lang-json";
+import { useEffect, useRef, useState } from "react";
+import {
+	buildBiomeConfiguration,
+	parseBiomeConfiguration,
+} from "@/playground/buildBiomeConfiguration";
+import CodeMirror from "@/playground/CodeMirror";
+import type { PlaygroundSettings } from "@/playground/types";
+
+interface SettingsJsonEditorModalProps {
+	isOpen: boolean;
+	settings: PlaygroundSettings;
+	onApply: (settings: PlaygroundSettings) => void;
+	onClose: () => void;
+}
+
+function createEditableConfiguration(
+	settings: PlaygroundSettings,
+): Configuration {
+	return {
+		$schema: "https://biomejs.dev/schemas/<version>/schema.json",
+		...buildBiomeConfiguration(settings),
+	};
+}
+
+export default function SettingsJsonEditorModal({
+	isOpen,
+	settings,
+	onApply,
+	onClose,
+}: SettingsJsonEditorModalProps) {
+	const dialogRef = useRef<HTMLDialogElement>(null);
+	const [jsonValue, setJsonValue] = useState("");
+	const [jsonError, setJsonError] = useState<string | null>(null);
+	const [copyStatus, setCopyStatus] = useState<"idle" | "copied">("idle");
+
+	useEffect(() => {
+		if (isOpen) {
+			setJsonValue(
+				JSON.stringify(createEditableConfiguration(settings), null, 2),
+			);
+			setJsonError(null);
+			setCopyStatus("idle");
+		}
+	}, [isOpen, settings]);
+
+	useEffect(() => {
+		if (!isOpen) {
+			if (dialogRef.current?.open) {
+				dialogRef.current.close();
+			}
+			return;
+		}
+
+		const dialog = dialogRef.current;
+		if (dialog === null || dialog.open) {
+			return;
+		}
+
+		dialog.showModal();
+	}, [isOpen]);
+
+	useEffect(() => {
+		if (copyStatus !== "copied") {
+			return;
+		}
+
+		const timeoutId = window.setTimeout(() => {
+			setCopyStatus("idle");
+		}, 2000);
+
+		return () => {
+			window.clearTimeout(timeoutId);
+		};
+	}, [copyStatus]);
+
+	async function copyJsonSettings() {
+		await navigator.clipboard.writeText(jsonValue);
+		setCopyStatus("copied");
+	}
+
+	function applyJsonSettings() {
+		try {
+			const parsed = JSON.parse(jsonValue) as Configuration;
+			onApply(parseBiomeConfiguration(parsed));
+			onClose();
+		} catch (error) {
+			setJsonError(
+				error instanceof Error ? error.message : "Invalid JSON settings.",
+			);
+		}
+	}
+
+	return (
+		<dialog
+			ref={dialogRef}
+			className="settings-json-modal"
+			aria-labelledby="settings-json-modal-title"
+			onClick={(event) => {
+				if (event.target === event.currentTarget) {
+					onClose();
+				}
+			}}
+			onKeyDown={(event) => {
+				if (
+					event.target === event.currentTarget &&
+					(event.key === "Enter" || event.key === " ")
+				) {
+					event.preventDefault();
+					onClose();
+				}
+			}}
+			onClose={onClose}
+			onCancel={(event) => {
+				event.preventDefault();
+				onClose();
+			}}
+		>
+			<form
+				method="dialog"
+				className="settings-json-modal__content"
+				onSubmit={(event) => {
+					event.preventDefault();
+				}}
+			>
+				<div className="settings-json-modal__header">
+					<h3 id="settings-json-modal-title">
+						Effective Playground configuration
+					</h3>
+					<button
+						type="button"
+						className="settings-json-modal__close"
+						onClick={onClose}
+						aria-label="Close JSON editor"
+					>
+						<span aria-hidden={true}>×</span>
+					</button>
+				</div>
+				<div className="settings-json-modal__subheader">
+					<span>biome.json</span>
+					<span className="settings-json-modal__hint">
+						Update the $schema version manually.
+					</span>
+				</div>
+				<CodeMirror
+					className="settings-json-modal__editor"
+					value={jsonValue}
+					extensions={[json()]}
+					onChange={(value) => {
+						setJsonValue(value);
+						if (jsonError !== null) {
+							setJsonError(null);
+						}
+					}}
+					placeholder="{}"
+					autoFocus={true}
+				/>
+				{jsonError && <p className="settings-json-modal__error">{jsonError}</p>}
+				<div className="settings-json-modal__actions">
+					<button type="button" onClick={copyJsonSettings}>
+						{copyStatus === "copied" ? "Copied" : "Copy"}
+					</button>
+					<button type="button" onClick={applyJsonSettings}>
+						Apply to Playground
+					</button>
+				</div>
+			</form>
+		</dialog>
+	);
+}

--- a/src/playground/components/SettingsJsonEditorModal.tsx
+++ b/src/playground/components/SettingsJsonEditorModal.tsx
@@ -32,13 +32,15 @@ export default function SettingsJsonEditorModal({
 }: SettingsJsonEditorModalProps) {
 	const dialogRef = useRef<HTMLDialogElement>(null);
 	const wasOpenRef = useRef(false);
-	const [jsonValue, setJsonValue] = useState("");
+	const [configurationAsJson, setConfigurationAsJson] = useState(() =>
+		JSON.stringify(createEditableConfiguration(settings), null, 2),
+	);
 	const [jsonError, setJsonError] = useState<string | null>(null);
 	const [copyStatus, setCopyStatus] = useState<"idle" | "copied">("idle");
 
 	useEffect(() => {
 		if (isOpen && !wasOpenRef.current) {
-			setJsonValue(
+			setConfigurationAsJson(
 				JSON.stringify(createEditableConfiguration(settings), null, 2),
 			);
 			setJsonError(null);
@@ -79,13 +81,13 @@ export default function SettingsJsonEditorModal({
 	}, [copyStatus]);
 
 	async function copyJsonSettings() {
-		await navigator.clipboard.writeText(jsonValue);
+		await navigator.clipboard.writeText(configurationAsJson);
 		setCopyStatus("copied");
 	}
 
 	function applyJsonSettings() {
 		try {
-			const parsed = JSON.parse(jsonValue) as Configuration;
+			const parsed = JSON.parse(configurationAsJson) as Configuration;
 			onApply(parseBiomeConfiguration(parsed, settings));
 			onClose();
 		} catch (error) {
@@ -148,10 +150,10 @@ export default function SettingsJsonEditorModal({
 				</div>
 				<CodeMirror
 					className="settings-json-modal__editor"
-					value={jsonValue}
+					value={configurationAsJson}
 					extensions={[json()]}
 					onChange={(value) => {
-						setJsonValue(value);
+						setConfigurationAsJson(value);
 						if (jsonError !== null) {
 							setJsonError(null);
 						}

--- a/src/playground/components/SettingsJsonEditorModal.tsx
+++ b/src/playground/components/SettingsJsonEditorModal.tsx
@@ -83,7 +83,7 @@ export default function SettingsJsonEditorModal({
 	function applyJsonSettings() {
 		try {
 			const parsed = JSON.parse(jsonValue) as Configuration;
-			onApply(parseBiomeConfiguration(parsed));
+			onApply(parseBiomeConfiguration(parsed, settings));
 			onClose();
 		} catch (error) {
 			setJsonError(

--- a/src/playground/tabs/SettingsTab.tsx
+++ b/src/playground/tabs/SettingsTab.tsx
@@ -7,6 +7,7 @@ import type {
 import type React from "react";
 import { type Dispatch, type SetStateAction, useId, useState } from "react";
 import EnumSelect from "@/playground/components/EnumSelect";
+import SettingsJsonEditorModal from "@/playground/components/SettingsJsonEditorModal";
 import { LINT_RULES } from "@/playground/generated/lintRules.ts";
 import {
 	ArrowParentheses,
@@ -76,6 +77,7 @@ export default function SettingsTab({
 			experimentalFullSupportEnabled,
 			cssModules,
 			tailwindDirectives,
+			gritTargetLanguage,
 		},
 	},
 }: SettingsTabProps) {
@@ -320,6 +322,39 @@ export default function SettingsTab({
 					{singleFileMode ? "Multi-file mode" : "Single-file mode"}
 				</button>
 			</section>
+			<SettingsJsonEditorSection
+				settings={{
+					lineWidth,
+					indentWidth,
+					indentStyle,
+					quoteStyle,
+					jsxQuoteStyle,
+					quoteProperties,
+					trailingCommas,
+					semicolons,
+					arrowParentheses,
+					operatorLinebreak,
+					bracketSpacing,
+					bracketSameLine,
+					expand,
+					indentScriptAndStyle,
+					whitespaceSensitivity,
+					lintRules,
+					enabledLinting,
+					analyzerFixMode,
+					enabledAssist,
+					unsafeParameterDecoratorsEnabled,
+					allowComments,
+					attributePosition,
+					ruleDomains,
+					experimentalEmbeddedSnippetsEnabled,
+					experimentalFullSupportEnabled,
+					cssModules,
+					tailwindDirectives,
+					gritTargetLanguage,
+				}}
+				setPlaygroundState={setPlaygroundState}
+			/>
 
 			{singleFileMode ? (
 				<LanguageView language={language} setLanguage={setLanguage} />
@@ -753,6 +788,37 @@ function SyntaxSettings({
 					<label htmlFor={tailwindDirectivesId}>Tailwind v4</label>
 				</div>
 			</section>
+		</>
+	);
+}
+
+function SettingsJsonEditorSection({
+	settings,
+	setPlaygroundState,
+}: {
+	settings: PlaygroundState["settings"];
+	setPlaygroundState: Dispatch<SetStateAction<PlaygroundState>>;
+}) {
+	const [isJsonModalOpen, setIsJsonModalOpen] = useState(false);
+
+	return (
+		<>
+			<section className="settings-json-actions">
+				<button type="button" onClick={() => setIsJsonModalOpen(true)}>
+					Edit as JSON
+				</button>
+			</section>
+			<SettingsJsonEditorModal
+				isOpen={isJsonModalOpen}
+				settings={settings}
+				onApply={(nextSettings) => {
+					setPlaygroundState((state) => ({
+						...state,
+						settings: nextSettings,
+					}));
+				}}
+				onClose={() => setIsJsonModalOpen(false)}
+			/>
 		</>
 	);
 }

--- a/src/playground/tabs/SettingsTab.tsx
+++ b/src/playground/tabs/SettingsTab.tsx
@@ -805,7 +805,7 @@ function SettingsJsonEditorSection({
 		<>
 			<section className="settings-json-actions">
 				<button type="button" onClick={() => setIsJsonModalOpen(true)}>
-					Edit as JSON
+					Edit configuration as JSON
 				</button>
 			</section>
 			<SettingsJsonEditorModal

--- a/src/styles/playground/_settings.css
+++ b/src/styles/playground/_settings.css
@@ -308,6 +308,7 @@
 	border: 1px solid var(--sl-border);
 	border-radius: 14px;
 	background: #282c34;
+	color: rgb(226 232 240 / 92%);
 	box-shadow: 0 28px 80px rgb(0 0 0 / 35%);
 }
 
@@ -384,4 +385,5 @@
 	margin: 0;
 	padding: 10px 14px 0;
 	font-size: 0.75rem;
+	color: rgb(248 113 113 / 92%);
 }

--- a/src/styles/playground/_settings.css
+++ b/src/styles/playground/_settings.css
@@ -279,3 +279,109 @@
 		}
 	}
 }
+
+.settings-json-modal {
+	z-index: 1000;
+	width: min(840px, calc(100vw - 48px));
+	height: min(640px, calc(100vh - 64px));
+	padding: 0;
+	margin: auto;
+	border: 0;
+	background: transparent;
+	color: inherit;
+	overflow: visible;
+	max-width: none;
+	max-height: none;
+}
+
+.settings-json-modal::backdrop {
+	background: rgb(0 0 0 / 72%);
+}
+
+.settings-json-modal__content {
+	display: flex;
+	flex-direction: column;
+	gap: 0;
+	width: 100%;
+	height: 100%;
+	overflow: hidden;
+	border: 1px solid var(--sl-border);
+	border-radius: 14px;
+	background: #282c34;
+	box-shadow: 0 28px 80px rgb(0 0 0 / 35%);
+}
+
+.settings-json-modal__header,
+.settings-json-modal__actions,
+.settings-json-modal__subheader {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	gap: 8px;
+	padding: 10px 14px;
+	background: #282c34;
+}
+
+.settings-json-modal__header h3 {
+	margin: 0;
+	font-size: 0.9375rem;
+	font-weight: 600;
+	letter-spacing: 0.01em;
+}
+
+.settings-json-modal__close {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 28px;
+	height: 28px;
+	padding: 0;
+	margin-left: auto;
+	font-size: 1.125rem;
+	line-height: 1;
+}
+
+.settings-json-modal__actions {
+	justify-content: flex-end;
+	border-top: 1px solid var(--sl-border);
+}
+
+.settings-json-modal__header {
+	border-bottom: 1px solid var(--sl-border);
+}
+
+.settings-json-modal__subheader {
+	gap: 12px;
+	border-bottom: 1px solid var(--sl-border);
+	font-family: var(--code-font);
+	font-size: 0.75rem;
+	color: rgb(226 232 240 / 88%);
+}
+
+.settings-json-modal__hint {
+	opacity: 0.64;
+	font-size: 0.6875rem;
+}
+
+.settings-json-modal__editor {
+	flex: 1;
+	min-height: 0;
+	background: #282c34;
+}
+
+.settings-json-modal__editor .cm-editor {
+	height: 100%;
+	font-size: 0.875rem;
+	background: #282c34;
+}
+
+.settings-json-modal__editor .cm-scroller {
+	font-family: var(--code-font);
+	line-height: 1.6;
+}
+
+.settings-json-modal__error {
+	margin: 0;
+	padding: 10px 14px 0;
+	font-size: 0.75rem;
+}


### PR DESCRIPTION
## Summary
Closes #4113 
- add an `Edit as JSON` entry point in the Playground settings tab
- add a native `dialog`-based JSON editor for editing Playground settings
- expose settings as a `biome.json`-like configuration that can also be copied

## Notes

- the JSON includes a placeholder `$schema` value
- users can update the `$schema` version manually if needed
- this keeps the existing worker behavior unchanged
