### PR TITLE
docs: document .htm support

### DIFF
--- a/src/content/docs/internals/language-support.mdx
+++ b/src/content/docs/internals/language-support.mdx
@@ -31,6 +31,8 @@ Legend:
 
 *\* currently requires [explicit opt-in](/reference/configuration/#html)*
 
+Biome recognizes files with the `.html` and `.htm` extensions as HTML.
+
 ## JavaScript support
 
 Biome supports the ES2024 version of the language.


### PR DESCRIPTION
## Summary

* update the **Language support** page to document that Biome recognizes both `.html` and `.htm` files as HTML, following the support introduced in biomejs/biome#11126
