### PR TITLE
docs(git-hooks): add css to glob examples

### DIFF
--- a/src/content/docs/es/recipes/git-hooks.mdx
+++ b/src/content/docs/es/recipes/git-hooks.mdx
@@ -22,7 +22,7 @@ Algunos ejemplos de configuraciones _Lefthook_.:
   pre-commit:
     commands:
       check:
-        glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
+        glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}"
         run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
   ```
 
@@ -32,7 +32,7 @@ Algunos ejemplos de configuraciones _Lefthook_.:
   pre-commit:
     commands:
       check:
-        glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
+        glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}"
         run: npx @biomejs/biome check --write --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
         stage_fixed: true
   ```
@@ -45,7 +45,7 @@ Algunos ejemplos de configuraciones _Lefthook_.:
   pre-push:
     commands:
       check:
-        glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
+        glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}"
         run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {push_files}
   ```
 
@@ -90,8 +90,8 @@ Estos son algunos ejemplos de comandos que pueden resultarte útiles al ejecutar
 ```jsonc title="package.json"
 {
   "lint-staged": {
-    // Ejecuta Biome en archivos por etapas que tengan las siguientes extensiones: js, ts, jsx, tsx, json y jsonc
-    "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}": [
+    // Ejecuta Biome en archivos por etapas que tengan las siguientes extensiones: js, ts, jsx, tsx, json, jsonc y css
+    "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}": [
       "biome check --files-ignore-unknown=true", // Comprueba el formato y verificar errores
       "biome check --write --no-errors-on-unmatched", // Formatea, organiza importaciones, verifica errores, y aplica correcciones seguras
       "biome check --write --organize-imports-enabled=false --no-errors-on-unmatched", // Formatea y aplica correcciones seguras
@@ -174,7 +174,7 @@ repos:
         entry: npx @biomejs/biome check --write --files-ignore-unknown=true --no-errors-on-unmatched
         language: system
         types: [text]
-        files: "\\.(jsx?|tsx?|c(js|ts)|m(js|ts)|d\\.(ts|cts|mts)|jsonc?)$"
+        files: "\\.(jsx?|tsx?|c(js|ts)|m(js|ts)|d\\.(ts|cts|mts)|jsonc?|css)$"
 ```
 
 La opción de pre-commit `files` es opcional,

--- a/src/content/docs/fr/recipes/git-hooks.mdx
+++ b/src/content/docs/fr/recipes/git-hooks.mdx
@@ -23,7 +23,7 @@ Quelques exemples de configuration de _Lefthook&nbsp;:_
   pre-commit:
     commands:
       check:
-        glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
+        glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}"
         run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
   ```
 
@@ -33,7 +33,7 @@ Quelques exemples de configuration de _Lefthook&nbsp;:_
   pre-commit:
     commands:
       check:
-        glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
+        glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}"
         run: npx @biomejs/biome check --write --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
         stage_fixed: true
   ```
@@ -46,7 +46,7 @@ Quelques exemples de configuration de _Lefthook&nbsp;:_
   pre-push:
     commands:
       check:
-        glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
+        glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}"
         run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {push_files}
   ```
 
@@ -92,8 +92,8 @@ Voici un exemple de commandes que vous pourriez trouver utiles en exécutant les
 ```jsonc title="package.json"
 {
   "lint-staged": {
-    // Exécuter Biome sur les fichiers indexés avec les extensions suivantes : js, ts, jsx, tsx, json et jsonc
-    "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}": [
+    // Exécuter Biome sur les fichiers indexés avec les extensions suivantes : js, ts, jsx, tsx, json, jsonc et css
+    "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}": [
       "biome check --files-ignore-unknown=true", // Vérifier le formatage et le linting
       "biome check --write --no-errors-on-unmatched", // Formater, trier les imports, analyser et faire appliquer les corrections sûres
       "biome check --write --organize-imports-enabled=false --no-errors-on-unmatched", // Formater et faire appliquer les corrections sûres
@@ -178,7 +178,7 @@ repos:
         entry: npx @biomejs/biome check --write --files-ignore-unknown=true --no-errors-on-unmatched
         language: system
         types: [text]
-        files: "\\.(jsx?|tsx?|c(js|ts)|m(js|ts)|d\\.(ts|cts|mts)|jsonc?)$"
+        files: "\\.(jsx?|tsx?|c(js|ts)|m(js|ts)|d\\.(ts|cts|mts)|jsonc?|css)$"
 ```
 
 L’option de pre-commit `files` est facultative

--- a/src/content/docs/ja/recipes/git-hooks.mdx
+++ b/src/content/docs/ja/recipes/git-hooks.mdx
@@ -23,7 +23,7 @@ Gitリポジトリのルートに`lefthook.yml`というファイルを追加し
   pre-commit:
     commands:
       check:
-        glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
+        glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}"
         run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
   ```
 
@@ -33,7 +33,7 @@ Gitリポジトリのルートに`lefthook.yml`というファイルを追加し
   pre-commit:
     commands:
       check:
-        glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
+        glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}"
         run: npx @biomejs/biome check --write --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
         stage_fixed: true
   ```
@@ -46,7 +46,7 @@ Gitリポジトリのルートに`lefthook.yml`というファイルを追加し
   pre-push:
     commands:
       check:
-        glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
+        glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}"
         run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {push_files}
   ```
 
@@ -91,8 +91,8 @@ Git Hooksを実行するときに便利なコマンドの例です：
 ```jsonc title="package.json"
 {
   "lint-staged": {
-    // 次の拡張子を持つステージングファイルに対してBiomeを実行する: js, ts, jsx, tsx, json and jsonc
-    "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}": [
+    // 次の拡張子を持つステージングファイルに対してBiomeを実行する: js, ts, jsx, tsx, json, jsonc and css
+    "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}": [
       "biome check --files-ignore-unknown=true", // フォーマットのチェックとリント
       "biome check --write --no-errors-on-unmatched", // フォーマット、インポート文のソート、リント、安全な修正の適用
       "biome check --write --organize-imports-enabled=false --no-errors-on-unmatched", // フォーマットと安全な修正の適用
@@ -177,7 +177,7 @@ repos:
         entry: npx @biomejs/biome check --write --files-ignore-unknown=true --no-errors-on-unmatched
         language: system
         types: [text]
-        files: "\\.(jsx?|tsx?|c(js|ts)|m(js|ts)|d\\.(ts|cts|mts)|jsonc?)$"
+        files: "\\.(jsx?|tsx?|c(js|ts)|m(js|ts)|d\\.(ts|cts|mts)|jsonc?|css)$"
 ```
 
 Biomeは`--files-ignore-unknown=true`を指定することで未知のファイルを無視するため、pre-commitの `files` オプションは必須ではありません。

--- a/src/content/docs/pl/recipes/git-hooks.mdx
+++ b/src/content/docs/pl/recipes/git-hooks.mdx
@@ -23,7 +23,7 @@ Kilka przykładów konfiguracji _Lefthook_:
   pre-commit:
     commands:
       check:
-        glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
+        glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}"
         run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
   ```
 
@@ -33,7 +33,7 @@ Kilka przykładów konfiguracji _Lefthook_:
   pre-commit:
     commands:
       check:
-        glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
+        glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}"
         run: npx @biomejs/biome check --write --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
         stage_fixed: true
   ```
@@ -46,7 +46,7 @@ Kilka przykładów konfiguracji _Lefthook_:
   pre-push:
     commands:
       check:
-        glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
+        glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}"
         run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {push_files}
   ```
 
@@ -92,8 +92,8 @@ Oto kilka przykładów poleceń, które mogą być przydatne podczas uruchamiani
 ```jsonc title="package.json"
 {
   "lint-staged": {
-    // Uruchom Biome na przygotowanych plikach z następującymi rozszerzeniami: js, ts, jsx, tsx, json i jsonc
-    "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}": [
+    // Uruchom Biome na przygotowanych plikach z następującymi rozszerzeniami: js, ts, jsx, tsx, json, jsonc i css
+    "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}": [
       "biome check --files-ignore-unknown=true", // Sprawdź formatowanie i lintuj
       "biome check --write --no-errors-on-unmatched", // Formatuj, sortuj importy, lintuj i zastosuj bezpieczne poprawki
       "biome check --write --organize-imports-enabled=false --no-errors-on-unmatched", // formatuj i zastosuj bezpieczne poprawki
@@ -178,7 +178,7 @@ repos:
         entry: npx @biomejs/biome check --write --files-ignore-unknown=true --no-errors-on-unmatched
         language: system
         types: [text]
-        files: "\\.(jsx?|tsx?|c(js|ts)|m(js|ts)|d\\.(ts|cts|mts)|jsonc?)$"
+        files: "\\.(jsx?|tsx?|c(js|ts)|m(js|ts)|d\\.(ts|cts|mts)|jsonc?|css)$"
 ```
 
 Opcja pre-commit `files` jest opcjonalna,

--- a/src/content/docs/pt-BR/recipes/git-hooks.mdx
+++ b/src/content/docs/pt-BR/recipes/git-hooks.mdx
@@ -24,7 +24,7 @@ Alguns exemplos de configurações:
   pre-commit:
     commands:
       check:
-        glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
+        glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}"
         run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
   ```
 
@@ -34,7 +34,7 @@ Alguns exemplos de configurações:
   pre-commit:
     commands:
       check:
-        glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
+        glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}"
         run: npx @biomejs/biome check --write --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
         stage_fixed: true
   ```
@@ -47,7 +47,7 @@ Alguns exemplos de configurações:
   pre-push:
     commands:
       check:
-        glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
+        glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}"
         run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {push_files}
   ```
 
@@ -93,8 +93,8 @@ Aqui alguns exemplos de comandos que podem ser úteis ao executar os Git hooks:
 ```jsonc title="package.json"
 {
   "lint-staged": {
-    // Executa o Biome em arquivos em stage que possui as seguintes extensões: js, ts, jsx, tsx, json e jsonc.
-    "**.{js|ts|cjs|mjs|d.cts|d.mts|jsx|tsx|json|jsonc}": [
+    // Executa o Biome em arquivos em stage que possui as seguintes extensões: js, ts, jsx, tsx, json, jsonc e css.
+    "**.{js|ts|cjs|mjs|d.cts|d.mts|jsx|tsx|json|jsonc|css}": [
       "biome check --files-ignore-unknown=true", // Formatar e verificar erros.
       "biome check --write --no-errors-on-unmatched", // Formatar, organizar importações, verificar erros e aplicar correções seguras.
       "biome check --write --organize-imports-enabled=false --no-errors-on-unmatched", // Formatar e aplicar correções seguras.
@@ -179,7 +179,7 @@ repos:
         entry: npx @biomejs/biome check --write --files-ignore-unknown=true --no-errors-on-unmatched
         language: system
         types: [text]
-        files: "\\.(jsx?|tsx?|c(js|ts)|m(js|ts)|d\\.(ts|cts|mts)|jsonc?)$"
+        files: "\\.(jsx?|tsx?|c(js|ts)|m(js|ts)|d\\.(ts|cts|mts)|jsonc?|css)$"
 ```
 
 A opção `files` é opcional,

--- a/src/content/docs/recipes/git-hooks.mdx
+++ b/src/content/docs/recipes/git-hooks.mdx
@@ -23,7 +23,7 @@ Some examples of _Lefthook_ configurations:
   pre-commit:
     commands:
       check:
-        glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
+        glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}"
         run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
   ```
 
@@ -33,7 +33,7 @@ Some examples of _Lefthook_ configurations:
   pre-commit:
     commands:
       check:
-        glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
+        glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}"
         run: npx @biomejs/biome check --write --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
         stage_fixed: true
   ```
@@ -46,7 +46,7 @@ Some examples of _Lefthook_ configurations:
   pre-push:
     commands:
       check:
-        glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
+        glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}"
         run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {push_files}
   ```
 
@@ -92,8 +92,8 @@ Here's some example of commands that you could find useful when running the Git 
 ```jsonc title="package.json"
 {
   "lint-staged": {
-    // Run Biome on staged files that have the following extensions: js, ts, jsx, tsx, json and jsonc
-    "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}": [
+    // Run Biome on staged files that have the following extensions: js, ts, jsx, tsx, json, jsonc and css
+    "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}": [
       "biome check --files-ignore-unknown=true", // Check formatting and lint
       "biome check --write --no-errors-on-unmatched", // Format, sort imports, lint, and apply safe fixes
       "biome check --write --organize-imports-enabled=false --no-errors-on-unmatched", // format and apply safe fixes
@@ -178,7 +178,7 @@ repos:
         entry: npx @biomejs/biome check --write --files-ignore-unknown=true --no-errors-on-unmatched
         language: system
         types: [text]
-        files: "\\.(jsx?|tsx?|c(js|ts)|m(js|ts)|d\\.(ts|cts|mts)|jsonc?)$"
+        files: "\\.(jsx?|tsx?|c(js|ts)|m(js|ts)|d\\.(ts|cts|mts)|jsonc?|css)$"
 ```
 
 The pre-commit option `files` is optional,

--- a/src/content/docs/zh-CN/recipes/git-hooks.mdx
+++ b/src/content/docs/zh-CN/recipes/git-hooks.mdx
@@ -23,7 +23,7 @@ Git 允许在运行 git 命令的过程中执行 [Git Hooks](https://git-scm.com
   pre-commit:
     commands:
       check:
-        glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
+        glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}"
         run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
   ```
 
@@ -33,7 +33,7 @@ Git 允许在运行 git 命令的过程中执行 [Git Hooks](https://git-scm.com
   pre-commit:
     commands:
       check:
-        glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
+        glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}"
         run: npx @biomejs/biome check --write --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
         stage_fixed: true
   ```
@@ -46,7 +46,7 @@ Git 允许在运行 git 命令的过程中执行 [Git Hooks](https://git-scm.com
   pre-push:
     commands:
       check:
-        glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}"
+        glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}"
         run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {push_files}
   ```
 
@@ -92,8 +92,8 @@ lint-staged 的配置直接集成在 `package.json` 内。
 ```jsonc title="package.json"
 {
   "lint-staged": {
-    // Run Biome on staged files that have the following extensions: js, ts, jsx, tsx, json and jsonc
-    "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc}": [
+    // Run Biome on staged files that have the following extensions: js, ts, jsx, tsx, json, jsonc and css
+    "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}": [
       "biome check --files-ignore-unknown=true", // Check formatting and lint
       "biome check --write --no-errors-on-unmatched", // Format, sort imports, lint, and apply safe fixes
       "biome check --write --organize-imports-enabled=false --no-errors-on-unmatched", // format and apply safe fixes
@@ -178,7 +178,7 @@ repos:
         entry: npx @biomejs/biome check --write --files-ignore-unknown=true --no-errors-on-unmatched
         language: system
         types: [text]
-        files: "\\.(jsx?|tsx?|c(js|ts)|m(js|ts)|d\\.(ts|cts|mts)|jsonc?)$"
+        files: "\\.(jsx?|tsx?|c(js|ts)|m(js|ts)|d\\.(ts|cts|mts)|jsonc?|css)$"
 ```
 
 pre-commit 配置项 `files ` 是可选的，


### PR DESCRIPTION
## Summary

Add `css` to extension-enumerating examples in the Git Hooks recipe (Lefthook, lint-staged, and pre-commit local hook). The previous examples predated stable CSS support, so staged `.css` files were excluded when readers copied the glob patterns.

Fixes #4306
