### PR TITLE
docs: clarify scope of `--changed` for VCS integration

### DIFF
--- a/src/content/docs/guides/integrate-in-vcs.mdx
+++ b/src/content/docs/guides/integrate-in-vcs.mdx
@@ -57,7 +57,9 @@ biome check --changed
 ```
 
 :::caution
-Biome doesn't check what's changed, this means that even adding spaces or newlines to a file, will mark this file as "changed"
+Biome doesn't check what's actually changed in the code, meaning even adding spaces or newlines to a file will mark it as "changed".
+
+Also note that `--changed` applies to both the formatter and the linter. Biome only processes the files that have diffs — it won't automatically check downstream files that import from them. If you change an exported type in one file, you might still need to run a full lint to catch related errors in other files.
 :::
 
 Alternatively, you can use the option `--since` to specify an arbitrary branch. This option **takes precedence** over the option `vcs.defaultBranch`. For example, you might want to check your changes against the `next` branch:


### PR DESCRIPTION
Closes #3133.

This updates the docs for the VCS integration to clarify two things that were confusing users:
1. `--changed` applies to both the formatter and the linter.
2. It only checks the exact files that have diffs. It won't automatically trace dependencies to run full linting on downstream files that import those changed files.

This aims to address the confusion highlighted in the issue.