### PR TITLE
fix(styles): add borders to code fence bodies

### DIFF
--- a/src/styles/_code-blocks.css
+++ b/src/styles/_code-blocks.css
@@ -40,7 +40,8 @@
 	content: "TERMINAL";
 }
 
-.expressive-code .frame:not(.has-title, .is-terminal) pre {
+.expressive-code:not(.linter .expressive-code) .frame:not(.is-terminal) pre {
+	border: 1px solid var(--ec-brdCol);
 	border-top: 0;
 	border-radius: 0 0 var(--biome-radius-sm) var(--biome-radius-sm);
 }


### PR DESCRIPTION
## Summary

This PR fixes code fences missing a border.

### Before

<img width="740" height="150" alt="Screenshot 2026-08-20 at 21 04 52" src="https://github.com/user-attachments/assets/f6eca0ed-a8d0-4af7-90d7-b471941ed590" />

### After

<img width="740" height="150" alt="Screenshot 2026-08-20 at 21 04 20" src="https://github.com/user-attachments/assets/db977e6d-05c4-4a1d-bb74-11e1b8d15339" />


