### PR TITLE
docs: remove --colors=off from lefthook examples

### DIFF
--- a/src/content/docs/es/recipes/git-hooks.mdx
+++ b/src/content/docs/es/recipes/git-hooks.mdx
@@ -23,7 +23,7 @@ Algunos ejemplos de configuraciones _Lefthook_.:
     commands:
       check:
         glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}"
-        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
+        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true {staged_files}
   ```
 
 - Formatea, corrige y aplica correcciones seguras al código antes de efectuar un commit
@@ -33,7 +33,7 @@ Algunos ejemplos de configuraciones _Lefthook_.:
     commands:
       check:
         glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}"
-        run: npx @biomejs/biome check --write --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
+        run: npx @biomejs/biome check --write --no-errors-on-unmatched --files-ignore-unknown=true {staged_files}
         stage_fixed: true
   ```
 
@@ -46,7 +46,7 @@ Algunos ejemplos de configuraciones _Lefthook_.:
     commands:
       check:
         glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}"
-        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {push_files}
+        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true {push_files}
   ```
 
 Ten en cuenta que no es necesario utilizar tanto `glob` como `--files-ignore-unknown=true`.
@@ -56,6 +56,12 @@ Si deseas un mayor control sobre los archivos que se gestionan, debes utilizar `
 `--no-errors-on-unmatched` silencia posibles errores en caso de que _no se procesen ficheros_..
 
 Una vez configurado, ejecuta `lefthook install` para configurar los hooks.
+
+
+:::note
+If you are using an older version of Lefthook and see raw ANSI escape sequences in your terminal, you should either upgrade Lefthook or configure Lefthook colors / set `NO_COLOR`. Alternatively, you can pass `--colors=off` to Biome.
+:::
+
 
 ## Husky
 

--- a/src/content/docs/fr/recipes/git-hooks.mdx
+++ b/src/content/docs/fr/recipes/git-hooks.mdx
@@ -24,7 +24,7 @@ Quelques exemples de configuration de _Lefthook&nbsp;:_
     commands:
       check:
         glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}"
-        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
+        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true {staged_files}
   ```
 
 - formater, analyser et faire appliquer les corrections de code sûres avant un commit&nbsp;:
@@ -34,7 +34,7 @@ Quelques exemples de configuration de _Lefthook&nbsp;:_
     commands:
       check:
         glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}"
-        run: npx @biomejs/biome check --write --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
+        run: npx @biomejs/biome check --write --no-errors-on-unmatched --files-ignore-unknown=true {staged_files}
         stage_fixed: true
   ```
 
@@ -47,7 +47,7 @@ Quelques exemples de configuration de _Lefthook&nbsp;:_
     commands:
       check:
         glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}"
-        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {push_files}
+        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true {push_files}
   ```
 
 Notez que vous n’avez pas besoin d’utiliser à la fois `glob` et `--files-ignore-unknown=true`.
@@ -57,6 +57,11 @@ Pour plus de contrôle sur les fichiers à traiter, vous devriez utiliser `glob`
 `--no-errors-on-unmatched` passe sous silence de possibles erreurs pour le cas où *aucun fichier ne serait traité.*
 
 Une fois la configuration effectuée, exécutez `lefthook install` pour installer les hooks.
+
+
+:::note
+If you are using an older version of Lefthook and see raw ANSI escape sequences in your terminal, you should either upgrade Lefthook or configure Lefthook colors / set `NO_COLOR`. Alternatively, you can pass `--colors=off` to Biome.
+:::
 
 
 ## Husky

--- a/src/content/docs/ja/recipes/git-hooks.mdx
+++ b/src/content/docs/ja/recipes/git-hooks.mdx
@@ -24,7 +24,7 @@ Gitリポジトリのルートに`lefthook.yml`というファイルを追加し
     commands:
       check:
         glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}"
-        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
+        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true {staged_files}
   ```
 
 - コミット前にフォーマットチェックやリントを行い、[安全な修正](/ja/linter#安全な修正safe-fixes)を行う
@@ -34,7 +34,7 @@ Gitリポジトリのルートに`lefthook.yml`というファイルを追加し
     commands:
       check:
         glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}"
-        run: npx @biomejs/biome check --write --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
+        run: npx @biomejs/biome check --write --no-errors-on-unmatched --files-ignore-unknown=true {staged_files}
         stage_fixed: true
   ```
 
@@ -47,7 +47,7 @@ Gitリポジトリのルートに`lefthook.yml`というファイルを追加し
     commands:
       check:
         glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}"
-        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {push_files}
+        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true {push_files}
   ```
 
 `glob`と`--files-ignore-unknown=true` を併用する必要はありません。
@@ -57,6 +57,11 @@ Gitリポジトリのルートに`lefthook.yml`というファイルを追加し
 `--no-errors-on-unmatched`は、*どのファイルも処理されなかった場合*に発生するエラーを抑制します。
 
 設定後、`lefthook install` を実行してフックのセットアップを完了させましょう。
+
+
+:::note
+If you are using an older version of Lefthook and see raw ANSI escape sequences in your terminal, you should either upgrade Lefthook or configure Lefthook colors / set `NO_COLOR`. Alternatively, you can pass `--colors=off` to Biome.
+:::
 
 
 ## Husky

--- a/src/content/docs/pl/recipes/git-hooks.mdx
+++ b/src/content/docs/pl/recipes/git-hooks.mdx
@@ -24,7 +24,7 @@ Kilka przykładów konfiguracji _Lefthook_:
     commands:
       check:
         glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}"
-        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
+        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true {staged_files}
   ```
 
 - Formatuj, lintuj i zastosuj bezpieczne poprawki kodu przed commitowaniem
@@ -34,7 +34,7 @@ Kilka przykładów konfiguracji _Lefthook_:
     commands:
       check:
         glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}"
-        run: npx @biomejs/biome check --write --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
+        run: npx @biomejs/biome check --write --no-errors-on-unmatched --files-ignore-unknown=true {staged_files}
         stage_fixed: true
   ```
 
@@ -47,7 +47,7 @@ Kilka przykładów konfiguracji _Lefthook_:
     commands:
       check:
         glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}"
-        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {push_files}
+        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true {push_files}
   ```
 
 Zauważ, że nie musisz używać jednocześnie `glob` i `--files-ignore-unknown=true`.
@@ -57,6 +57,11 @@ Jeśli chcesz mieć większą kontrolę nad tym, które pliki są obsługiwane, 
 `--no-errors-on-unmatched` wycisza możliwe błędy w przypadku, gdy *nie są przetwarzane żadne pliki*.
 
 Po skonfigurowaniu uruchom `lefthook install`, aby skonfigurować hooki.
+
+
+:::note
+If you are using an older version of Lefthook and see raw ANSI escape sequences in your terminal, you should either upgrade Lefthook or configure Lefthook colors / set `NO_COLOR`. Alternatively, you can pass `--colors=off` to Biome.
+:::
 
 
 ## Husky

--- a/src/content/docs/pt-BR/recipes/git-hooks.mdx
+++ b/src/content/docs/pt-BR/recipes/git-hooks.mdx
@@ -25,7 +25,7 @@ Alguns exemplos de configurações:
     commands:
       check:
         glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}"
-        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
+        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true {staged_files}
   ```
 
 - Formatar, verificar erros e aplicar correções seguras antes de efetuar o commit.
@@ -35,7 +35,7 @@ Alguns exemplos de configurações:
     commands:
       check:
         glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}"
-        run: npx @biomejs/biome check --write --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
+        run: npx @biomejs/biome check --write --no-errors-on-unmatched --files-ignore-unknown=true {staged_files}
         stage_fixed: true
   ```
 
@@ -48,7 +48,7 @@ Alguns exemplos de configurações:
     commands:
       check:
         glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}"
-        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {push_files}
+        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true {push_files}
   ```
 
 Não é necessário utilizar tanto `glob` quanto `--files-ignore-unknown=true`.
@@ -58,6 +58,11 @@ Se você deseja mais controle sobre os arquivos que são lidados, você deve usa
 `--no-errors-on-unmatched` silencia possíveis erros no caso de *nenhum arquivo ser processado*.
 
 Uma vez configurado, execute `lefthook install` para inicializar os hooks.
+
+
+:::note
+If you are using an older version of Lefthook and see raw ANSI escape sequences in your terminal, you should either upgrade Lefthook or configure Lefthook colors / set `NO_COLOR`. Alternatively, you can pass `--colors=off` to Biome.
+:::
 
 
 ## Husky

--- a/src/content/docs/recipes/git-hooks.mdx
+++ b/src/content/docs/recipes/git-hooks.mdx
@@ -24,7 +24,7 @@ Some examples of _Lefthook_ configurations:
     commands:
       check:
         glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}"
-        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
+        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true {staged_files}
   ```
 
 - Format, lint, and apply safe code fixes before committing
@@ -34,7 +34,7 @@ Some examples of _Lefthook_ configurations:
     commands:
       check:
         glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}"
-        run: npx @biomejs/biome check --write --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
+        run: npx @biomejs/biome check --write --no-errors-on-unmatched --files-ignore-unknown=true {staged_files}
         stage_fixed: true
   ```
 
@@ -47,7 +47,7 @@ Some examples of _Lefthook_ configurations:
     commands:
       check:
         glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}"
-        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {push_files}
+        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true {push_files}
   ```
 
 Note that you don't need to use both `glob` and `--files-ignore-unknown=true`.
@@ -57,6 +57,11 @@ If you wish more control over which files are handled, you should use `glob`.
 `--no-errors-on-unmatched` silents possible errors in case *no files are processed*.
 
 Once configured, run `lefthook install` to set up the hooks.
+
+
+:::note
+If you are using an older version of Lefthook and see raw ANSI escape sequences in your terminal, you should either upgrade Lefthook or configure Lefthook colors / set `NO_COLOR`. Alternatively, you can pass `--colors=off` to Biome.
+:::
 
 
 ## Husky

--- a/src/content/docs/zh-CN/recipes/git-hooks.mdx
+++ b/src/content/docs/zh-CN/recipes/git-hooks.mdx
@@ -24,7 +24,7 @@ Git 允许在运行 git 命令的过程中执行 [Git Hooks](https://git-scm.com
     commands:
       check:
         glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}"
-        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
+        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true {staged_files}
   ```
 
 - 提交前进行格式化，lint，以及进行安全的代码修复
@@ -34,7 +34,7 @@ Git 允许在运行 git 命令的过程中执行 [Git Hooks](https://git-scm.com
     commands:
       check:
         glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}"
-        run: npx @biomejs/biome check --write --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
+        run: npx @biomejs/biome check --write --no-errors-on-unmatched --files-ignore-unknown=true {staged_files}
         stage_fixed: true
   ```
 
@@ -47,7 +47,7 @@ Git 允许在运行 git 命令的过程中执行 [Git Hooks](https://git-scm.com
     commands:
       check:
         glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}"
-        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {push_files}
+        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true {push_files}
   ```
 
 注意，你不需要同时使用 `glob` 和 `--files-ignore-unknown=true`。
@@ -57,6 +57,11 @@ Git 允许在运行 git 命令的过程中执行 [Git Hooks](https://git-scm.com
 `--no-errors-on-unmatched` 会静默*没有文件被处理*的情况下产生的错误。
 
 完成配置后，运行 `lefthook install` 来设置 hooks。
+
+
+:::note
+If you are using an older version of Lefthook and see raw ANSI escape sequences in your terminal, you should either upgrade Lefthook or configure Lefthook colors / set `NO_COLOR`. Alternatively, you can pass `--colors=off` to Biome.
+:::
 
 
 ## Husky


### PR DESCRIPTION
Resolves #4305

Removed the `--colors=off` flag from the Lefthook examples in `git-hooks.mdx` (and its translations) since recent Lefthook versions handle TTY correctly.

Also added a brief note for users on older Lefthook versions as suggested in the issue.