### PR TITLE
fix: use fixed image URL for GitHub avatars

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -32,27 +32,27 @@ const plugins = [
 		authors: {
 			arendjr: {
 				name: "Arend van Beelen jr.",
-				picture: "https://github.com/arendjr.png",
+				picture: "https://avatars.githubusercontent.com/u/533294?v=4",
 				url: "https://arendjr.nl/",
 			},
 			conaclos: {
 				name: "Victorien Elvinger",
-				picture: "https://github.com/conaclos.png",
+				picture: "https://avatars.githubusercontent.com/u/2358560?v=4",
 				url: "https://bsky.app/profile/conaclos.bsky.social",
 			},
 			dyc3: {
 				name: "Carson McManus",
-				picture: "https://github.com/dyc3.png",
+				picture: "https://avatars.githubusercontent.com/u/1808807?v=4",
 				url: "https://github.com/dyc3",
 			},
 			ema: {
 				name: "Emanuele Stoppa",
-				picture: "https://github.com/ematipico.png",
+				picture: "https://avatars.githubusercontent.com/u/602478?v=4",
 				url: "https://bsky.app/profile/ematipico.xyz",
 			},
 			nhedger: {
 				name: "Nicolas Hedger",
-				picture: "https://github.com/nhedger.png",
+				picture: "https://avatars.githubusercontent.com/u/649677?v=4",
 				url: "https://bsky.app/profile/hedger.ch",
 			},
 			team: {

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -1034,7 +1034,12 @@ export default defineConfig({
 		format: "directory",
 	},
 	image: {
-		domains: ["github.com", "avatars.githubusercontent.com", "raw.githubusercontent.com", "img.shields.io"],
+		domains: [
+			"github.com",
+			"avatars.githubusercontent.com",
+			"raw.githubusercontent.com",
+			"img.shields.io",
+		],
 	},
 
 	markdown: {

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -1034,7 +1034,7 @@ export default defineConfig({
 		format: "directory",
 	},
 	image: {
-		domains: ["github.com", "raw.githubusercontent.com", "img.shields.io"],
+		domains: ["github.com", "avatars.githubusercontent.com", "raw.githubusercontent.com", "img.shields.io"],
 	},
 
 	markdown: {

--- a/src/components/Avatar.astro
+++ b/src/components/Avatar.astro
@@ -12,26 +12,17 @@ if (!member) {
 	throw new Error(`The member ${handle} doesn't exist`);
 }
 
-// Fetch the image and extract the redirected URL as Astro doesn't support remote images with redirection.
-const response = await fetch(
-	`https://github.com/${member.data.id}.png?size=25`,
-	{ redirect: "manual" },
-);
-const imageUrl = response.headers.get("location");
-if (response.status < 300 || response.status >= 400 || !imageUrl) {
-	throw new Error("The GitHub avatar image should respond with 30x redirect");
-}
-
 const prefix = member.data.type === "core" ? "Core Contributor" : "Maintainer";
-const url = `https://github.com/${member.data.id}`;
-const alt = `Member @${member.data.id}`;
+const url = `https://github.com/${member.id}`;
+const imageUrl = `https://avatars.githubusercontent.com/u/${member.data.id}?v=4&s=25`;
+const alt = `Member @${member.id}`;
 ---
 
 <span class="avatar">
 	<span>{prefix}</span>
 	<a href={url} title={alt}>
 		<Image src={imageUrl} alt={alt} width="25" height="25" />
-		<span>@{member.data.id}</span>
+		<span>@{member.id}</span>
 	</a>
 </span>
 

--- a/src/components/Avatar.astro
+++ b/src/components/Avatar.astro
@@ -12,9 +12,18 @@ if (!member) {
 	throw new Error(`The member ${handle} doesn't exist`);
 }
 
+// Fetch the image and extract the redirected URL as Astro doesn't support remote images with redirection.
+const response = await fetch(
+	`https://github.com/${member.data.id}.png?size=25`,
+	{ redirect: "manual" },
+);
+if (response.status < 300 || response.status >= 400) {
+	throw new Error("The GitHub avatar image should response 30x redirect");
+}
+
 const prefix = member.data.type === "core" ? "Core Contributor" : "Maintainer";
 const url = `https://github.com/${member.data.id}`;
-const imageUrl = `${url}.png?size=25`;
+const imageUrl = response.headers.get("location") as string;
 const alt = `Member @${member.data.id}`;
 ---
 

--- a/src/components/Avatar.astro
+++ b/src/components/Avatar.astro
@@ -17,13 +17,13 @@ const response = await fetch(
 	`https://github.com/${member.data.id}.png?size=25`,
 	{ redirect: "manual" },
 );
-if (response.status < 300 || response.status >= 400) {
-	throw new Error("The GitHub avatar image should response 30x redirect");
+const imageUrl = response.headers.get("location");
+if (response.status < 300 || response.status >= 400 || !imageUrl) {
+	throw new Error("The GitHub avatar image should respond with 30x redirect");
 }
 
 const prefix = member.data.type === "core" ? "Core Contributor" : "Maintainer";
 const url = `https://github.com/${member.data.id}`;
-const imageUrl = response.headers.get("location") as string;
 const alt = `Member @${member.data.id}`;
 ---
 

--- a/src/components/GitHubAvatar.astro
+++ b/src/components/GitHubAvatar.astro
@@ -16,12 +16,12 @@ const response = await fetch(
 	`https://github.com/${member.data.id}.png?size=200`,
 	{ redirect: "manual" },
 );
-if (response.status < 300 || response.status >= 400) {
-	throw new Error("The GitHub avatar image should response 30x redirect");
+const image = response.headers.get("location");
+if (response.status < 300 || response.status >= 400 || !image) {
+	throw new Error("The GitHub avatar image should respond with 30x redirect");
 }
 
 const url = `https://github.com/${member.data.id}`;
-const image = response.headers.get("location") as string;
 const alt = `User ${handle}`;
 ---
 

--- a/src/components/GitHubAvatar.astro
+++ b/src/components/GitHubAvatar.astro
@@ -7,21 +7,12 @@ interface Props {
 }
 const { handle } = Astro.props;
 const member = await getEntry("team", handle);
+
 if (!member) {
 	throw new Error(`The member ${handle} doesn't exist`);
 }
-
-// Fetch the image and extract the redirected URL as Astro doesn't support remote images with redirection.
-const response = await fetch(
-	`https://github.com/${member.data.id}.png?size=200`,
-	{ redirect: "manual" },
-);
-const image = response.headers.get("location");
-if (response.status < 300 || response.status >= 400 || !image) {
-	throw new Error("The GitHub avatar image should respond with 30x redirect");
-}
-
-const url = `https://github.com/${member.data.id}`;
+const url = `https://github.com/${member.id}`;
+const image = `https://avatars.githubusercontent.com/u/${member.data.id}?v=4&s=200`;
 const alt = `User ${handle}`;
 ---
 
@@ -32,5 +23,5 @@ const alt = `User ${handle}`;
             width="200"
             height="200"
     />
-	<span>@{member.data.id}</span>
+	<span>@{member.id}</span>
 </a>

--- a/src/components/GitHubAvatar.astro
+++ b/src/components/GitHubAvatar.astro
@@ -7,12 +7,21 @@ interface Props {
 }
 const { handle } = Astro.props;
 const member = await getEntry("team", handle);
-
 if (!member) {
 	throw new Error(`The member ${handle} doesn't exist`);
 }
+
+// Fetch the image and extract the redirected URL as Astro doesn't support remote images with redirection.
+const response = await fetch(
+	`https://github.com/${member.data.id}.png?size=200`,
+	{ redirect: "manual" },
+);
+if (response.status < 300 || response.status >= 400) {
+	throw new Error("The GitHub avatar image should response 30x redirect");
+}
+
 const url = `https://github.com/${member.data.id}`;
-const image = `https://github.com/${member.data.id}.png?size=200`;
+const image = response.headers.get("location") as string;
 const alt = `User ${handle}`;
 ---
 

--- a/src/components/Maintainers.astro
+++ b/src/components/Maintainers.astro
@@ -4,12 +4,6 @@ import GitHubAvatar from "@/components/GitHubAvatar.astro";
 
 <ul class="credits-people-list maintainers">
     <li>
-       <GitHubAvatar handle="DaniGuardiola" />
-    </li>
-    <li>
-       <GitHubAvatar handle="minht11" />
-    </li>
-    <li>
        <GitHubAvatar handle="SuperchupuDev" />
     </li>
     <li>

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,7 +1,8 @@
-import { defineCollection, z } from "astro:content";
+import { defineCollection } from "astro:content";
 import { docsLoader, i18nLoader } from "@astrojs/starlight/loaders";
 import { docsSchema, i18nSchema } from "@astrojs/starlight/schema";
 import { file } from "astro/loaders";
+import { z } from "astro/zod";
 import { blogSchema } from "starlight-blog/schema";
 import { changelogsLoader } from "starlight-changelogs/loader";
 
@@ -26,7 +27,7 @@ export const collections = {
 	team: defineCollection({
 		schema: () =>
 			z.object({
-				id: z.string(),
+				id: z.number(),
 				type: z.enum(["core", "maintainer"]),
 			}),
 		loader: file("src/content/team.json"),

--- a/src/content/team.json
+++ b/src/content/team.json
@@ -1,19 +1,17 @@
-[
-  { "id": "ematipico", "type": "core" },
-  { "id": "arendjr", "type": "core" },
-  { "id": "conaclos", "type": "core" },
-  { "id": "dyc3", "type": "core" },
-  { "id": "siketyan", "type": "core" },
-  { "id": "unvalley", "type": "core" },
-  { "id": "denbezrukov", "type": "core" },
-  { "id": "nhedger", "type": "core" },
-  { "id": "DaniGuardiola", "type": "maintainer" },
-  { "id": "minht11", "type": "maintainer" },
-  { "id": "SuperchupuDev", "type": "maintainer" },
-  { "id": "mdevils", "type": "maintainer" },
-  { "id": "l0ngvh", "type": "maintainer" },
-  { "id": "togami2864", "type": "maintainer" },
-  { "id": "chansuke", "type": "maintainer" },
-  { "id": "fireairforce", "type": "maintainer" },
-  { "id": "netail", "type": "maintainer" }
-]
+{
+  "ematipico": { "id": 602478, "type": "core" },
+  "arendjr": { "id": 533294, "type": "core" },
+  "conaclos": { "id": 2358560, "type": "core" },
+  "dyc3": { "id": 1808807, "type": "core" },
+  "siketyan": { "id": 12772118, "type": "core" },
+  "unvalley": { "id": 38400669, "type": "core" },
+  "denbezrukov": { "id": 6227442, "type": "core" },
+  "nhedger": { "id": 649677, "type": "core" },
+  "SuperchupuDev": { "id": 53496941, "type": "maintainer" },
+  "mdevils": { "id": 176898, "type": "maintainer" },
+  "l0ngvh": { "id": 78085736, "type": "maintainer" },
+  "togami2864": { "id": 62130798, "type": "maintainer" },
+  "chansuke": { "id": 501052, "type": "maintainer" },
+  "fireairforce": { "id": 32598811, "type": "maintainer" },
+  "netail": { "id": 11695769, "type": "maintainer" }
+}


### PR DESCRIPTION
## Summary

Astro doesn't support redirection for remote images since 5.17.3 (https://github.com/withastro/astro/commit/e01e98b063e90d274c42130ec2a60cc0966622c9). To mitigate the error, added pre-fetching the redirected image URL in `Avatar` and `GitHubAvatar` components.

This will resolve the build error in #4097 