### PR TITLE
ci: sync job patching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,7 +62,7 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 [[package]]
 name = "biome_analyze"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_analyze_macros",
  "biome_console",
@@ -83,7 +83,7 @@ dependencies = [
 [[package]]
 name = "biome_analyze_macros"
 version = "0.0.0"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "anyhow",
  "biome_string_case",
@@ -97,7 +97,7 @@ dependencies = [
 [[package]]
 name = "biome_aria"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_aria_metadata",
 ]
@@ -105,7 +105,7 @@ dependencies = [
 [[package]]
 name = "biome_aria_metadata"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_deserialize",
  "biome_deserialize_macros",
@@ -121,7 +121,7 @@ dependencies = [
 [[package]]
 name = "biome_cli"
 version = "0.0.0"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "anyhow",
  "biome_analyze",
@@ -182,7 +182,7 @@ dependencies = [
 [[package]]
 name = "biome_configuration"
 version = "0.0.1"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_analyze",
  "biome_configuration_macros",
@@ -214,7 +214,7 @@ dependencies = [
 [[package]]
 name = "biome_configuration_macros"
 version = "0.0.1"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_analyze",
  "biome_css_analyze",
@@ -236,7 +236,7 @@ dependencies = [
 [[package]]
 name = "biome_console"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_markup",
  "biome_text_size",
@@ -250,7 +250,7 @@ dependencies = [
 [[package]]
 name = "biome_control_flow"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_rowan",
  "rustc-hash 2.1.2",
@@ -259,7 +259,7 @@ dependencies = [
 [[package]]
 name = "biome_css_analyze"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_analyze",
  "biome_analyze_macros",
@@ -285,7 +285,7 @@ dependencies = [
 [[package]]
 name = "biome_css_factory"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_css_syntax",
  "biome_rowan",
@@ -294,7 +294,7 @@ dependencies = [
 [[package]]
 name = "biome_css_formatter"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_css_syntax",
  "biome_diagnostics",
@@ -307,7 +307,7 @@ dependencies = [
 [[package]]
 name = "biome_css_parser"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_console",
  "biome_css_factory",
@@ -323,7 +323,7 @@ dependencies = [
 [[package]]
 name = "biome_css_semantic"
 version = "0.0.0"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_css_syntax",
  "biome_formatter",
@@ -335,7 +335,7 @@ dependencies = [
 [[package]]
 name = "biome_css_syntax"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_rowan",
  "biome_string_case",
@@ -346,7 +346,7 @@ dependencies = [
 [[package]]
 name = "biome_deserialize"
 version = "0.6.0"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_console",
  "biome_diagnostics",
@@ -364,7 +364,7 @@ dependencies = [
 [[package]]
 name = "biome_deserialize_macros"
 version = "0.6.0"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_string_case",
  "proc-macro-error2",
@@ -376,7 +376,7 @@ dependencies = [
 [[package]]
 name = "biome_diagnostics"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "backtrace",
  "biome_console",
@@ -398,7 +398,7 @@ dependencies = [
 [[package]]
 name = "biome_diagnostics_categories"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "quote",
  "serde",
@@ -407,7 +407,7 @@ dependencies = [
 [[package]]
 name = "biome_diagnostics_macros"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "proc-macro-error2",
  "proc-macro2",
@@ -418,7 +418,7 @@ dependencies = [
 [[package]]
 name = "biome_flags"
 version = "0.0.0"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_console",
 ]
@@ -426,7 +426,7 @@ dependencies = [
 [[package]]
 name = "biome_formatter"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_console",
  "biome_deserialize",
@@ -447,7 +447,7 @@ dependencies = [
 [[package]]
 name = "biome_fs"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_diagnostics",
  "camino",
@@ -467,7 +467,7 @@ dependencies = [
 [[package]]
 name = "biome_glob"
 version = "0.1.0"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_deserialize",
  "biome_deserialize_macros",
@@ -480,7 +480,7 @@ dependencies = [
 [[package]]
 name = "biome_graphql_analyze"
 version = "0.0.1"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_analyze",
  "biome_analyze_macros",
@@ -503,7 +503,7 @@ dependencies = [
 [[package]]
 name = "biome_graphql_factory"
 version = "0.1.0"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_graphql_syntax",
  "biome_rowan",
@@ -512,7 +512,7 @@ dependencies = [
 [[package]]
 name = "biome_graphql_formatter"
 version = "0.1.0"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_diagnostics",
  "biome_formatter",
@@ -524,7 +524,7 @@ dependencies = [
 [[package]]
 name = "biome_graphql_parser"
 version = "0.1.0"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_console",
  "biome_diagnostics",
@@ -540,7 +540,7 @@ dependencies = [
 [[package]]
 name = "biome_graphql_syntax"
 version = "0.1.0"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_rowan",
  "biome_string_case",
@@ -551,7 +551,7 @@ dependencies = [
 [[package]]
 name = "biome_grit_factory"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_grit_syntax",
  "biome_rowan",
@@ -560,7 +560,7 @@ dependencies = [
 [[package]]
 name = "biome_grit_formatter"
 version = "0.0.0"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_diagnostics_categories",
  "biome_formatter",
@@ -572,7 +572,7 @@ dependencies = [
 [[package]]
 name = "biome_grit_parser"
 version = "0.1.0"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_console",
  "biome_diagnostics",
@@ -590,7 +590,7 @@ dependencies = [
 [[package]]
 name = "biome_grit_patterns"
 version = "0.0.1"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_analyze",
  "biome_console",
@@ -620,7 +620,7 @@ dependencies = [
 [[package]]
 name = "biome_grit_syntax"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_rowan",
  "biome_string_case",
@@ -631,7 +631,7 @@ dependencies = [
 [[package]]
 name = "biome_html_analyze"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_analyze",
  "biome_analyze_macros",
@@ -655,7 +655,7 @@ dependencies = [
 [[package]]
 name = "biome_html_factory"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_html_syntax",
  "biome_rowan",
@@ -664,7 +664,7 @@ dependencies = [
 [[package]]
 name = "biome_html_formatter"
 version = "0.0.0"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_console",
  "biome_deserialize",
@@ -683,7 +683,7 @@ dependencies = [
 [[package]]
 name = "biome_html_parser"
 version = "0.0.1"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_console",
  "biome_diagnostics",
@@ -698,7 +698,7 @@ dependencies = [
 [[package]]
 name = "biome_html_syntax"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_rowan",
  "biome_string_case",
@@ -710,7 +710,7 @@ dependencies = [
 [[package]]
 name = "biome_js_analyze"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_analyze",
  "biome_analyze_macros",
@@ -755,7 +755,7 @@ dependencies = [
 [[package]]
 name = "biome_js_factory"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_js_syntax",
  "biome_rowan",
@@ -764,7 +764,7 @@ dependencies = [
 [[package]]
 name = "biome_js_formatter"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_deserialize",
  "biome_deserialize_macros",
@@ -787,7 +787,7 @@ dependencies = [
 [[package]]
 name = "biome_js_parser"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_console",
  "biome_diagnostics",
@@ -808,7 +808,7 @@ dependencies = [
 [[package]]
 name = "biome_js_semantic"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_formatter",
  "biome_js_syntax",
@@ -822,7 +822,7 @@ dependencies = [
 [[package]]
 name = "biome_js_syntax"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_aria",
  "biome_aria_metadata",
@@ -836,7 +836,7 @@ dependencies = [
 [[package]]
 name = "biome_js_type_info"
 version = "0.0.1"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_formatter",
  "biome_js_semantic",
@@ -852,7 +852,7 @@ dependencies = [
 [[package]]
 name = "biome_js_type_info_macros"
 version = "0.0.1"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "proc-macro-error2",
  "proc-macro2",
@@ -863,7 +863,7 @@ dependencies = [
 [[package]]
 name = "biome_jsdoc_comment"
 version = "0.0.1"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_formatter",
  "biome_js_parser",
@@ -874,7 +874,7 @@ dependencies = [
 [[package]]
 name = "biome_json_analyze"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_analyze",
  "biome_analyze_macros",
@@ -897,7 +897,7 @@ dependencies = [
 [[package]]
 name = "biome_json_factory"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_json_syntax",
  "biome_rowan",
@@ -906,7 +906,7 @@ dependencies = [
 [[package]]
 name = "biome_json_formatter"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_deserialize",
  "biome_deserialize_macros",
@@ -923,7 +923,7 @@ dependencies = [
 [[package]]
 name = "biome_json_parser"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_console",
  "biome_diagnostics",
@@ -939,7 +939,7 @@ dependencies = [
 [[package]]
 name = "biome_json_syntax"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_rowan",
  "biome_string_case",
@@ -952,7 +952,7 @@ dependencies = [
 [[package]]
 name = "biome_json_value"
 version = "0.1.0"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_deserialize",
  "biome_deserialize_macros",
@@ -966,7 +966,7 @@ dependencies = [
 [[package]]
 name = "biome_line_index"
 version = "0.1.0"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_text_size",
  "rustc-hash 2.1.2",
@@ -975,7 +975,7 @@ dependencies = [
 [[package]]
 name = "biome_lsp"
 version = "0.0.0"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "anyhow",
  "biome_analyze",
@@ -1007,7 +1007,7 @@ dependencies = [
 [[package]]
 name = "biome_lsp_converters"
 version = "0.1.0"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "anyhow",
  "biome_line_index",
@@ -1019,7 +1019,7 @@ dependencies = [
 [[package]]
 name = "biome_markup"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "proc-macro-error2",
  "proc-macro2",
@@ -1029,7 +1029,7 @@ dependencies = [
 [[package]]
 name = "biome_migrate"
 version = "0.0.0"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_analyze",
  "biome_configuration",
@@ -1047,7 +1047,7 @@ dependencies = [
 [[package]]
 name = "biome_module_graph"
 version = "0.0.1"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_console",
  "biome_css_semantic",
@@ -1077,7 +1077,7 @@ dependencies = [
 [[package]]
 name = "biome_package"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_console",
  "biome_deserialize",
@@ -1100,7 +1100,7 @@ dependencies = [
 [[package]]
 name = "biome_parser"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_console",
  "biome_diagnostics",
@@ -1114,7 +1114,7 @@ dependencies = [
 [[package]]
 name = "biome_plugin_loader"
 version = "0.0.1"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_analyze",
  "biome_console",
@@ -1143,7 +1143,7 @@ dependencies = [
 [[package]]
 name = "biome_project_layout"
 version = "0.0.1"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_package",
  "biome_parser",
@@ -1156,7 +1156,7 @@ dependencies = [
 [[package]]
 name = "biome_resolver"
 version = "0.1.0"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_console",
  "biome_diagnostics",
@@ -1170,7 +1170,7 @@ dependencies = [
 [[package]]
 name = "biome_rowan"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_text_edit",
  "biome_text_size",
@@ -1183,7 +1183,7 @@ dependencies = [
 [[package]]
 name = "biome_rule_options"
 version = "0.0.1"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_console",
  "biome_deserialize",
@@ -1207,7 +1207,7 @@ dependencies = [
 [[package]]
 name = "biome_ruledoc_utils"
 version = "0.0.1"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "anyhow",
  "biome_analyze",
@@ -1226,7 +1226,7 @@ dependencies = [
 [[package]]
 name = "biome_service"
 version = "0.0.0"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_analyze",
  "biome_configuration",
@@ -1298,7 +1298,7 @@ dependencies = [
 [[package]]
 name = "biome_string_case"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_rowan",
  "caseless",
@@ -1307,7 +1307,7 @@ dependencies = [
 [[package]]
 name = "biome_suppression"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_console",
  "biome_diagnostics",
@@ -1317,7 +1317,7 @@ dependencies = [
 [[package]]
 name = "biome_tailwind_factory"
 version = "0.0.1"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_rowan",
  "biome_tailwind_syntax",
@@ -1326,7 +1326,7 @@ dependencies = [
 [[package]]
 name = "biome_tailwind_parser"
 version = "0.0.1"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_console",
  "biome_diagnostics",
@@ -1341,7 +1341,7 @@ dependencies = [
 [[package]]
 name = "biome_tailwind_syntax"
 version = "0.0.1"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_rowan",
  "serde",
@@ -1350,7 +1350,7 @@ dependencies = [
 [[package]]
 name = "biome_test_utils"
 version = "0.0.0"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_analyze",
  "biome_configuration",
@@ -1385,7 +1385,7 @@ dependencies = [
 [[package]]
 name = "biome_text_edit"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "biome_text_size",
  "serde",
@@ -1395,7 +1395,7 @@ dependencies = [
 [[package]]
 name = "biome_text_size"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 dependencies = [
  "schemars",
  "serde",
@@ -1404,7 +1404,7 @@ dependencies = [
 [[package]]
 name = "biome_unicode_table"
 version = "0.5.7"
-source = "git+https://github.com/biomejs/biome.git?rev=ce70f76ba660846047932a617529622f0b0c5b29#ce70f76ba660846047932a617529622f0b0c5b29"
+source = "git+https://github.com/biomejs/biome.git?rev=de2a33ce8be86b696742f3adee35a66dc9fa943b#de2a33ce8be86b696742f3adee35a66dc9fa943b"
 
 [[package]]
 name = "bitflags"
@@ -1585,6 +1585,7 @@ dependencies = [
  "biome_text_edit",
  "bpaf",
  "camino",
+ "jiff-static",
  "lock_api",
  "pulldown-cmark",
  "schemars",
@@ -2342,9 +2343,9 @@ checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
 
 [[package]]
 name = "jiff"
-version = "0.2.24"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f00b5dbd620d61dfdcb6007c9c1f6054ebd75319f163d886a9055cec1155073d"
+checksum = "392c70591e8749fe235ddaf513e6f58b26bce3dcc16524cecc8936f75afa161e"
 dependencies = [
  "jiff-static",
  "jiff-tzdb-platform",
@@ -2352,14 +2353,14 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.61.2",
+ "windows-link",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.24"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e000de030ff8022ea1da3f466fbb0f3a809f5e51ed31f6dd931c35181ad8e6d7"
+checksum = "47b605b0c050d845fc355bb11eb3f9a8deddc218ea60c76e61aa1f2adfb2c96a"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,45 +16,51 @@
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [dependencies]
   anyhow                = "1.0.102"
-  biome_analyze         = { git = "https://github.com/biomejs/biome.git", rev = "ce70f76ba660846047932a617529622f0b0c5b29", version = "0.5.7", features = ["schema"] }
-  biome_cli             = { git = "https://github.com/biomejs/biome.git", rev = "ce70f76ba660846047932a617529622f0b0c5b29", version = "0.0.0" }
-  biome_configuration   = { git = "https://github.com/biomejs/biome.git", rev = "ce70f76ba660846047932a617529622f0b0c5b29", version = "0.0.1", features = ["cli", "schema"] }
-  biome_console         = { git = "https://github.com/biomejs/biome.git", rev = "ce70f76ba660846047932a617529622f0b0c5b29", version = "0.5.7" }
-  biome_css_analyze     = { git = "https://github.com/biomejs/biome.git", rev = "ce70f76ba660846047932a617529622f0b0c5b29", version = "0.5.7" }
-  biome_css_parser      = { git = "https://github.com/biomejs/biome.git", rev = "ce70f76ba660846047932a617529622f0b0c5b29", version = "0.5.7" }
-  biome_css_semantic    = { git = "https://github.com/biomejs/biome.git", rev = "ce70f76ba660846047932a617529622f0b0c5b29", version = "0.0.0" }
-  biome_css_syntax      = { git = "https://github.com/biomejs/biome.git", rev = "ce70f76ba660846047932a617529622f0b0c5b29", version = "0.5.7" }
-  biome_deserialize     = { git = "https://github.com/biomejs/biome.git", rev = "ce70f76ba660846047932a617529622f0b0c5b29", version = "0.6.0" }
-  biome_diagnostics     = { git = "https://github.com/biomejs/biome.git", rev = "ce70f76ba660846047932a617529622f0b0c5b29", version = "0.5.7" }
-  biome_flags           = { git = "https://github.com/biomejs/biome.git", rev = "ce70f76ba660846047932a617529622f0b0c5b29", version = "0.0.0" }
-  biome_formatter       = { git = "https://github.com/biomejs/biome.git", rev = "ce70f76ba660846047932a617529622f0b0c5b29", version = "0.5.7" }
-  biome_fs              = { git = "https://github.com/biomejs/biome.git", rev = "ce70f76ba660846047932a617529622f0b0c5b29", version = "0.5.7" }
-  biome_graphql_analyze = { git = "https://github.com/biomejs/biome.git", rev = "ce70f76ba660846047932a617529622f0b0c5b29", version = "0.0.1" }
-  biome_graphql_parser  = { git = "https://github.com/biomejs/biome.git", rev = "ce70f76ba660846047932a617529622f0b0c5b29", version = "0.1.0" }
-  biome_graphql_syntax  = { git = "https://github.com/biomejs/biome.git", rev = "ce70f76ba660846047932a617529622f0b0c5b29", version = "0.1.0" }
-  biome_html_analyze    = { git = "https://github.com/biomejs/biome.git", rev = "ce70f76ba660846047932a617529622f0b0c5b29", version = "0.5.7" }
-  biome_html_parser     = { git = "https://github.com/biomejs/biome.git", rev = "ce70f76ba660846047932a617529622f0b0c5b29", version = "0.0.1" }
-  biome_html_syntax     = { git = "https://github.com/biomejs/biome.git", rev = "ce70f76ba660846047932a617529622f0b0c5b29", version = "0.5.7" }
-  biome_js_analyze      = { git = "https://github.com/biomejs/biome.git", rev = "ce70f76ba660846047932a617529622f0b0c5b29", version = "0.5.7" }
-  biome_js_formatter    = { git = "https://github.com/biomejs/biome.git", rev = "ce70f76ba660846047932a617529622f0b0c5b29", version = "0.5.7" }
-  biome_js_parser       = { git = "https://github.com/biomejs/biome.git", rev = "ce70f76ba660846047932a617529622f0b0c5b29", version = "0.5.7" }
-  biome_js_syntax       = { git = "https://github.com/biomejs/biome.git", rev = "ce70f76ba660846047932a617529622f0b0c5b29", version = "0.5.7" }
-  biome_json_analyze    = { git = "https://github.com/biomejs/biome.git", rev = "ce70f76ba660846047932a617529622f0b0c5b29", version = "0.5.7" }
-  biome_json_factory    = { git = "https://github.com/biomejs/biome.git", rev = "ce70f76ba660846047932a617529622f0b0c5b29", version = "0.5.7" }
-  biome_json_formatter  = { git = "https://github.com/biomejs/biome.git", rev = "ce70f76ba660846047932a617529622f0b0c5b29", version = "0.5.7" }
-  biome_json_parser     = { git = "https://github.com/biomejs/biome.git", rev = "ce70f76ba660846047932a617529622f0b0c5b29", version = "0.5.7" }
-  biome_json_syntax     = { git = "https://github.com/biomejs/biome.git", rev = "ce70f76ba660846047932a617529622f0b0c5b29", version = "0.5.7" }
-  biome_module_graph    = { git = "https://github.com/biomejs/biome.git", rev = "ce70f76ba660846047932a617529622f0b0c5b29", version = "0.0.1" }
-  biome_project_layout  = { git = "https://github.com/biomejs/biome.git", rev = "ce70f76ba660846047932a617529622f0b0c5b29", version = "0.0.1" }
-  biome_rowan           = { git = "https://github.com/biomejs/biome.git", rev = "ce70f76ba660846047932a617529622f0b0c5b29", version = "0.5.7" }
-  biome_ruledoc_utils   = { git = "https://github.com/biomejs/biome.git", rev = "ce70f76ba660846047932a617529622f0b0c5b29", version = "0.0.1" }
-  biome_service         = { git = "https://github.com/biomejs/biome.git", rev = "ce70f76ba660846047932a617529622f0b0c5b29", version = "0.0.0" }
-  biome_string_case     = { git = "https://github.com/biomejs/biome.git", rev = "ce70f76ba660846047932a617529622f0b0c5b29", version = "0.5.7" }
-  biome_test_utils      = { git = "https://github.com/biomejs/biome.git", rev = "ce70f76ba660846047932a617529622f0b0c5b29", version = "0.0.0" }
-  biome_text_edit       = { git = "https://github.com/biomejs/biome.git", rev = "ce70f76ba660846047932a617529622f0b0c5b29", version = "0.5.7" }
+  biome_analyze         = { git = "https://github.com/biomejs/biome.git", rev = "de2a33ce8be86b696742f3adee35a66dc9fa943b", version = "0.5.7", features = [
+    "schema"
+  ] }
+  biome_cli             = { git = "https://github.com/biomejs/biome.git", rev = "de2a33ce8be86b696742f3adee35a66dc9fa943b", version = "0.0.0" }
+  biome_configuration   = { git = "https://github.com/biomejs/biome.git", rev = "de2a33ce8be86b696742f3adee35a66dc9fa943b", version = "0.0.1", features = [
+    "cli",
+    "schema"
+  ] }
+  biome_console         = { git = "https://github.com/biomejs/biome.git", rev = "de2a33ce8be86b696742f3adee35a66dc9fa943b", version = "0.5.7" }
+  biome_css_analyze     = { git = "https://github.com/biomejs/biome.git", rev = "de2a33ce8be86b696742f3adee35a66dc9fa943b", version = "0.5.7" }
+  biome_css_parser      = { git = "https://github.com/biomejs/biome.git", rev = "de2a33ce8be86b696742f3adee35a66dc9fa943b", version = "0.5.7" }
+  biome_css_semantic    = { git = "https://github.com/biomejs/biome.git", rev = "de2a33ce8be86b696742f3adee35a66dc9fa943b", version = "0.0.0" }
+  biome_css_syntax      = { git = "https://github.com/biomejs/biome.git", rev = "de2a33ce8be86b696742f3adee35a66dc9fa943b", version = "0.5.7" }
+  biome_deserialize     = { git = "https://github.com/biomejs/biome.git", rev = "de2a33ce8be86b696742f3adee35a66dc9fa943b", version = "0.6.0" }
+  biome_diagnostics     = { git = "https://github.com/biomejs/biome.git", rev = "de2a33ce8be86b696742f3adee35a66dc9fa943b", version = "0.5.7" }
+  biome_flags           = { git = "https://github.com/biomejs/biome.git", rev = "de2a33ce8be86b696742f3adee35a66dc9fa943b", version = "0.0.0" }
+  biome_formatter       = { git = "https://github.com/biomejs/biome.git", rev = "de2a33ce8be86b696742f3adee35a66dc9fa943b", version = "0.5.7" }
+  biome_fs              = { git = "https://github.com/biomejs/biome.git", rev = "de2a33ce8be86b696742f3adee35a66dc9fa943b", version = "0.5.7" }
+  biome_graphql_analyze = { git = "https://github.com/biomejs/biome.git", rev = "de2a33ce8be86b696742f3adee35a66dc9fa943b", version = "0.0.1" }
+  biome_graphql_parser  = { git = "https://github.com/biomejs/biome.git", rev = "de2a33ce8be86b696742f3adee35a66dc9fa943b", version = "0.1.0" }
+  biome_graphql_syntax  = { git = "https://github.com/biomejs/biome.git", rev = "de2a33ce8be86b696742f3adee35a66dc9fa943b", version = "0.1.0" }
+  biome_html_analyze    = { git = "https://github.com/biomejs/biome.git", rev = "de2a33ce8be86b696742f3adee35a66dc9fa943b", version = "0.5.7" }
+  biome_html_parser     = { git = "https://github.com/biomejs/biome.git", rev = "de2a33ce8be86b696742f3adee35a66dc9fa943b", version = "0.0.1" }
+  biome_html_syntax     = { git = "https://github.com/biomejs/biome.git", rev = "de2a33ce8be86b696742f3adee35a66dc9fa943b", version = "0.5.7" }
+  biome_js_analyze      = { git = "https://github.com/biomejs/biome.git", rev = "de2a33ce8be86b696742f3adee35a66dc9fa943b", version = "0.5.7" }
+  biome_js_formatter    = { git = "https://github.com/biomejs/biome.git", rev = "de2a33ce8be86b696742f3adee35a66dc9fa943b", version = "0.5.7" }
+  biome_js_parser       = { git = "https://github.com/biomejs/biome.git", rev = "de2a33ce8be86b696742f3adee35a66dc9fa943b", version = "0.5.7" }
+  biome_js_syntax       = { git = "https://github.com/biomejs/biome.git", rev = "de2a33ce8be86b696742f3adee35a66dc9fa943b", version = "0.5.7" }
+  biome_json_analyze    = { git = "https://github.com/biomejs/biome.git", rev = "de2a33ce8be86b696742f3adee35a66dc9fa943b", version = "0.5.7" }
+  biome_json_factory    = { git = "https://github.com/biomejs/biome.git", rev = "de2a33ce8be86b696742f3adee35a66dc9fa943b", version = "0.5.7" }
+  biome_json_formatter  = { git = "https://github.com/biomejs/biome.git", rev = "de2a33ce8be86b696742f3adee35a66dc9fa943b", version = "0.5.7" }
+  biome_json_parser     = { git = "https://github.com/biomejs/biome.git", rev = "de2a33ce8be86b696742f3adee35a66dc9fa943b", version = "0.5.7" }
+  biome_json_syntax     = { git = "https://github.com/biomejs/biome.git", rev = "de2a33ce8be86b696742f3adee35a66dc9fa943b", version = "0.5.7" }
+  biome_module_graph    = { git = "https://github.com/biomejs/biome.git", rev = "de2a33ce8be86b696742f3adee35a66dc9fa943b", version = "0.0.1" }
+  biome_project_layout  = { git = "https://github.com/biomejs/biome.git", rev = "de2a33ce8be86b696742f3adee35a66dc9fa943b", version = "0.0.1" }
+  biome_rowan           = { git = "https://github.com/biomejs/biome.git", rev = "de2a33ce8be86b696742f3adee35a66dc9fa943b", version = "0.5.7" }
+  biome_ruledoc_utils   = { git = "https://github.com/biomejs/biome.git", rev = "de2a33ce8be86b696742f3adee35a66dc9fa943b", version = "0.0.1" }
+  biome_service         = { git = "https://github.com/biomejs/biome.git", rev = "de2a33ce8be86b696742f3adee35a66dc9fa943b", version = "0.0.0" }
+  biome_string_case     = { git = "https://github.com/biomejs/biome.git", rev = "de2a33ce8be86b696742f3adee35a66dc9fa943b", version = "0.5.7" }
+  biome_test_utils      = { git = "https://github.com/biomejs/biome.git", rev = "de2a33ce8be86b696742f3adee35a66dc9fa943b", version = "0.0.0" }
+  biome_text_edit       = { git = "https://github.com/biomejs/biome.git", rev = "de2a33ce8be86b696742f3adee35a66dc9fa943b", version = "0.5.7" }
   bpaf                  = { version = "0.9.26", features = ["docgen"] }
   # If you update this library, be aware of the breaking changes
   camino                = "1.2.2"
+  jiff-static           = "0.2.27"
   # Needed to fix some weird dependency
   lock_api              = "0.4.14"
   pulldown-cmark        = "0.13.3"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@astrojs/react": "5.0.5",
     "@astrojs/rss": "4.0.18",
     "@astrojs/starlight": "0.39.2",
-    "@biomejs/biome": "2.4.15",
+    "@biomejs/biome": "https://pkg.pr.new/biomejs/biome/@biomejs/biome@19c71415458c64273945fd0f16263cffc8e0479a",
     "@biomejs/version-utils": "0.4.0",
     "@biomejs/wasm-web": "https://pkg.pr.new/@biomejs/wasm-web@ce70f76",
     "@codemirror/lang-css": "6.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,8 +34,8 @@ importers:
         specifier: 0.39.2
         version: 0.39.2(astro@6.3.3(@netlify/blobs@10.7.7)(@types/node@24.12.4)(jiti@2.6.1)(rollup@4.60.1)(yaml@2.8.3))(typescript@5.9.3)
       '@biomejs/biome':
-        specifier: 2.4.15
-        version: 2.4.15
+        specifier: https://pkg.pr.new/biomejs/biome/@biomejs/biome@19c71415458c64273945fd0f16263cffc8e0479a
+        version: https://pkg.pr.new/biomejs/biome/@biomejs/biome@19c71415458c64273945fd0f16263cffc8e0479a
       '@biomejs/version-utils':
         specifier: ^0.4.0
         version: 0.4.0
@@ -384,59 +384,64 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
-  '@biomejs/biome@2.4.15':
-    resolution: {integrity: sha512-j5VH3a/h/HXTKBM50MDMxRCzkeLv9S2XJcW2WgnZT1+xyisi+0bISrXR82gCX+8S9lvK0skEvHJRN+3Ktr2hlw==}
+  '@biomejs/biome@https://pkg.pr.new/biomejs/biome/@biomejs/biome@19c71415458c64273945fd0f16263cffc8e0479a':
+    resolution: {integrity: sha512-PAYf8JglAV5BsAiVpLOexf5lIeWWfuoxeG8zLp4JDiUfOHzg/eCcSXjGMOdKUadb214x15asambO0jtCOTiZ2w==, tarball: https://pkg.pr.new/biomejs/biome/@biomejs/biome@19c71415458c64273945fd0f16263cffc8e0479a}
+    version: 2.4.15
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.4.15':
-    resolution: {integrity: sha512-rF3PPqLq1yoST79zaQbDjVJwsuIeci/O+9bgNmC5QpgOqz6aqYuzA4abyAGx+mgyiDXn4A049xAN8gijbuR1Qg==}
+  '@biomejs/cli-darwin-arm64@https://pkg.pr.new/biomejs/biome/@biomejs/cli-darwin-arm64@19c71415458c64273945fd0f16263cffc8e0479a':
+    resolution: {integrity: sha512-T330WoZ2z+vz7OhigrV4G8GUrOy193w2lVSeyy8xdagDo9ds6II640rG8QkiL5gceI3OglyaGg0uQq6KK4ss5w==, tarball: https://pkg.pr.new/biomejs/biome/@biomejs/cli-darwin-arm64@19c71415458c64273945fd0f16263cffc8e0479a}
+    version: 2.4.15
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.4.15':
-    resolution: {integrity: sha512-/5KHXYMfSJs1fNXiX30xFtI8JcCFV6zaVVLxOa0M2sfqBKHkpQhRTv94yxQWxeTY2lzo2OuTlNvPC+hDQt2wcQ==}
+  '@biomejs/cli-darwin-x64@https://pkg.pr.new/biomejs/biome/@biomejs/cli-darwin-x64@19c71415458c64273945fd0f16263cffc8e0479a':
+    resolution: {integrity: sha512-AmilwB4M3zSKhqFpGrNoUoJYl0SVUYf4Rb5Jw81XmcOdQw1jHKKCJdwCVFF3rbNhX8keTGcbMJwSWnE69mw19Q==, tarball: https://pkg.pr.new/biomejs/biome/@biomejs/cli-darwin-x64@19c71415458c64273945fd0f16263cffc8e0479a}
+    version: 2.4.15
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.4.15':
-    resolution: {integrity: sha512-ZPcxznxm0pogHBLZhYntyR3sR+MrZjqJIKEr7ZqVen0Rl+P/4upVmfYXjftizi9RoqZntg33fv/1fbdhbYXpEQ==}
+  '@biomejs/cli-linux-arm64-musl@https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-arm64-musl@19c71415458c64273945fd0f16263cffc8e0479a':
+    resolution: {integrity: sha512-CBxVecyzMp+Rvr9Wu2yqDIBA4DbBiZ+XyDqzmmtbZW0QTB6BqKEuBFTn+6DFvxKGaeYtAf1z/tPXNm/ORo23hg==, tarball: https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-arm64-musl@19c71415458c64273945fd0f16263cffc8e0479a}
+    version: 2.4.15
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
-  '@biomejs/cli-linux-arm64@2.4.15':
-    resolution: {integrity: sha512-owaAMZD/T4LrD0ELNCk0Km3qrRHuM0X6EAyVE1FSqGY0rbLoiDLrO4Us2tllm6cAeB2Ioa9C2C08NZPdr8+0Ug==}
+  '@biomejs/cli-linux-arm64@https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-arm64@19c71415458c64273945fd0f16263cffc8e0479a':
+    resolution: {integrity: sha512-cVnp8ICpvaLk99thG65JwJY9+gwIDk+NwjG0+HSlbYWsc1eJl98ThkXeNTaubpxsDSQiTrj1EftjN9ZngHvdSA==, tarball: https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-arm64@19c71415458c64273945fd0f16263cffc8e0479a}
+    version: 2.4.15
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@2.4.15':
-    resolution: {integrity: sha512-CNq/9W38SYSH023lfcQ4KKU8K0YX8T//FZUhcgtMMRABDojx5XsMV7jlweAvGSl389wJQB29Qo6Zb/a+jdvt+w==}
+  '@biomejs/cli-linux-x64-musl@https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-x64-musl@19c71415458c64273945fd0f16263cffc8e0479a':
+    resolution: {integrity: sha512-gsoesy1rqoynkdhAsdMw150RpcIowZ5Pc6D1dgPtgGMdvDKdMEKSHpBZgvkJbAMx+n9kLwB9mVD/dq0GhdGokQ==, tarball: https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-x64-musl@19c71415458c64273945fd0f16263cffc8e0479a}
+    version: 2.4.15
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
-  '@biomejs/cli-linux-x64@2.4.15':
-    resolution: {integrity: sha512-0jj7THz12GbUOLmMibktK6DZjqz2zV64KFxyBtcFTKPiiOIY0a7vns1elpO1dERvxpsZ5ik0oFfz0oGwFde1+g==}
+  '@biomejs/cli-linux-x64@https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-x64@19c71415458c64273945fd0f16263cffc8e0479a':
+    resolution: {integrity: sha512-psFbx5U/PwepUULmQf20U/onXRZWbKqYk7WQkxadcMUyihQqvqm1BhhR6LytdLXmJ4afapZ1aKuNww/v77RhHQ==, tarball: https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-x64@19c71415458c64273945fd0f16263cffc8e0479a}
+    version: 2.4.15
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@2.4.15':
-    resolution: {integrity: sha512-ouhkYdlhp/1GghEJPdWwD/Vi3gQ1nFxuSpMolWsbq3Lsq3QUR4jl6UdhhscdCugKU5vOEuMiJhvKj66O0OCq+w==}
+  '@biomejs/cli-win32-arm64@https://pkg.pr.new/biomejs/biome/@biomejs/cli-win32-arm64@19c71415458c64273945fd0f16263cffc8e0479a':
+    resolution: {integrity: sha512-ef7YS9NDqlbAGtEAWNT+nxOX/pOJvmaqieg0KoUobmXkOI4fjq0DylQyM4hHfy5VJhOGIDxf2uHPTA7KFO213Q==, tarball: https://pkg.pr.new/biomejs/biome/@biomejs/cli-win32-arm64@19c71415458c64273945fd0f16263cffc8e0479a}
+    version: 2.4.15
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.4.15':
-    resolution: {integrity: sha512-zBrGq5mx5wwpnow4+2BxUvleDM+GNd4sLbPaMapsSLQLD0NGRCquqPBTgN+7XkUteHvj7M+BstuI8tmnV7+HgQ==}
+  '@biomejs/cli-win32-x64@https://pkg.pr.new/biomejs/biome/@biomejs/cli-win32-x64@19c71415458c64273945fd0f16263cffc8e0479a':
+    resolution: {integrity: sha512-FeIepL4QT+rEQD4T6gUdk7G3rylx+qK3vIkl9+V60Jj4x2xmn0fbEYYoyVapuhwxWQ4RB9z/B/Oz2mC2GEettA==, tarball: https://pkg.pr.new/biomejs/biome/@biomejs/cli-win32-x64@19c71415458c64273945fd0f16263cffc8e0479a}
+    version: 2.4.15
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -6760,39 +6765,39 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@biomejs/biome@2.4.15':
+  '@biomejs/biome@https://pkg.pr.new/biomejs/biome/@biomejs/biome@19c71415458c64273945fd0f16263cffc8e0479a':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.4.15
-      '@biomejs/cli-darwin-x64': 2.4.15
-      '@biomejs/cli-linux-arm64': 2.4.15
-      '@biomejs/cli-linux-arm64-musl': 2.4.15
-      '@biomejs/cli-linux-x64': 2.4.15
-      '@biomejs/cli-linux-x64-musl': 2.4.15
-      '@biomejs/cli-win32-arm64': 2.4.15
-      '@biomejs/cli-win32-x64': 2.4.15
+      '@biomejs/cli-darwin-arm64': https://pkg.pr.new/biomejs/biome/@biomejs/cli-darwin-arm64@19c71415458c64273945fd0f16263cffc8e0479a
+      '@biomejs/cli-darwin-x64': https://pkg.pr.new/biomejs/biome/@biomejs/cli-darwin-x64@19c71415458c64273945fd0f16263cffc8e0479a
+      '@biomejs/cli-linux-arm64': https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-arm64@19c71415458c64273945fd0f16263cffc8e0479a
+      '@biomejs/cli-linux-arm64-musl': https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-arm64-musl@19c71415458c64273945fd0f16263cffc8e0479a
+      '@biomejs/cli-linux-x64': https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-x64@19c71415458c64273945fd0f16263cffc8e0479a
+      '@biomejs/cli-linux-x64-musl': https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-x64-musl@19c71415458c64273945fd0f16263cffc8e0479a
+      '@biomejs/cli-win32-arm64': https://pkg.pr.new/biomejs/biome/@biomejs/cli-win32-arm64@19c71415458c64273945fd0f16263cffc8e0479a
+      '@biomejs/cli-win32-x64': https://pkg.pr.new/biomejs/biome/@biomejs/cli-win32-x64@19c71415458c64273945fd0f16263cffc8e0479a
 
-  '@biomejs/cli-darwin-arm64@2.4.15':
+  '@biomejs/cli-darwin-arm64@https://pkg.pr.new/biomejs/biome/@biomejs/cli-darwin-arm64@19c71415458c64273945fd0f16263cffc8e0479a':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.4.15':
+  '@biomejs/cli-darwin-x64@https://pkg.pr.new/biomejs/biome/@biomejs/cli-darwin-x64@19c71415458c64273945fd0f16263cffc8e0479a':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.4.15':
+  '@biomejs/cli-linux-arm64-musl@https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-arm64-musl@19c71415458c64273945fd0f16263cffc8e0479a':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.4.15':
+  '@biomejs/cli-linux-arm64@https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-arm64@19c71415458c64273945fd0f16263cffc8e0479a':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.4.15':
+  '@biomejs/cli-linux-x64-musl@https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-x64-musl@19c71415458c64273945fd0f16263cffc8e0479a':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.4.15':
+  '@biomejs/cli-linux-x64@https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-x64@19c71415458c64273945fd0f16263cffc8e0479a':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.4.15':
+  '@biomejs/cli-win32-arm64@https://pkg.pr.new/biomejs/biome/@biomejs/cli-win32-arm64@19c71415458c64273945fd0f16263cffc8e0479a':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.4.15':
+  '@biomejs/cli-win32-x64@https://pkg.pr.new/biomejs/biome/@biomejs/cli-win32-x64@19c71415458c64273945fd0f16263cffc8e0479a':
     optional: true
 
   '@biomejs/version-utils@0.4.0':

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -19,7 +19,7 @@ export const collections = {
 			return z.object({
 				id: z.string(),
 				logo: image(),
-				url: z.string().url(),
+				url: z.url(),
 				featured: z.boolean(),
 			});
 		},

--- a/src/playground/Playground.tsx
+++ b/src/playground/Playground.tsx
@@ -70,7 +70,7 @@ export default function Playground({
 	const prettierOutput = file.prettier;
 	const gritQuery = file.gritQuery ?? "";
 	const gritQueryResults = biomeOutput.gritQuery ?? { matches: [] };
-	const gritTargetLanguage = playgroundState.settings.gritTargetLanguage;
+	const searchLanguage = playgroundState.settings.searchLanguage;
 
 	const codeMirrorExtensions = useMemo(() => {
 		if (isJsonFilename(playgroundState.currentFile)) {
@@ -338,7 +338,7 @@ export default function Playground({
 							code={code}
 							gritQuery={gritQuery}
 							gritQueryResults={gritQueryResults}
-							gritTargetLanguage={gritTargetLanguage}
+							searchLanguage={searchLanguage}
 							onGritQueryChange={(query) => {
 								setPlaygroundState((state) => ({
 									...state,
@@ -405,7 +405,7 @@ export default function Playground({
 						code={code}
 						gritQuery={gritQuery}
 						gritQueryResults={gritQueryResults}
-						gritTargetLanguage={gritTargetLanguage}
+						searchLanguage={searchLanguage}
 						currentPane={playgroundState.pane}
 						setPlaygroundState={setPlaygroundState}
 						onGritQueryChange={(query) => {

--- a/src/playground/PlaygroundLoader.tsx
+++ b/src/playground/PlaygroundLoader.tsx
@@ -254,14 +254,14 @@ function PlaygroundLoader() {
 				filename: state.currentFile,
 				code: getCurrentCode(state),
 				gritQuery: file?.gritQuery,
-				defaultLanguage: state.settings.gritTargetLanguage,
+				defaultLanguage: state.settings.searchLanguage,
 			});
 		});
 	}, [
 		loadingState,
 		state.currentFile,
 		state.cursorPosition,
-		state.settings.gritTargetLanguage,
+		state.settings.searchLanguage,
 		getCurrentCode(state),
 		getFileState(state, state.currentFile)?.gritQuery,
 	]);
@@ -513,11 +513,12 @@ function initState(
 			tailwindDirectives:
 				searchParams.get("tailwindDirectives") === "true" ||
 				defaultPlaygroundState.settings.tailwindDirectives,
-			gritTargetLanguage:
-				(searchParams.get("gritTargetLanguage") as
-					| "JavaScript"
-					| "CSS"
-					| undefined) ?? defaultPlaygroundState.settings.gritTargetLanguage,
+			searchLanguage:
+				(searchParams.get("searchLanguage") as
+					| "js"
+					| "css"
+					| "json"
+					| undefined) ?? defaultPlaygroundState.settings.searchLanguage,
 		},
 	};
 }

--- a/src/playground/components/DiagnosticsPane.tsx
+++ b/src/playground/components/DiagnosticsPane.tsx
@@ -1,4 +1,4 @@
-import type { Diagnostic, GritTargetLanguage } from "@biomejs/wasm-web";
+import type { Diagnostic, SearchLanguage } from "@biomejs/wasm-web";
 import type { ReactCodeMirrorRef } from "@uiw/react-codemirror";
 import type { Dispatch, RefObject, SetStateAction } from "react";
 import Tabs from "@/playground/components/Tabs";
@@ -14,9 +14,9 @@ interface Props {
 	code: string;
 	gritQuery: string;
 	gritQueryResults: { matches: [number, number][]; error: string | undefined };
-	gritTargetLanguage: GritTargetLanguage;
+	searchLanguage: SearchLanguage;
 	onGritQueryChange: (query: string) => void;
-	onLanguageChange: (language: GritTargetLanguage) => void;
+	onLanguageChange: (language: SearchLanguage) => void;
 	setPlaygroundState: Dispatch<SetStateAction<PlaygroundState>>;
 	currentPane: PlaygroundPane;
 }
@@ -28,7 +28,7 @@ export default function DiagnosticsPane({
 	code,
 	gritQuery,
 	gritQueryResults,
-	gritTargetLanguage,
+	searchLanguage,
 	onGritQueryChange,
 	onLanguageChange,
 	setPlaygroundState,
@@ -72,7 +72,7 @@ export default function DiagnosticsPane({
 							code={code}
 							gritQuery={gritQuery}
 							gritQueryResults={gritQueryResults}
-							gritTargetLanguage={gritTargetLanguage}
+							searchLanguage={searchLanguage}
 							onGritQueryChange={onGritQueryChange}
 							onLanguageChange={onLanguageChange}
 						/>

--- a/src/playground/tabs/GritQLSearchTab.tsx
+++ b/src/playground/tabs/GritQLSearchTab.tsx
@@ -1,4 +1,4 @@
-import type { GritTargetLanguage } from "@biomejs/wasm-web";
+import type { SearchLanguage } from "@biomejs/wasm-web";
 import { EditorSelection } from "@codemirror/state";
 import type { ReactCodeMirrorRef } from "@uiw/react-codemirror";
 import type { RefObject } from "react";
@@ -12,9 +12,9 @@ interface Props {
 	code: string;
 	gritQuery: string;
 	gritQueryResults: { matches: [number, number][]; error: string | undefined };
-	gritTargetLanguage: GritTargetLanguage;
+	searchLanguage: SearchLanguage;
 	onGritQueryChange: (query: string) => void;
-	onLanguageChange: (language: GritTargetLanguage) => void;
+	onLanguageChange: (language: SearchLanguage) => void;
 }
 
 export default function GritQLSearchTab({
@@ -22,7 +22,7 @@ export default function GritQLSearchTab({
 	code,
 	gritQuery,
 	gritQueryResults,
-	gritTargetLanguage,
+	searchLanguage,
 	onGritQueryChange,
 	onLanguageChange,
 }: Props) {
@@ -49,10 +49,8 @@ export default function GritQLSearchTab({
 			<div className="gritql-stats">
 				<select
 					className="gritql-select"
-					value={gritTargetLanguage}
-					onChange={(e) =>
-						onLanguageChange(e.target.value as GritTargetLanguage)
-					}
+					value={searchLanguage}
+					onChange={(e) => onLanguageChange(e.target.value as SearchLanguage)}
 				>
 					<option value="JavaScript">JavaScript</option>
 					<option value="CSS">CSS</option>

--- a/src/playground/types.ts
+++ b/src/playground/types.ts
@@ -1,8 +1,8 @@
 import type {
 	Diagnostic,
 	FixFileMode,
-	GritTargetLanguage,
 	RuleDomains,
+	SearchLanguage,
 } from "@biomejs/wasm-web";
 import type { parser } from "codemirror-lang-rome-ast";
 import type { Dispatch, SetStateAction } from "react";
@@ -246,7 +246,7 @@ export interface PlaygroundSettings {
 	experimentalFullSupportEnabled: boolean;
 	cssModules: boolean;
 	tailwindDirectives: boolean;
-	gritTargetLanguage: GritTargetLanguage;
+	searchLanguage: SearchLanguage;
 }
 
 export interface PlaygroundFileState {
@@ -307,7 +307,7 @@ export const defaultPlaygroundState: PlaygroundState = {
 		experimentalFullSupportEnabled: true,
 		cssModules: false,
 		tailwindDirectives: true,
-		gritTargetLanguage: "JavaScript",
+		searchLanguage: "js",
 	},
 };
 


### PR DESCRIPTION
## Summary

This PR fixes the codegen, and updates the playground to use the correct `searchLanguage`, which was updated a few days ago.

The `tsc` job still fails because `plugins` is missing from the types, but I fixed it here: https://github.com/biomejs/biome/pull/10478

The next release should be good