### PR TITLE
Add Markdown playground

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@codemirror/lang-html": "6.4.11",
     "@codemirror/lang-javascript": "6.2.5",
     "@codemirror/lang-json": "6.0.2",
+    "@codemirror/lang-markdown": "^6.5.0",
     "@codemirror/lang-vue": "0.1.3",
     "@codemirror/language": "6.12.3",
     "@codemirror/lint": "6.9.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,9 @@ importers:
       '@codemirror/lang-json':
         specifier: 6.0.2
         version: 6.0.2
+      '@codemirror/lang-markdown':
+        specifier: ^6.5.0
+        version: 6.5.0
       '@codemirror/lang-vue':
         specifier: 0.1.3
         version: 0.1.3
@@ -498,6 +501,9 @@ packages:
 
   '@codemirror/lang-json@6.0.2':
     resolution: {integrity: sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==}
+
+  '@codemirror/lang-markdown@6.5.0':
+    resolution: {integrity: sha512-0K40bZ35jpHya6FriukbgaleaqzBLZfOh7HuzqbMxBXkbYMJDxfF39c23xOgxFezR+3G+tR2/Mup+Xk865OMvw==}
 
   '@codemirror/lang-vue@0.1.3':
     resolution: {integrity: sha512-QSKdtYTDRhEHCfo5zOShzxCmqKJvgGrZwDQSdbvCRJ5pRLWBS7pD/8e/tH44aVQT6FKm0t6RVNoSUWHOI5vNug==}
@@ -1137,6 +1143,9 @@ packages:
 
   '@lezer/lr@1.4.8':
     resolution: {integrity: sha512-bPWa0Pgx69ylNlMlPvBPryqeLYQjyJjqPx+Aupm5zydLIF3NE+6MMLT8Yi23Bd9cif9VS00aUebn+6fDIGBcDA==}
+
+  '@lezer/markdown@1.6.3':
+    resolution: {integrity: sha512-jpGm5Ps+XErS+xA4urw7ogEGkeZOahVQF21Z6oECF0sj+2liwZopd2+I8uH5I/vZsRuuze3OxBREIANLf6KKUw==}
 
   '@lunariajs/core@0.1.1':
     resolution: {integrity: sha512-sAqM9+DVsLe3xHM9wu2pEnKGYMs/bWS9qpR+CGHol3RihOELnOQTzHddXbdB1MtgesbI8dnQuG64Ocd8KkWsng==}
@@ -6827,6 +6836,16 @@ snapshots:
       '@codemirror/language': 6.12.3
       '@lezer/json': 1.0.3
 
+  '@codemirror/lang-markdown@6.5.0':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/lang-html': 6.4.11
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@lezer/common': 1.5.2
+      '@lezer/markdown': 1.6.3
+
   '@codemirror/lang-vue@0.1.3':
     dependencies:
       '@codemirror/lang-html': 6.4.11
@@ -7311,6 +7330,11 @@ snapshots:
   '@lezer/lr@1.4.8':
     dependencies:
       '@lezer/common': 1.5.2
+
+  '@lezer/markdown@1.6.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
 
   '@lunariajs/core@0.1.1':
     dependencies:

--- a/src/playground/Playground.tsx
+++ b/src/playground/Playground.tsx
@@ -2,6 +2,7 @@ import { css } from "@codemirror/lang-css";
 import { html } from "@codemirror/lang-html";
 import { javascript } from "@codemirror/lang-javascript";
 import { json } from "@codemirror/lang-json";
+import { markdown } from "@codemirror/lang-markdown";
 import { vue } from "@codemirror/lang-vue";
 import { EditorSelection } from "@codemirror/state";
 import type { ViewUpdate } from "@codemirror/view";
@@ -48,6 +49,7 @@ import {
 	isHtmlFilename,
 	isJsonFilename,
 	isJsxFilename,
+	isMarkdownFilename,
 	isSvelteFilename,
 	isTypeScriptFilename,
 	isVueFilename,
@@ -88,6 +90,9 @@ export default function Playground({
 		}
 		if (isSvelteFilename(playgroundState.currentFile)) {
 			return [svelte()];
+		}
+		if (isMarkdownFilename(playgroundState.currentFile)) {
+			return [markdown()];
 		}
 		const jsx = isJsxFilename(playgroundState.currentFile);
 		const typescript = isTypeScriptFilename(playgroundState.currentFile);

--- a/src/playground/tabs/SettingsTab.tsx
+++ b/src/playground/tabs/SettingsTab.tsx
@@ -435,6 +435,7 @@ function LanguageView({
 						[LANGUAGE.Vue]: "Vue",
 						[LANGUAGE.Svelte]: "Svelte",
 						[LANGUAGE.Astro]: "Astro",
+						[LANGUAGE.Markdown]: "Markdown",
 					}}
 					value={language ?? LANGUAGE.TSX}
 					onChangeValue={setLanguage}

--- a/src/playground/types.ts
+++ b/src/playground/types.ts
@@ -209,6 +209,7 @@ export const LANGUAGE = {
 	Vue: "vue",
 	Svelte: "svelte",
 	Astro: "astro",
+	Markdown: "md",
 } as const;
 
 export type Language = (typeof LANGUAGE)[keyof typeof LANGUAGE];

--- a/src/playground/utils.ts
+++ b/src/playground/utils.ts
@@ -267,6 +267,10 @@ export function isAstroFilename(filename: string): boolean {
 	return filename.endsWith(".astro");
 }
 
+export function isMarkdownFilename(filename: string): boolean {
+	return filename.endsWith(".md");
+}
+
 export function guessLanguage(filename: string): Language {
 	if (isJsonFilename(filename)) return LANGUAGE.JSON;
 	if (isGraphqlFilename(filename)) return LANGUAGE.GraphQL;
@@ -276,6 +280,7 @@ export function guessLanguage(filename: string): Language {
 	if (isVueFilename(filename)) return LANGUAGE.Vue;
 	if (isSvelteFilename(filename)) return LANGUAGE.Svelte;
 	if (isAstroFilename(filename)) return LANGUAGE.Astro;
+	if (isMarkdownFilename(filename)) return LANGUAGE.Markdown;
 	if (isJsxFilename(filename))
 		return isTypeScriptFilename(filename) ? LANGUAGE.TSX : LANGUAGE.JSX;
 	return isTypeScriptFilename(filename) ? LANGUAGE.TS : LANGUAGE.JS;
@@ -323,6 +328,8 @@ export function getExtension(opts: ExtensionOptions): string {
 			return "svelte";
 		case LANGUAGE.Astro:
 			return "astro";
+		case LANGUAGE.Markdown:
+			return "md";
 		default:
 			throw new Error(
 				`Unsupported language type: ${opts.language satisfies never}`, // must be exhaustive
@@ -341,7 +348,8 @@ export function isValidExtension(filename: string): boolean {
 		isGraphqlFilename(filename) ||
 		isHtmlFilename(filename) ||
 		isFrameworkTemplateFilename(filename) ||
-		isGritFilename(filename)
+		isGritFilename(filename) ||
+		isMarkdownFilename(filename)
 	);
 }
 

--- a/src/playground/workers/biomeWorker.ts
+++ b/src/playground/workers/biomeWorker.ts
@@ -226,6 +226,11 @@ self.addEventListener("message", async (e) => {
 					},
 					experimentalFullSupportEnabled,
 				},
+				markdown: {
+					formatter: {
+						enabled: true,
+					},
+				},
 			};
 
 			switch (lintRules) {

--- a/src/playground/workers/biomeWorker.ts
+++ b/src/playground/workers/biomeWorker.ts
@@ -226,11 +226,6 @@ self.addEventListener("message", async (e) => {
 					},
 					experimentalFullSupportEnabled,
 				},
-				markdown: {
-					formatter: {
-						enabled: true,
-					},
-				},
 			};
 
 			switch (lintRules) {

--- a/src/playground/workers/prettierWorker.ts
+++ b/src/playground/workers/prettierWorker.ts
@@ -7,6 +7,8 @@ import pluginGraphql from "prettier/plugins/graphql.mjs";
 // @ts-expect-error
 import pluginHtml from "prettier/plugins/html.mjs";
 // @ts-expect-error
+import pluginMarkdown from "prettier/plugins/markdown.mjs";
+// @ts-expect-error
 import pluginCss from "prettier/plugins/postcss.mjs";
 import * as prettier from "prettier/standalone";
 // @ts-expect-error
@@ -31,6 +33,7 @@ import {
 	isGraphqlFilename,
 	isHtmlFilename,
 	isJsonFilename,
+	isMarkdownFilename,
 	isSvelteFilename,
 	isTypeScriptFilename,
 	isVueFilename,
@@ -181,6 +184,7 @@ async function formatWithPrettier(
 				pluginEstree,
 				pluginGraphql,
 				pluginHtml,
+				pluginMarkdown,
 				pluginSvelte,
 			],
 			parser: getPrettierParser(options.filepath),
@@ -265,6 +269,9 @@ function getPrettierParser(filename: string): string {
 	}
 	if (isSvelteFilename(filename)) {
 		return "svelte";
+	}
+	if (isMarkdownFilename(filename)) {
+		return "markdown";
 	}
 	return "babel";
 }


### PR DESCRIPTION
This PR adds the playground for Markdown.

Keeping in mind that the formatter pane still shows "Not supported" because biome's Configuration has markdown behind a feature. As soon as we lift or enable that feature (I don't know when's the right time), the pane should show formatting. I tested this with a local wasm build.