### PR TITLE
fix: default go-to definition

### DIFF
--- a/src/content/docs/editors/introduction.mdx
+++ b/src/content/docs/editors/introduction.mdx
@@ -105,7 +105,7 @@ However, during local development, you want to disable this rule because it's us
 ### `go_to_definition`
 
 **Type**: `boolean`<br />
-**Default**: `true`
+**Default**: `false`
 
 Enables the LSP's `textDocument/definition` capabilities using the Biome module graph.
 

--- a/src/content/docs/reference/vscode.mdx
+++ b/src/content/docs/reference/vscode.mdx
@@ -190,7 +190,7 @@ However, during local development, you want to disable this rule because it's us
 
 Enables the [Go-to definition](/editors/introduction#go_to_definition) feature in the editor.
 
-> Default: `true`
+> Default: `false`
 
 ```json title=".vscode/settings.json"
 {

--- a/src/content/docs/reference/zed.mdx
+++ b/src/content/docs/reference/zed.mdx
@@ -111,7 +111,7 @@ However, during local development, you want to disable this rule because it's us
 
 Enables the [Go-to definition](/editors/introduction#go_to_definition) feature in the editor.
 
-> Default: `true`
+> Default: `false`
 
 ```json title=".zed/settings.json"
 {


### PR DESCRIPTION
## Summary

As part of https://github.com/biomejs/biome/pull/10689