### PR TITLE
docs(vscode): fix grammar in Troubleshooting intro

### DIFF
--- a/src/content/docs/reference/vscode.mdx
+++ b/src/content/docs/reference/vscode.mdx
@@ -310,7 +310,7 @@ The polling interval in milliseconds. This is only applicable when using the `po
 
 ## Troubleshooting
 
-There may be times when you encounter unexpected issues with the extension. Here a a couple tip to help you troubleshoot
+There may be times when you encounter unexpected issues with the extension. Here are a couple of tips to help you troubleshoot
 the most common issues, and reset the extension's state.
 
 ### Accessing the LSP trace


### PR DESCRIPTION
## Summary

`src/content/docs/reference/vscode.mdx:313` has a broken sentence:

```diff
- There may be times when you encounter unexpected issues with the extension. Here a a couple tip to help you troubleshoot
+ There may be times when you encounter unexpected issues with the extension. Here are a couple of tips to help you troubleshoot
```

Three issues on one line: duplicated `a a`, missing verb (`are`), and singular `tip` (should be `tips` since the section lists multiple).

## Verified

- [x] One-line diff, MDX-only, no code blocks affected.
- [x] Section continues to read naturally with the fix ("Here are a couple of tips to help you troubleshoot the most common issues, and reset the extension's state.")