### PR TITLE
docs: fix broken paragraph to code whitespace

### DIFF
--- a/src/content/docs/guides/integrate-in-vcs.mdx
+++ b/src/content/docs/guides/integrate-in-vcs.mdx
@@ -4,8 +4,8 @@ description: Learn how you can integrate Biome with VCS
 ---
 
 The VCS (Version Control System) integration is meant to take advantage of **additional** features that only a VCS can provide.
-At the moment, Biome only supports Git.
-The integration is **opt-in**.
+At the moment, Biome only supports Git. The integration is **opt-in**.
+
 You have to enable `vcs.enabled` and set `vcs.clientKind` in the Biome configuration file:
 
 ```json title="biome.json"


### PR DESCRIPTION
## Summary

This PR does a small change in the paragraph to avoid the whitespace between the paragraph and the code sample to be wrong.

Before:
<img width="747" height="446" alt="image" src="https://github.com/user-attachments/assets/b2b630ea-3315-4f46-b71c-38606db2d910" />

After: 
<img width="745" height="474" alt="image" src="https://github.com/user-attachments/assets/515f8f76-ab83-47c8-8c41-84846384a784" />
