### PR TITLE
docs: inlineConfig example for helix

### DIFF
--- a/src/content/docs/guides/editors/third-party-extensions.mdx
+++ b/src/content/docs/guides/editors/third-party-extensions.mdx
@@ -27,8 +27,14 @@ Biome has an `lsp-proxy` command that acts as a server for the Language Server P
 Helix 23.10 has [support for multiple language servers](https://github.com/helix-editor/helix/pull/2507). Now you can use biome alongside `typescript-language-server`.
 
 ```toml
-[language-server]
-biome = { command = "biome", args = ["lsp-proxy"] }
+[language-server.biome]
+command = "biome"
+args = ["lsp-proxy"]
+
+# Inline configuration is also supported 
+# https://biomejs.dev/blog/biome-v2-4/#editor-inline-configuration
+[language-server.biome.config.biome.inlineConfig]
+linter.rules.suspicious.noConsole = "off"
 
 [[language]]
 name = "javascript"


### PR DESCRIPTION
## Summary

<!-- 
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

Add an example for `inlineConfig` for the helix editor configuration example. I'm submitting here instead of the helix wiki as the [helix wiki page](https://github.com/helix-editor/helix/wiki/Language-Server-Configurations#biome) points here for configuration.