### PR TITLE
docs: clearly communicate missing features when migrating from prettier

### DIFF
--- a/src/content/docs/formatter/differences-with-prettier.md
+++ b/src/content/docs/formatter/differences-with-prettier.md
@@ -5,6 +5,17 @@ description: In-depth explanation of the differences with Prettier.
 
 In some cases, Biome has intentionally decided to format code in a way that doesn't match Prettier's output. These divergences are explained below.
 
+## Known limitations compared to Prettier
+
+While Biome scores highly on compatibility for supported languages, there are a few features that are not currently implemented:
+
+- **Embedded language formatting** (e.g. formatting JavaScript inside an HTML `<script>` tag or CSS in a `<style>` block) is [not yet supported](https://github.com/biomejs/biome/issues/3334).
+- **Markdown formatting** is [currently in progress](https://github.com/biomejs/biome/issues/3718).
+- **YAML formatting** is not supported.
+- **Framework-specific files** like `.vue`, `.svelte`, and `.astro` are not natively supported by the formatter.
+
+If your project relies heavily on these, you can easily use Prettier alongside Biome as a fallback to format only the file types that Biome doesn't support.
+
 ## Prettier doesn't unquote some object properties that are valid JavaScript identifiers.
 
 Prettier and Biome unquote object and class properties that are valid JavaScript identifiers.

--- a/src/content/docs/formatter/differences-with-prettier.md
+++ b/src/content/docs/formatter/differences-with-prettier.md
@@ -7,14 +7,7 @@ In some cases, Biome has intentionally decided to format code in a way that does
 
 ## Known limitations compared to Prettier
 
-While Biome scores highly on compatibility for supported languages, there are a few features that are not currently implemented:
-
-- **Embedded language formatting** (e.g. formatting JavaScript inside an HTML `<script>` tag or CSS in a `<style>` block) is [not yet supported](https://github.com/biomejs/biome/issues/3334).
-- **Markdown formatting** is [currently in progress](https://github.com/biomejs/biome/issues/3718).
-- **YAML formatting** is not supported.
-- **Framework-specific files** like `.vue`, `.svelte`, and `.astro` are not natively supported by the formatter.
-
-If your project relies heavily on these, you can easily use Prettier alongside Biome as a fallback to format only the file types that Biome doesn't support.
+Biome does not yet support formatting for all languages and frameworks. For a detailed breakdown of what is currently supported, please see our [language support page](https://biomejs.dev/internals/language-support/).
 
 ## Prettier doesn't unquote some object properties that are valid JavaScript identifiers.
 

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -55,7 +55,7 @@ import FeaturedUsers from "@/components/FeaturedUsers.astro"
 
     **Biome is a [fast formatter](https://github.com/biomejs/biome/tree/main/benchmark#formatting)** for _JavaScript_,
     _TypeScript_, _JSX_, _TSX_, _JSON_, _HTML_, _CSS_ and _GraphQL_ that scores **[97% compatibility with
-    _Prettier_](https://console.algora.io/challenges/prettier)**, **saving CI and developer time**.
+    _Prettier_](https://console.algora.io/challenges/prettier)** (see [known limitations](/formatter/differences-with-prettier/#known-limitations-compared-to-prettier)), **saving CI and developer time**.
 
     Biome can even **format malformed code** as you write it in [your favorite editor](/guides/editors/first-party-extensions/).
 


### PR DESCRIPTION
Closes #3126.

This PR adds a **Known limitations compared to Prettier** section to the differences page, and a quick link to it next to the 97% compatibility claim on the front page.

As requested in the issue, this helps users migrating from Prettier understand exactly what features are currently out of scope (embedded languages, Markdown, YAML, and framework-specific files) so they aren't misled, and suggests using Prettier alongside Biome for those specific edge cases.