### PR TITLE
Add `--` in yarn commands to distinguish commands flags from yarn flags

### DIFF
--- a/src/components/PackageManagerBiomeCommand.astro
+++ b/src/components/PackageManagerBiomeCommand.astro
@@ -28,6 +28,6 @@ const biomeBin = "biome";
 		/>
 	</TabItem>
 	<TabItem label="yarn" icon="seti:yarn">
-		<Code frame="none" code={`yarn exec ${biomeBin} ${command}`} lang="bash" />
+		<Code frame="none" code={`yarn exec ${biomeBin} -- ${command}`} lang="bash" />
 	</TabItem>
 </Tabs>


### PR DESCRIPTION
## Summary


This should address biomejs/biome#6999, where the `--write` flag isn't actually passed to the biome command.

Note, `src/components/PackageManagerCommand.astro` might need a similar fix, but I haven't seen how/where it's used.
