### PR TITLE
ci: use cargo-sweep to minimize size of saved caches

### DIFF
--- a/.github/actions/run-codegen/action.yaml
+++ b/.github/actions/run-codegen/action.yaml
@@ -17,7 +17,7 @@ runs:
       uses: moonrepo/setup-rust@ede6de059f8046a5e236c94046823e2af11ca670 # v1.2.2
       with:
         cache: false
-        bins: cargo-cache
+        bins: cargo-cache, cargo-sweep
 
     - name: Restore rust cache
       id: cache-restore
@@ -28,6 +28,10 @@ runs:
         path: |
           $HOME/.cargo/registry
           target/debug
+
+    - name: Stamp rust build cache
+      shell: bash
+      run: cargo sweep --stamp
 
     - name: Codegen
       shell: bash
@@ -85,6 +89,10 @@ runs:
         echo "Removing dep-info files (*.d)"
         find "target/debug" -type f -name "*.d" -exec rm -f {} \;
       continue-on-error: true
+
+    - name: Sweep unused rust build cache
+      shell: bash
+      run: cargo sweep --file
 
     - name: Save new rust cache
       uses: actions/cache/save@668228422ae6a00e4ad889ee87cd7109ec5666a7 # v5.0.4


### PR DESCRIPTION
## Summary

<!-- 
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

Our sync job takes >30 minutes, and most of that is downloading and uncompressing the build cache, and then compressing it and reuploading it. This is because the build cache can balloon to tens of gigs. Hoping this will reduce or negate that.
