### PR TITLE
chore(deps): use Biome 2.4.16

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@astrojs/react": "5.0.5",
     "@astrojs/rss": "4.0.18",
     "@astrojs/starlight": "0.39.2",
-    "@biomejs/biome": "https://pkg.pr.new/biomejs/biome/@biomejs/biome@19c71415458c64273945fd0f16263cffc8e0479a",
+    "@biomejs/biome": "2.4.16",
     "@biomejs/version-utils": "0.4.0",
     "@biomejs/wasm-web": "https://pkg.pr.new/@biomejs/wasm-web@5f4ea56",
     "@codemirror/lang-css": "6.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,8 +34,8 @@ importers:
         specifier: 0.39.2
         version: 0.39.2(astro@6.3.3(@netlify/blobs@10.7.7)(@types/node@24.12.4)(jiti@2.6.1)(rollup@4.60.1)(yaml@2.8.3))(typescript@5.9.3)
       '@biomejs/biome':
-        specifier: https://pkg.pr.new/biomejs/biome/@biomejs/biome@19c71415458c64273945fd0f16263cffc8e0479a
-        version: https://pkg.pr.new/biomejs/biome/@biomejs/biome@19c71415458c64273945fd0f16263cffc8e0479a
+        specifier: 2.4.16
+        version: 2.4.16
       '@biomejs/version-utils':
         specifier: ^0.4.0
         version: 0.4.0
@@ -384,64 +384,59 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
-  '@biomejs/biome@https://pkg.pr.new/biomejs/biome/@biomejs/biome@19c71415458c64273945fd0f16263cffc8e0479a':
-    resolution: {integrity: sha512-PAYf8JglAV5BsAiVpLOexf5lIeWWfuoxeG8zLp4JDiUfOHzg/eCcSXjGMOdKUadb214x15asambO0jtCOTiZ2w==, tarball: https://pkg.pr.new/biomejs/biome/@biomejs/biome@19c71415458c64273945fd0f16263cffc8e0479a}
-    version: 2.4.15
+  '@biomejs/biome@2.4.16':
+    resolution: {integrity: sha512-x9ajFh1zChVybCiM3TN6OD4phAqLgtPZjFrZF+aTMYCPjwBO+k529TX7PPsAqtGNLeV4UgzwQnowEgS7bGmzcA==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@https://pkg.pr.new/biomejs/biome/@biomejs/cli-darwin-arm64@19c71415458c64273945fd0f16263cffc8e0479a':
-    resolution: {integrity: sha512-T330WoZ2z+vz7OhigrV4G8GUrOy193w2lVSeyy8xdagDo9ds6II640rG8QkiL5gceI3OglyaGg0uQq6KK4ss5w==, tarball: https://pkg.pr.new/biomejs/biome/@biomejs/cli-darwin-arm64@19c71415458c64273945fd0f16263cffc8e0479a}
-    version: 2.4.15
+  '@biomejs/cli-darwin-arm64@2.4.16':
+    resolution: {integrity: sha512-wxPvu4XOA85YJk9ixSWUmq/QBHbid85BISbOAqqBM/5xQpPk9ayjk5375tOlSC0BeCwNSbPFafQBm+vBumXq0A==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@https://pkg.pr.new/biomejs/biome/@biomejs/cli-darwin-x64@19c71415458c64273945fd0f16263cffc8e0479a':
-    resolution: {integrity: sha512-AmilwB4M3zSKhqFpGrNoUoJYl0SVUYf4Rb5Jw81XmcOdQw1jHKKCJdwCVFF3rbNhX8keTGcbMJwSWnE69mw19Q==, tarball: https://pkg.pr.new/biomejs/biome/@biomejs/cli-darwin-x64@19c71415458c64273945fd0f16263cffc8e0479a}
-    version: 2.4.15
+  '@biomejs/cli-darwin-x64@2.4.16':
+    resolution: {integrity: sha512-xFCqGPwYusQJp4N4NJLi1XJiZqjwFdjhT+KqtNy+Ug3qgfczqnTa6MSDvxJF6TkuDLoYJItMapz6tAf7kCekFw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-arm64-musl@19c71415458c64273945fd0f16263cffc8e0479a':
-    resolution: {integrity: sha512-CBxVecyzMp+Rvr9Wu2yqDIBA4DbBiZ+XyDqzmmtbZW0QTB6BqKEuBFTn+6DFvxKGaeYtAf1z/tPXNm/ORo23hg==, tarball: https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-arm64-musl@19c71415458c64273945fd0f16263cffc8e0479a}
-    version: 2.4.15
+  '@biomejs/cli-linux-arm64-musl@2.4.16':
+    resolution: {integrity: sha512-oYxnW0ARfJkr72ezzF2OR8N/rtkgLUQeYtF8cFhVswbknHxtTcmzSsanVJP8yQKnGpGpc2ck6c5zLvHahL6Cbg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
-  '@biomejs/cli-linux-arm64@https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-arm64@19c71415458c64273945fd0f16263cffc8e0479a':
-    resolution: {integrity: sha512-cVnp8ICpvaLk99thG65JwJY9+gwIDk+NwjG0+HSlbYWsc1eJl98ThkXeNTaubpxsDSQiTrj1EftjN9ZngHvdSA==, tarball: https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-arm64@19c71415458c64273945fd0f16263cffc8e0479a}
-    version: 2.4.15
+  '@biomejs/cli-linux-arm64@2.4.16':
+    resolution: {integrity: sha512-2kFb4//jxfZaP6D+Rj5VkHkxgyD9EoRAVBEQb8PKRv+s4NO2zYNJKXFaJmK1CmhufJOWEfpHKaRbOja7qjmdhQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-x64-musl@19c71415458c64273945fd0f16263cffc8e0479a':
-    resolution: {integrity: sha512-gsoesy1rqoynkdhAsdMw150RpcIowZ5Pc6D1dgPtgGMdvDKdMEKSHpBZgvkJbAMx+n9kLwB9mVD/dq0GhdGokQ==, tarball: https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-x64-musl@19c71415458c64273945fd0f16263cffc8e0479a}
-    version: 2.4.15
+  '@biomejs/cli-linux-x64-musl@2.4.16':
+    resolution: {integrity: sha512-iHDS+MCM65DPqWGu+ECC3uoALyj2H7F4nVUPxIPjz/PIl94EUu+EDfGZDzFP+NY1EOPVt9NQvwFqq7HdMmowdg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
-  '@biomejs/cli-linux-x64@https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-x64@19c71415458c64273945fd0f16263cffc8e0479a':
-    resolution: {integrity: sha512-psFbx5U/PwepUULmQf20U/onXRZWbKqYk7WQkxadcMUyihQqvqm1BhhR6LytdLXmJ4afapZ1aKuNww/v77RhHQ==, tarball: https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-x64@19c71415458c64273945fd0f16263cffc8e0479a}
-    version: 2.4.15
+  '@biomejs/cli-linux-x64@2.4.16':
+    resolution: {integrity: sha512-NbcBbi/nJqn5baae6wqRXdS7Gadf2uRpehSh6vMSYpG8OhkXl/Xg8aorWrJ+9VWqAT5ml90alLvorkpMW0nBwQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@https://pkg.pr.new/biomejs/biome/@biomejs/cli-win32-arm64@19c71415458c64273945fd0f16263cffc8e0479a':
-    resolution: {integrity: sha512-ef7YS9NDqlbAGtEAWNT+nxOX/pOJvmaqieg0KoUobmXkOI4fjq0DylQyM4hHfy5VJhOGIDxf2uHPTA7KFO213Q==, tarball: https://pkg.pr.new/biomejs/biome/@biomejs/cli-win32-arm64@19c71415458c64273945fd0f16263cffc8e0479a}
-    version: 2.4.15
+  '@biomejs/cli-win32-arm64@2.4.16':
+    resolution: {integrity: sha512-0rgImMsNb5v/chhkIFe3wu7PEFClS6RBAYUijGL9UsYN3PanSaoK24HSSuSJb1pYbYYVjzAyZTl3gtjJ84BM8A==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@https://pkg.pr.new/biomejs/biome/@biomejs/cli-win32-x64@19c71415458c64273945fd0f16263cffc8e0479a':
-    resolution: {integrity: sha512-FeIepL4QT+rEQD4T6gUdk7G3rylx+qK3vIkl9+V60Jj4x2xmn0fbEYYoyVapuhwxWQ4RB9z/B/Oz2mC2GEettA==, tarball: https://pkg.pr.new/biomejs/biome/@biomejs/cli-win32-x64@19c71415458c64273945fd0f16263cffc8e0479a}
-    version: 2.4.15
+  '@biomejs/cli-win32-x64@2.4.16':
+    resolution: {integrity: sha512-Kp85jgoBHa05gix6UIRjfCDiUV3w/8VIdZ247VyyO2gEjaw12WEVhdIjlxp/AMzXxqxQwbxNTDVZ3Mwd2RG5rw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -6775,39 +6770,39 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
-  '@biomejs/biome@https://pkg.pr.new/biomejs/biome/@biomejs/biome@19c71415458c64273945fd0f16263cffc8e0479a':
+  '@biomejs/biome@2.4.16':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': https://pkg.pr.new/biomejs/biome/@biomejs/cli-darwin-arm64@19c71415458c64273945fd0f16263cffc8e0479a
-      '@biomejs/cli-darwin-x64': https://pkg.pr.new/biomejs/biome/@biomejs/cli-darwin-x64@19c71415458c64273945fd0f16263cffc8e0479a
-      '@biomejs/cli-linux-arm64': https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-arm64@19c71415458c64273945fd0f16263cffc8e0479a
-      '@biomejs/cli-linux-arm64-musl': https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-arm64-musl@19c71415458c64273945fd0f16263cffc8e0479a
-      '@biomejs/cli-linux-x64': https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-x64@19c71415458c64273945fd0f16263cffc8e0479a
-      '@biomejs/cli-linux-x64-musl': https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-x64-musl@19c71415458c64273945fd0f16263cffc8e0479a
-      '@biomejs/cli-win32-arm64': https://pkg.pr.new/biomejs/biome/@biomejs/cli-win32-arm64@19c71415458c64273945fd0f16263cffc8e0479a
-      '@biomejs/cli-win32-x64': https://pkg.pr.new/biomejs/biome/@biomejs/cli-win32-x64@19c71415458c64273945fd0f16263cffc8e0479a
+      '@biomejs/cli-darwin-arm64': 2.4.16
+      '@biomejs/cli-darwin-x64': 2.4.16
+      '@biomejs/cli-linux-arm64': 2.4.16
+      '@biomejs/cli-linux-arm64-musl': 2.4.16
+      '@biomejs/cli-linux-x64': 2.4.16
+      '@biomejs/cli-linux-x64-musl': 2.4.16
+      '@biomejs/cli-win32-arm64': 2.4.16
+      '@biomejs/cli-win32-x64': 2.4.16
 
-  '@biomejs/cli-darwin-arm64@https://pkg.pr.new/biomejs/biome/@biomejs/cli-darwin-arm64@19c71415458c64273945fd0f16263cffc8e0479a':
+  '@biomejs/cli-darwin-arm64@2.4.16':
     optional: true
 
-  '@biomejs/cli-darwin-x64@https://pkg.pr.new/biomejs/biome/@biomejs/cli-darwin-x64@19c71415458c64273945fd0f16263cffc8e0479a':
+  '@biomejs/cli-darwin-x64@2.4.16':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-arm64-musl@19c71415458c64273945fd0f16263cffc8e0479a':
+  '@biomejs/cli-linux-arm64-musl@2.4.16':
     optional: true
 
-  '@biomejs/cli-linux-arm64@https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-arm64@19c71415458c64273945fd0f16263cffc8e0479a':
+  '@biomejs/cli-linux-arm64@2.4.16':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-x64-musl@19c71415458c64273945fd0f16263cffc8e0479a':
+  '@biomejs/cli-linux-x64-musl@2.4.16':
     optional: true
 
-  '@biomejs/cli-linux-x64@https://pkg.pr.new/biomejs/biome/@biomejs/cli-linux-x64@19c71415458c64273945fd0f16263cffc8e0479a':
+  '@biomejs/cli-linux-x64@2.4.16':
     optional: true
 
-  '@biomejs/cli-win32-arm64@https://pkg.pr.new/biomejs/biome/@biomejs/cli-win32-arm64@19c71415458c64273945fd0f16263cffc8e0479a':
+  '@biomejs/cli-win32-arm64@2.4.16':
     optional: true
 
-  '@biomejs/cli-win32-x64@https://pkg.pr.new/biomejs/biome/@biomejs/cli-win32-x64@19c71415458c64273945fd0f16263cffc8e0479a':
+  '@biomejs/cli-win32-x64@2.4.16':
     optional: true
 
   '@biomejs/version-utils@0.4.0':


### PR DESCRIPTION
## Summary

#4272 made the job failing because the `setup-biome` action doesn't support reading `pkg.pr.new` versions. Updated `@biomejs/biome` to the latest version v2.4.16 so the job should become green now.