### PR TITLE
docs: remove --colors=off from lefthook examples

### DIFF
--- a/src/content/docs/recipes/git-hooks.mdx
+++ b/src/content/docs/recipes/git-hooks.mdx
@@ -24,7 +24,7 @@ Some examples of _Lefthook_ configurations:
     commands:
       check:
         glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}"
-        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
+        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true {staged_files}
   ```
 
 - Format, lint, and apply safe code fixes before committing
@@ -34,7 +34,7 @@ Some examples of _Lefthook_ configurations:
     commands:
       check:
         glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}"
-        run: npx @biomejs/biome check --write --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {staged_files}
+        run: npx @biomejs/biome check --write --no-errors-on-unmatched --files-ignore-unknown=true {staged_files}
         stage_fixed: true
   ```
 
@@ -47,7 +47,7 @@ Some examples of _Lefthook_ configurations:
     commands:
       check:
         glob: "*.{js,ts,cjs,mjs,d.cts,d.mts,jsx,tsx,json,jsonc,css}"
-        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true --colors=off {push_files}
+        run: npx @biomejs/biome check --no-errors-on-unmatched --files-ignore-unknown=true {push_files}
   ```
 
 Note that you don't need to use both `glob` and `--files-ignore-unknown=true`.
@@ -57,6 +57,10 @@ If you wish more control over which files are handled, you should use `glob`.
 `--no-errors-on-unmatched` silents possible errors in case *no files are processed*.
 
 Once configured, run `lefthook install` to set up the hooks.
+
+:::note
+If you are using an older version of Lefthook and see raw ANSI escape sequences in your terminal, you should either upgrade Lefthook or configure Lefthook colors / set `NO_COLOR`. Alternatively, you can pass `--colors=off` to Biome.
+:::
 
 
 ## Husky

--- a/src/content/docs/recipes/git-hooks.mdx
+++ b/src/content/docs/recipes/git-hooks.mdx
@@ -59,7 +59,7 @@ If you wish more control over which files are handled, you should use `glob`.
 Once configured, run `lefthook install` to set up the hooks.
 
 :::note
-If you are using an older version of Lefthook and see raw ANSI escape sequences in your terminal, you should either upgrade Lefthook or configure Lefthook colors / set `NO_COLOR`. Alternatively, you can pass `--colors=off` to Biome.
+If you are using Lefthook older than `v2.1.6` and see raw ANSI escape sequences in your terminal, you should either upgrade Lefthook or configure Lefthook colors / set `NO_COLOR`. Alternatively, you can pass `--colors=off` to Biome.
 :::
 
 


### PR DESCRIPTION
Resolves #4305

As requested, this PR modifies ONLY the English  file to remove the `--colors=off` flag from the Lefthook examples and add the version compatibility note.

(Replaces closed PR #4329)