### PR TITLE
fix(docs): hide line numbers in short code blocks

### DIFF
--- a/src/components/PackageManagerBiomeCommand.astro
+++ b/src/components/PackageManagerBiomeCommand.astro
@@ -12,14 +12,25 @@ const biomeBin = "biome";
 
 <Tabs syncKey="command">
 	<TabItem label="npm" icon="seti:npm">
-		<Code frame="none" code={`npx ${biomePackage} ${command}`} lang="bash" />
+		<Code
+			frame="none"
+			showLineNumbers={false}
+			code={`npx ${biomePackage} ${command}`}
+			lang="bash"
+		/>
 	</TabItem>
 	<TabItem label="pnpm" icon="pnpm">
-		<Code frame="none" code={`pnpx ${biomePackage} ${command}`} lang="bash" />
+		<Code
+			frame="none"
+			showLineNumbers={false}
+			code={`pnpx ${biomePackage} ${command}`}
+			lang="bash"
+		/>
 	</TabItem>
 	<TabItem label="bun" icon="bun">
 		<Code
 			frame="none"
+			showLineNumbers={false}
 			code={`bunx --bun ${biomePackage} ${command}`}
 			lang="bash"
 		/>
@@ -27,6 +38,7 @@ const biomeBin = "biome";
 	<TabItem label="deno" icon="deno">
 		<Code
 			frame="none"
+			showLineNumbers={false}
 			code={`deno run -A npm:${biomePackage} ${command}`}
 			lang="bash"
 		/>
@@ -34,6 +46,7 @@ const biomeBin = "biome";
 	<TabItem label="yarn" icon="seti:yarn">
 		<Code
 			frame="none"
+			showLineNumbers={false}
 			code={`yarn exec ${biomeBin} -- ${command}`}
 			lang="bash"
 		/>

--- a/src/components/PackageManagerCommand.astro
+++ b/src/components/PackageManagerCommand.astro
@@ -6,6 +6,7 @@ import { Code, TabItem, Tabs } from "@astrojs/starlight/components";
 	<TabItem label="npm" icon="seti:npm">
 		<Code
 			frame="none"
+			showLineNumbers={false}
 			code={`${Astro.props.npx ? "npx" : "npm"} ${Astro.props.npx ?? Astro.props.npm ?? Astro.props.command}`}
 			lang="bash"
 		/>
@@ -13,6 +14,7 @@ import { Code, TabItem, Tabs } from "@astrojs/starlight/components";
 	<TabItem label="pnpm" icon="pnpm">
 		<Code
 			frame="none"
+			showLineNumbers={false}
 			code={`pnpm ${Astro.props.pnpm ?? Astro.props.command}`}
 			lang="bash"
 		/>
@@ -20,6 +22,7 @@ import { Code, TabItem, Tabs } from "@astrojs/starlight/components";
 	<TabItem label="bun" icon="bun">
 		<Code
 			frame="none"
+			showLineNumbers={false}
 			code={`bun${Astro.props.bun ? "" : "x"} ${Astro.props.bunx ?? Astro.props.bun ?? Astro.props.command}`}
 			lang="bash"
 		/>
@@ -27,6 +30,7 @@ import { Code, TabItem, Tabs } from "@astrojs/starlight/components";
 	<TabItem label="deno" icon="deno">
 		<Code
 			frame="none"
+			showLineNumbers={false}
 			code={`deno ${Astro.props.deno ?? Astro.props.command}`}
 			lang="bash"
 		/>
@@ -34,6 +38,7 @@ import { Code, TabItem, Tabs } from "@astrojs/starlight/components";
 	<TabItem label="yarn" icon="seti:yarn">
 		<Code
 			frame="none"
+			showLineNumbers={false}
 			code={`yarn ${Astro.props.yarn ?? Astro.props.command}`}
 			lang="bash"
 		/>

--- a/src/content/docs/es/formatter/index.mdx
+++ b/src/content/docs/es/formatter/index.mdx
@@ -28,7 +28,7 @@ Si pasas un glob como parámetro, tu shell lo expandirá.
 El resultado de la expansión depende de tu shell.
 Por ejemplo, algunos shells no soportan el glob recursivo `**` o la alternancia `{}` en el siguiente comando:
 
-```shell
+```shell showLineNumbers=false
 biome format ./src/**/*.test.{js,ts}
 ```
 

--- a/src/content/docs/es/guides/configure-biome.mdx
+++ b/src/content/docs/es/guides/configure-biome.mdx
@@ -164,7 +164,7 @@ La primera forma de controlar qué archivos y directorios sean procesados por Bi
 En el siguiente comando, formateamos sólo `file1.js` y todos los archivos del directorio `src`.
 Los directorios se recorren recursivamente.
 
-```shell
+```shell showLineNumbers=false
 biome format file1.js src/
 ```
 
@@ -208,7 +208,7 @@ Tomemos la siguiente configuración:
 
 Y ejecuta el siguiente comando:
 
-```shell
+```shell showLineNumbers=false
 biome format test/
 ```
 
@@ -217,7 +217,7 @@ Los archivos en `src` no están formateados porque el directorio no aparece en l
 
 Si ejecutamos el siguiente comando, no se alineará ningún archivo porque el directorio `test` se ignora explícitamente para el linter.
 
-```shell
+```shell showLineNumbers=false
 biome lint test/
 ```
 

--- a/src/content/docs/es/guides/integrate-in-vcs.mdx
+++ b/src/content/docs/es/guides/integrate-in-vcs.mdx
@@ -53,7 +53,7 @@ En primer lugar, tienes que actualizar tu archivo de configuración y decirle a 
 
 A continuación, añade la opción `--changed` a tu comando, para procesar sólo aquellos archivos que tu VCS reconozca como "cambiados". Biome, con la ayuda del VCS, determinará el archivo cambiado a partir de la rama `main` y su revisión actual:
 
-```shell
+```shell showLineNumbers=false
 biome check --changed
 ```
 
@@ -63,7 +63,7 @@ Biome no comprueba lo que ha cambiado, esto significa que incluso añadiendo esp
 
 Alternativamente, puede utilizar la opción `--since` para especificar una rama arbitraria. Esta opción **tiene precedencia** sobre la opción `vcs.defaultBranch`. Por ejemplo, puedes querer comprobar tus cambios en la rama `next`:
 
-```shell
+```shell showLineNumbers=false
 biome check --changed --since=next
 ```
 
@@ -72,7 +72,7 @@ biome check --changed --since=next
 Antes de confirmar los cambios, puedes comprobar los archivos de formato y lints que se han añadido al _index_, también conocidos como _staged files_.
 Añade la opción `--staged` a tu comando, para procesar sólo aquellos archivos:
 
-```shell
+```shell showLineNumbers=false
 biome check --staged
 ```
 

--- a/src/content/docs/es/guides/manual-installation.mdx
+++ b/src/content/docs/es/guides/manual-installation.mdx
@@ -32,7 +32,7 @@ Utiliza la variante Linux para Windows Subsystem for Linux (WSL).
 
 Biome está disponible como [fórmula Homebrew](https://formulae.brew.sh/formula/biome) para usuarios de macOS y Linux.
 
-```shell
+```shell showLineNumbers=false
 brew install biome
 ```
 
@@ -41,7 +41,7 @@ brew install biome
 Biome publica [imágenes Docker oficiales](https://github.com/biomejs/docker/pkgs/container/biome) compatibles
 con las arquitecturas **amd64** y **arm64** para todas las versiones de Biome a partir de `v1.7.0`.
 
-```
+```text showLineNumbers=false
 ghcr.io/biomejs/biome:{major}
 ghcr.io/biomejs/biome:{major}.{minor}
 ghcr.io/biomejs/biome:{major}.{minor}.{patch}
@@ -53,7 +53,7 @@ Estos son un par de ejemplos de cómo utilizar la imagen Docker:
 El directorio de trabajo por defecto es `/code` en la imagen Docker.
 :::
 
-```shell
+```shell showLineNumbers=false
 # Lint files
 docker run -v $(pwd):/code ghcr.io/biomejs/biome lint
 docker run -v $(pwd):/code ghcr.io/biomejs/biome lint --write
@@ -67,7 +67,7 @@ docker run -v $(pwd):/code ghcr.io/biomejs/biome format --write
 
 Para instalar Biome, descarga el ejecutable para tu plataforma de la [última versión CLI](https://github.com/biomejs/biome/releases) en GitHub y dale permiso de ejecución.
 
-<Code lang="shell" code={`
+<Code lang="shell" showLineNumbers={false} code={`
 # macOS arm (M1 o posterior)
 curl -L https://github.com/biomejs/biome/releases/download/@biomejs/biome@${version}/biome-darwin-arm64 -o biome
 chmod +x biome

--- a/src/content/docs/es/guides/migrate-eslint-prettier.mdx
+++ b/src/content/docs/es/guides/migrate-eslint-prettier.mdx
@@ -9,7 +9,7 @@ Biome proporciona comandos específicos para facilitar la migración desde ESLin
 
 Si no deseas conocer los detalles, basta con que ejecutes los siguientes comandos:
 
-```shell
+```shell showLineNumbers=false
 biome migrate eslint --write
 biome migrate prettier --write
 ```

--- a/src/content/docs/formatter/index.mdx
+++ b/src/content/docs/formatter/index.mdx
@@ -29,7 +29,7 @@ If you pass a glob as a parameter, your shell will expand it.
 The result of the expansion depends on your shell.
 For example, some shells don't support the recursive glob `**` or the alternation `{}` in the following command:
 
-```shell
+```shell showLineNumbers=false
 biome format ./src/**/*.test.{js,ts}
 ```
 

--- a/src/content/docs/fr/formatter/index.mdx
+++ b/src/content/docs/fr/formatter/index.mdx
@@ -29,7 +29,7 @@ Si vous passez un glob en paramètre, votre shell l’évaluera.
 Le résultat de l’évaluation dépend de votre shell.
 Par exemple, certains shells ne prennent pas en charge le glob récursif `**` ou l’alternance `{}` dans la commande suivante&nbsp;:
 
-```shell
+```shell showLineNumbers=false
 biome format ./src/**/*.test.{js,ts}
 ```
 

--- a/src/content/docs/fr/guides/configure-biome.mdx
+++ b/src/content/docs/fr/guides/configure-biome.mdx
@@ -174,7 +174,7 @@ La première façon de contrôler quels fichiers et répertoires sont traités p
 Avec la commande suivante, nous ne formatons que `file1.js` et tous les fichiers du répertoire `src`.
 Les répertoires sont parcourus de manière récursive.
 
-```shell
+```shell showLineNumbers=false
 biome format file1.js src/
 ```
 
@@ -218,7 +218,7 @@ Prenons la configuration suivante&nbsp;:
 
 Et exécutons la commande suivante&nbsp;:
 
-```shell
+```shell showLineNumbers=false
 biome format test/
 ```
 
@@ -227,7 +227,7 @@ Les fichiers de `src` ne sont pas formatés parce que le répertoire n’est pas
 
 Si nous exécutons la commande suivante, aucun fichier n’est analysé parce que le répertoire `test` est explicitement ignoré par l’outil de linting.
 
-```shell
+```shell showLineNumbers=false
 biome lint test/
 ```
 

--- a/src/content/docs/fr/guides/integrate-in-vcs.mdx
+++ b/src/content/docs/fr/guides/integrate-in-vcs.mdx
@@ -53,7 +53,7 @@ D’abord, vous devez mettre à jour votre fichier de configuration et dire à B
 
 Puis, ajoutez l’option `--changed` à votre commande pour ne traiter que ces fichiers que votre VCS reconnaît comme étant «&nbsp;modifiés&nbsp;». Biome, avec l’aide du VCS, déterminera les fichiers modifiés en se basant sur la branche `main` et sur votre révision actuelle&nbsp;:
 
-```shell
+```shell showLineNumbers=false
 biome check --changed
 ```
 
@@ -63,7 +63,7 @@ Biome ne vérifie pas ce qui a été modifié, ce qui veut dire que même l’aj
 
 Ou bien vous pouvez utiliser l’option `--since` pour spécifier une branche arbitraire. Cette option **est prioritaire** sur l’option `vcs.defaultBranch`. Par exemple, vous pourriez vouloir vérifier vos modifications par rapport à la branche `next`&nbsp;:
 
-```shell
+```shell showLineNumbers=false
 biome check --changed --since=next
 ```
 
@@ -72,7 +72,7 @@ biome check --changed --since=next
 Avant d’effectuer un commit de vos modifications, il se peut que vous vouliez vérifier le formatage et le linting des fichiers qui ont été ajoutés à _l’index,_ également connus sous le nom de _fichiers indexés_.
 Ajoutez l’option `--staged` à votre commande pour ne traiter que ces fichiers-là&nbsp;:
 
-```shell
+```shell showLineNumbers=false
 biome check --staged
 ```
 

--- a/src/content/docs/fr/guides/manual-installation.mdx
+++ b/src/content/docs/fr/guides/manual-installation.mdx
@@ -31,7 +31,7 @@ Utilisez la variante Linux pour Windows Subsystem for Linux (WSL).
 
 Biome est disponible sous forme de [formule Homebrew](https://formulae.brew.sh/formula/biome) pour les utilisateurs de macOS et de Linux.
 
-```shell
+```shell showLineNumbers=false
 brew install biome
 ```
 
@@ -39,7 +39,7 @@ brew install biome
 
 Pour installer Biome, prenez l’exécutable pour votre plateforme de la [dernière version de l’interface en ligne de commande](https://github.com/biomejs/biome/releases) sur GitHub et donnez-lui des permissions d’exécution.
 
-<Code lang="shell" code={`
+<Code lang="shell" showLineNumbers={false} code={`
 # macOS arm (M1 ou plus récente)
 curl -L https://github.com/biomejs/biome/releases/download/@biomejs/biome@${version}/biome-darwin-arm64 -o biome
 chmod +x biome

--- a/src/content/docs/fr/guides/migrate-eslint-prettier.mdx
+++ b/src/content/docs/fr/guides/migrate-eslint-prettier.mdx
@@ -9,7 +9,7 @@ Biome fournit des commandes dédiées pour faciliter la migration depuis ESLint 
 
 Si vous ne voulez pas en connaître les détails, exécutez simplement les commandes suivantes&nbsp;:
 
-```shell
+```shell showLineNumbers=false
 biome migrate eslint --write
 biome migrate prettier --write
 ```

--- a/src/content/docs/guides/configure-biome.mdx
+++ b/src/content/docs/guides/configure-biome.mdx
@@ -141,7 +141,7 @@ The first way to control which files and folders are processed by Biome is to
 list them in the CLI. In the following command, we only format `file1.js` and
 all the files in the `src` folder, because folders are recursively traversed.
 
-```shell
+```shell showLineNumbers=false
 biome format file1.js src/
 ```
 
@@ -188,7 +188,7 @@ the `src/` folder, the `test/` folder, and ignore files that have `.min.js` in t
 
 And run the following command:
 
-```shell
+```shell showLineNumbers=false
 biome format test/
 ```
 
@@ -201,7 +201,7 @@ CLI.
 If we run the following command, no files are linted because files inside the
 `test/` folder are explicitly ignored for the linter.
 
-```shell
+```shell showLineNumbers=false
 biome lint test/
 ```
 

--- a/src/content/docs/guides/getting-started.mdx
+++ b/src/content/docs/guides/getting-started.mdx
@@ -50,7 +50,7 @@ Biome provides a [command-line interface] to format, lint, and check your code.
 
 <Tabs syncKey="command">
 	<TabItem label="npm" icon="seti:npm">
-		<Code frame="none" code={`
+		<Code frame="none" showLineNumbers={false} code={`
 # Format all files
 npx @biomejs/biome format --write
 
@@ -71,7 +71,7 @@ npx @biomejs/biome check --write <files>
     `} lang="bash"  />
 	</TabItem>
 	<TabItem label="pnpm" icon="pnpm">
-		<Code frame="none" code={`
+		<Code frame="none" showLineNumbers={false} code={`
 # Format all files
 pnpx @biomejs/biome format --write
 
@@ -92,7 +92,7 @@ pnpx @biomejs/biome check --write <files>
     `} lang="bash"  />
 	</TabItem>
 	<TabItem label="bun" icon="bun">
-		<Code frame="none" code={`
+		<Code frame="none" showLineNumbers={false} code={`
 # Format all files
 bunx --bun @biomejs/biome format --write
 
@@ -113,7 +113,7 @@ bunx --bun @biomejs/biome check --write <files>
     `} lang="bash"  />
 	</TabItem>
 	<TabItem label="deno" icon="deno">
-		<Code frame="none" code={`
+		<Code frame="none" showLineNumbers={false} code={`
 # Format specific files
 deno run -A npm:@biomejs/biome format --write <files>
 
@@ -134,7 +134,7 @@ deno run -A npm:@biomejs/biome check --write <files>
     `} lang="bash"  />
 	</TabItem>
 	<TabItem label="yarn" icon="seti:yarn">
-		<Code frame="none" code={`
+		<Code frame="none" showLineNumbers={false} code={`
 # Format all files
 yarn exec biome format --write
 

--- a/src/content/docs/guides/integrate-in-vcs.mdx
+++ b/src/content/docs/guides/integrate-in-vcs.mdx
@@ -54,7 +54,7 @@ First, you have to update your configuration file and tell Biome what's the defa
 
 Then, add the `--changed` option to your command, to process only those files that your VCS acknowledged as "changed". Biome, with the help of the VCS, will determine the changed file from the branch `main` and your current revision:
 
-```shell
+```shell showLineNumbers=false
 biome check --changed
 ```
 
@@ -66,7 +66,7 @@ Also note that `--changed` applies to both the formatter and the linter. Biome o
 
 Alternatively, you can use the option `--since` to specify an arbitrary branch. This option **takes precedence** over the option `vcs.defaultBranch`. For example, you might want to check your changes against the `next` branch:
 
-```shell
+```shell showLineNumbers=false
 biome check --changed --since=next
 ```
 
@@ -75,7 +75,7 @@ biome check --changed --since=next
 Before committing your changes, you may want to check formatting and linting for files added to the index (also known as staged files) without running Biome on the entire project.
 To limit Biome to only processing files slated for committing, pass the `--staged` option to the command:
 
-```shell
+```shell showLineNumbers=false
 biome check --staged
 ```
 

--- a/src/content/docs/guides/investigate-slowness.mdx
+++ b/src/content/docs/guides/investigate-slowness.mdx
@@ -53,7 +53,7 @@ investigation. Specifically, we'll combine the following command-line arguments:
 If we combine these three arguments, we can create a log file with JSON messages
 containing all relevant timing information for Biome. For instance:
 
-```sh
+```sh showLineNumbers=false
 biome lint --log-level=tracing --log-kind=json --log-file=tracing.json
 ```
 
@@ -63,7 +63,7 @@ use [`jq`](https://github.com/jqlang/jq) to filter through this information.
 For example, if you want to figure out which paths take the longest when
 building the module graph, you can use the following command:
 
-```sh
+```sh showLineNumbers=false
 cat tracing.json | jq 'select(.span.name == "update_module_graph_internal") | { path: .span.path, time_busy: .["time.busy"], time_idle: .["time.idle"] }' > filtered.json
 ```
 
@@ -73,7 +73,7 @@ together with the paths used during the invocations.
 Similarly, if you want to figure out which files were slowest to analyse, you
 can use the following command:
 
-```sh
+```sh showLineNumbers=false
 cat tracing.json | jq '. | select(.span.name == "pull_diagnostics") | { path: .span.path, time_busy: .["time.busy"], time_idle: .["time.idle"] }' > filtered.json
 ```
 

--- a/src/content/docs/guides/manual-installation.mdx
+++ b/src/content/docs/guides/manual-installation.mdx
@@ -32,7 +32,7 @@ Use the Linux variant for Windows Subsystem for Linux (WSL).
 
 Biome is available as a [Homebrew formula](https://formulae.brew.sh/formula/biome) for macOS and Linux users.
 
-```shell
+```shell showLineNumbers=false
 brew install biome
 ```
 
@@ -40,7 +40,7 @@ brew install biome
 
 Biome is available as a community maintained package from the [Winget repository](https://github.com/microsoft/winget-pkgs/tree/master/manifests/b/biomejs/biome) for Windows users.
 
-```shell
+```shell showLineNumbers=false
 winget install biomejs.biome
 ```
 
@@ -52,14 +52,14 @@ Biome is available as a community maintained binary from the [Arch Linux Extra r
 The [extra] repository is usually enabled by default in /etc/pacman.conf. If it is disabled, uncomment the following lines:
 ::: 
 
-```ini
+```ini showLineNumbers=false
 [extra]
 Include = /etc/pacman.d/mirrorlist
 ```
 
 To install Biome run:
 
-```shell
+```shell showLineNumbers=false
 pacman -S biome
 ```
 
@@ -68,7 +68,7 @@ pacman -S biome
 Biome publishes [official Docker images](https://github.com/biomejs/docker/pkgs/container/biome) that support
 the **amd64** and **arm64** architectures for all Biome versions starting from `v1.7.0`.
 
-```
+```text showLineNumbers=false
 ghcr.io/biomejs/biome:{major}
 ghcr.io/biomejs/biome:{major}.{minor}
 ghcr.io/biomejs/biome:{major}.{minor}.{patch}
@@ -80,7 +80,7 @@ Here are a couple examples on how to use the Docker image:
 The default workdir is `/code` in the Docker image.
 :::
 
-```shell
+```shell showLineNumbers=false
 # Lint files
 docker run -v $(pwd):/code ghcr.io/biomejs/biome lint
 docker run -v $(pwd):/code ghcr.io/biomejs/biome lint --write
@@ -96,7 +96,7 @@ docker run -v $(pwd):/code ghcr.io/biomejs/biome format --write
 
 To install Biome, grab the executable for your platform from the [latest CLI release](https://github.com/biomejs/biome/releases) on GitHub and give it execution permission.
 
-<Code lang="shell" code={`
+<Code lang="shell" showLineNumbers={false} code={`
 # macOS arm (M1 or newer)
 curl -L https://github.com/biomejs/biome/releases/download/@biomejs/biome@${version}/biome-darwin-arm64 -o biome
 chmod +x biome

--- a/src/content/docs/guides/migrate-eslint-prettier.mdx
+++ b/src/content/docs/guides/migrate-eslint-prettier.mdx
@@ -9,7 +9,7 @@ Biome provides dedicated commands to ease the migration from ESLint and Prettier
 
 If you don't want to know the details, just run the following commands:
 
-```shell
+```shell showLineNumbers=false
 biome migrate eslint --write
 biome migrate prettier --write
 ```

--- a/src/content/docs/ja/formatter/index.mdx
+++ b/src/content/docs/ja/formatter/index.mdx
@@ -28,7 +28,7 @@ Biomeは[複数の言語をサポートする](/ja/internals/language-support)�
 展開の結果は、使用しているシェルによって異なります。
 例えば、一部のシェルは次のコマンドの再帰的glob `**` や代替 `{}` をサポートしていません：
 
-```shell
+```shell showLineNumbers=false
 biome format ./src/**/*.test.{js,ts}
 ```
 

--- a/src/content/docs/ja/guides/configure-biome.mdx
+++ b/src/content/docs/ja/guides/configure-biome.mdx
@@ -140,7 +140,7 @@ CLI、設定ファイル、VCSなど、さまざまな方法を使用して処�
 Biomeが処理するファイルやフォルダを制御する最初の方法は、CLIでそれらを列挙することです。
 以下のコマンドでは、`file1.js` と `src` フォルダ内のすべてのファイルのみをフォーマットします。フォルダは再帰的に走査されます。
 
-```shell
+```shell showLineNumbers=false
 biome format file1.js src/
 ```
 
@@ -181,7 +181,7 @@ Biomeの設定ファイル内のパスとglobは、設定ファイルがある�
 
 そして、以下のコマンドを実行します：
 
-```shell
+```shell showLineNumbers=false
 biome format test/
 ```
 
@@ -191,7 +191,7 @@ biome format test/
 
 次のコマンドを実行すると、`test/` フォルダ内のファイルはリンタで明示的に無視されているため、ファイルはリントされません。
 
-```shell
+```shell showLineNumbers=false
 biome lint test/
 ```
 

--- a/src/content/docs/ja/guides/getting-started.mdx
+++ b/src/content/docs/ja/guides/getting-started.mdx
@@ -45,7 +45,7 @@ Biomeは、コードのフォーマット、リント、チェックを行うた
 {/* <!-- textlint-disable --> */}
 <Tabs syncKey="command">
 	<TabItem label="npm" icon="seti:npm">
-		<Code frame="none" code={`
+		<Code frame="none" showLineNumbers={false} code={`
 # すべてのファイルをフォーマット
 npx @biomejs/biome format --write
 
@@ -66,7 +66,7 @@ npx @biomejs/biome check --write <files>
     `} lang="bash"  />
 	</TabItem>
 	<TabItem label="pnpm" icon="pnpm">
-		<Code frame="none" code={`
+		<Code frame="none" showLineNumbers={false} code={`
 # すべてのファイルをフォーマット
 pnpm exec biome format --write
 
@@ -87,7 +87,7 @@ pnpm exec biome check --write <files>
     `} lang="bash"  />
 	</TabItem>
 	<TabItem label="bun" icon="bun">
-		<Code frame="none" code={`
+		<Code frame="none" showLineNumbers={false} code={`
 # すべてのファイルをフォーマット
 bunx biome format --write
 
@@ -108,7 +108,7 @@ bunx biome check --write <files>
     `} lang="bash"  />
 	</TabItem>
 	<TabItem label="deno" icon="deno">
-		<Code frame="none" code={`
+		<Code frame="none" showLineNumbers={false} code={`
 # 特定のファイルをフォーマット
 deno run -A npm:@biomejs/biome format --write <files>
 
@@ -129,7 +129,7 @@ deno run -A npm:@biomejs/biome check --write <files>
     `} lang="bash"  />
 	</TabItem>
 	<TabItem label="yarn" icon="seti:yarn">
-		<Code frame="none" code={`
+		<Code frame="none" showLineNumbers={false} code={`
 # すべてのファイルをフォーマット
 yarn exec biome format --write
 

--- a/src/content/docs/ja/guides/integrate-in-vcs.mdx
+++ b/src/content/docs/ja/guides/integrate-in-vcs.mdx
@@ -51,7 +51,7 @@ VCS (バージョン管理システム）の統合は、**追加の**機能を�
 
 次に、コマンドに `--changed` オプションを追加すると、VCSが"変更された"と認識したファイルのみを処理します。Biomeは、VCSの助けを借りて、mainブランチと現在のリビジョンからの変更ファイルを判断します。
 
-```shell
+```shell showLineNumbers=false
 biome check --changed
 ```
 
@@ -61,7 +61,7 @@ Biomeは何が変更されたかをチェックしません。つまり、スペ
 
 あるいは、`--since` オプションを使って任意のブランチを指定することもできます。このオプションは `vcs.defaultBranch` オプションよりも**優先**されます。例えば、変更をnextブランチと比較したい場合は次のようにします。
 
-```shell
+```shell showLineNumbers=false
 biome check --changed --since=next
 ```
 
@@ -70,7 +70,7 @@ biome check --changed --since=next
 変更をコミットする前に、_インデックス_ に追加されたファイル、つまり _ステージされたファイル_ のフォーマットやリントをチェックしたい場合があります。
 コマンドに `--staged` オプションを追加して、ステージされたファイルのみを処理できます：
 
-```shell
+```shell showLineNumbers=false
 biome check --staged
 ```
 

--- a/src/content/docs/ja/guides/investigate-slowness.mdx
+++ b/src/content/docs/ja/guides/investigate-slowness.mdx
@@ -26,7 +26,7 @@ Biomeは高速であることを目指しています。_非常に高速です�
 
 これら3つの引数を組み合わせると、Biomeのすべての関連するタイミング情報を含むJSONメッセージのログファイルを作成できます。例えば：
 
-```sh
+```sh showLineNumbers=false
 biome lint --log-level=tracing --log-kind=json --log-file=tracing.json
 ```
 
@@ -34,7 +34,7 @@ biome lint --log-level=tracing --log-kind=json --log-file=tracing.json
 
 例えば、モジュールグラフを構築する際にどのパスが最も時間がかかるかを特定したい場合は、次のコマンドを使用できます：
 
-```sh
+```sh showLineNumbers=false
 cat tracing.json | jq 'select(.span.name == "update_module_graph_internal") | { path: .span.path, time_busy: .["time.busy"], time_idle: .["time.idle"] }' > filtered.json
 ```
 
@@ -42,7 +42,7 @@ cat tracing.json | jq 'select(.span.name == "update_module_graph_internal") | { 
 
 同様に、どのファイルの分析が最も遅かったかを特定したい場合は、次のコマンドを使用できます：
 
-```sh
+```sh showLineNumbers=false
 cat tracing.json | jq '. | select(.span.name == "pull_diagnostics") | { path: .span.path, time_busy: .["time.busy"], time_idle: .["time.idle"] }' > filtered.json
 ```
 

--- a/src/content/docs/ja/guides/manual-installation.mdx
+++ b/src/content/docs/ja/guides/manual-installation.mdx
@@ -32,7 +32,7 @@ Windows Subsystem for Linux (WSL) の場合は、Linux版を使用してくだ�
 
 BiomeはmacOSとLinuxユーザー向けに [Homebrew formula](https://formulae.brew.sh/formula/biome) から利用可能です。
 
-```shell
+```shell showLineNumbers=false
 brew install biome
 ```
 
@@ -41,7 +41,7 @@ brew install biome
 Biomeはバージョン `v1.7.0` 移行の各バージョンについて **amd64** および **arm64** アーキテクチャをサポートした
 [公式のDockerイメージ](https://github.com/biomejs/docker/pkgs/container/biome) を公開しています。
 
-```
+```text showLineNumbers=false
 ghcr.io/biomejs/biome:{major}
 ghcr.io/biomejs/biome:{major}.{minor}
 ghcr.io/biomejs/biome:{major}.{minor}.{patch}
@@ -53,7 +53,7 @@ ghcr.io/biomejs/biome:{major}.{minor}.{patch}
 デフォルトの作業ディレクトリはDockerイメージ内の `/code` です。
 :::
 
-```shell
+```shell showLineNumbers=false
 # ファイルをリントする
 docker run -v $(pwd):/code ghcr.io/biomejs/biome lint
 docker run -v $(pwd):/code ghcr.io/biomejs/biome lint --write
@@ -68,7 +68,7 @@ docker run -v $(pwd):/code ghcr.io/biomejs/biome format --write
 Biomeをインストールするには、GitHub上の[最新のCLIリリース](https://github.com/biomejs/biome/releases) からプラットフォームに合った実行可能ファイルを取得し、実行権限を与えてください。
 
 {/* <!-- textlint-disable --> */}
-<Code lang="shell" code={`
+<Code lang="shell" showLineNumbers={false} code={`
 # macOS arm (M1以降)
 curl -L https://github.com/biomejs/biome/releases/download/@biomejs/biome@${version}/biome-darwin-arm64 -o biome
 chmod +x biome

--- a/src/content/docs/ja/guides/migrate-eslint-prettier.mdx
+++ b/src/content/docs/ja/guides/migrate-eslint-prettier.mdx
@@ -9,7 +9,7 @@ Biomeには容易にESLintとPrettierから移行するためのコマンドが�
 
 詳細について知りたくない場合は、ただ以下のコマンドを実行してください。
 
-```shell
+```shell showLineNumbers=false
 biome migrate eslint --write
 biome migrate prettier --write
 ```

--- a/src/content/docs/pl/formatter/index.mdx
+++ b/src/content/docs/pl/formatter/index.mdx
@@ -29,7 +29,7 @@ Jeśli przekażesz glob jako parametr, Twoja powłoka go rozszerzy.
 Wynik rozszerzenia zależy od Twojej powłoki.
 Na przykład niektóre powłoki nie wspierają rekurencyjnego globa `**` lub alternacji `{}` w następującym poleceniu:
 
-```shell
+```shell showLineNumbers=false
 biome format ./src/**/*.test.{js,ts}
 ```
 

--- a/src/content/docs/pl/guides/configure-biome.mdx
+++ b/src/content/docs/pl/guides/configure-biome.mdx
@@ -127,7 +127,7 @@ Pierwszym sposobem kontrolowania, które pliki i foldery są przetwarzane przez 
 wymienienie ich w CLI. W poniższym poleceniu formatujemy tylko `file1.js` i
 wszystkie pliki w folderze `src`, ponieważ foldery są przeszukiwane rekurencyjnie.
 
-```shell
+```shell showLineNumbers=false
 biome format file1.js src/
 ```
 
@@ -174,7 +174,7 @@ folderze `src/`, folderze `test/` i ignorować pliki, które mają `.min.js` w s
 
 I uruchom następujące polecenie:
 
-```shell
+```shell showLineNumbers=false
 biome format test/
 ```
 
@@ -187,7 +187,7 @@ CLI.
 Jeśli uruchomimy następujące polecenie, żadne pliki nie są lintowane, ponieważ pliki w
 folderze `test/` są jawnie ignorowane dla lintera.
 
-```shell
+```shell showLineNumbers=false
 biome lint test/
 ```
 

--- a/src/content/docs/pl/guides/getting-started.mdx
+++ b/src/content/docs/pl/guides/getting-started.mdx
@@ -50,7 +50,7 @@ Biome zapewnia [interfejs wiersza poleceń] do formatowania, lintowania i sprawd
 
 <Tabs syncKey="command">
 	<TabItem label="npm" icon="seti:npm">
-		<Code frame="none" code={`
+		<Code frame="none" showLineNumbers={false} code={`
 # Formatuj wszystkie pliki
 npx @biomejs/biome format --write
 
@@ -71,7 +71,7 @@ npx @biomejs/biome check --write <files>
     `} lang="bash"  />
 	</TabItem>
 	<TabItem label="pnpm" icon="pnpm">
-		<Code frame="none" code={`
+		<Code frame="none" showLineNumbers={false} code={`
 # Formatuj wszystkie pliki
 pnpx @biomejs/biome format --write
 
@@ -92,7 +92,7 @@ pnpx @biomejs/biome check --write <files>
     `} lang="bash"  />
 	</TabItem>
 	<TabItem label="bun" icon="bun">
-		<Code frame="none" code={`
+		<Code frame="none" showLineNumbers={false} code={`
 # Formatuj wszystkie pliki
 bunx --bun @biomejs/biome format --write
 
@@ -113,7 +113,7 @@ bunx --bun @biomejs/biome check --write <files>
     `} lang="bash"  />
 	</TabItem>
 	<TabItem label="deno" icon="deno">
-		<Code frame="none" code={`
+		<Code frame="none" showLineNumbers={false} code={`
 # Formatuj określone pliki
 deno run -A npm:@biomejs/biome format --write <files>
 
@@ -134,7 +134,7 @@ deno run -A npm:@biomejs/biome check --write <files>
     `} lang="bash"  />
 	</TabItem>
 	<TabItem label="yarn" icon="seti:yarn">
-		<Code frame="none" code={`
+		<Code frame="none" showLineNumbers={false} code={`
 # Formatuj wszystkie pliki
 yarn exec biome format --write
 

--- a/src/content/docs/pl/guides/integrate-in-vcs.mdx
+++ b/src/content/docs/pl/guides/integrate-in-vcs.mdx
@@ -52,7 +52,7 @@ Najpierw musisz zaktualizować plik konfiguracyjny i powiedzieć Biome, jaka jes
 
 Następnie dodaj opcję `--changed` do swojej komendy, aby przetwarzać tylko te pliki, które Twój VCS rozpoznał jako "zmienione". Biome, z pomocą VCS, określi zmienione pliki z gałęzi `main` i Twojej bieżącej rewizji:
 
-```shell
+```shell showLineNumbers=false
 biome check --changed
 ```
 
@@ -62,7 +62,7 @@ Biome nie sprawdza, co się zmieniło, co oznacza, że nawet dodanie spacji lub 
 
 Alternatywnie możesz użyć opcji `--since`, aby określić dowolną gałąź. Ta opcja **ma pierwszeństwo** nad opcją `vcs.defaultBranch`. Na przykład, możesz chcieć sprawdzić swoje zmiany względem gałęzi `next`:
 
-```shell
+```shell showLineNumbers=false
 biome check --changed --since=next
 ```
 
@@ -71,7 +71,7 @@ biome check --changed --since=next
 Przed zatwierdzeniem zmian możesz chcieć sprawdzić formatowanie i lintować pliki, które zostały dodane do _indeksu_, znane również jako _pliki staged_.
 Dodaj opcję `--staged` do swojej komendy, aby przetwarzać tylko te pliki:
 
-```shell
+```shell showLineNumbers=false
 biome check --staged
 ```
 

--- a/src/content/docs/pl/guides/investigate-slowness.mdx
+++ b/src/content/docs/pl/guides/investigate-slowness.mdx
@@ -53,7 +53,7 @@ Od wersji 2.0, Biome ma ulepszone możliwości śledzenia, aby pomóc w tym
 Jeśli połączymy te trzy argumenty, możemy utworzyć plik logu z wiadomościami JSON
 zawierającymi wszystkie istotne informacje o czasie dla Biome. Na przykład:
 
-```sh
+```sh showLineNumbers=false
 biome lint --log-level=tracing --log-kind=json --log-file=tracing.json
 ```
 
@@ -63,7 +63,7 @@ To zapisuje plik `tracing.json`, ale może zawierać _dużo_ danych. Więc użyj
 Na przykład, jeśli chcesz dowiedzieć się, które ścieżki zajmują najdłużej podczas
 budowania grafu modułów, możesz użyć następującego polecenia:
 
-```sh
+```sh showLineNumbers=false
 cat tracing.json | jq 'select(.span.name == "update_module_graph_internal") | { path: .span.path, time_busy: .["time.busy"], time_idle: .["time.idle"] }' > filtered.json
 ```
 
@@ -73,7 +73,7 @@ razem ze ścieżkami używanymi podczas wywołań.
 Podobnie, jeśli chcesz dowiedzieć się, które pliki były najwolniejsze do analizy,
 możesz użyć następującego polecenia:
 
-```sh
+```sh showLineNumbers=false
 cat tracing.json | jq '. | select(.span.name == "pull_diagnostics") | { path: .span.path, time_busy: .["time.busy"], time_idle: .["time.idle"] }' > filtered.json
 ```
 

--- a/src/content/docs/pl/guides/manual-installation.mdx
+++ b/src/content/docs/pl/guides/manual-installation.mdx
@@ -32,7 +32,7 @@ Użyj wariantu Linux dla Windows Subsystem for Linux (WSL).
 
 Biome jest dostępny jako [formuła Homebrew](https://formulae.brew.sh/formula/biome) dla użytkowników macOS i Linux.
 
-```shell
+```shell showLineNumbers=false
 brew install biome
 ```
 
@@ -41,7 +41,7 @@ brew install biome
 Biome publikuje [oficjalne obrazy Docker](https://github.com/biomejs/docker/pkgs/container/biome), które obsługują
 architektury **amd64** i **arm64** dla wszystkich wersji Biome począwszy od `v1.7.0`.
 
-```
+```text showLineNumbers=false
 ghcr.io/biomejs/biome:{major}
 ghcr.io/biomejs/biome:{major}.{minor}
 ghcr.io/biomejs/biome:{major}.{minor}.{patch}
@@ -53,7 +53,7 @@ Oto kilka przykładów, jak używać obrazu Docker:
 Domyślny katalog roboczy to `/code` w obrazie Docker.
 :::
 
-```shell
+```shell showLineNumbers=false
 # Lintowanie plików
 docker run -v $(pwd):/code ghcr.io/biomejs/biome lint
 docker run -v $(pwd):/code ghcr.io/biomejs/biome lint --write
@@ -69,7 +69,7 @@ docker run -v $(pwd):/code ghcr.io/biomejs/biome format --write
 
 Aby zainstalować Biome, pobierz plik wykonywalny dla swojej platformy z [najnowszego wydania CLI](https://github.com/biomejs/biome/releases) na GitHub i nadaj mu uprawnienia wykonywania.
 
-<Code lang="shell" code={`
+<Code lang="shell" showLineNumbers={false} code={`
 # macOS arm (M1 lub nowszy)
 curl -L https://github.com/biomejs/biome/releases/download/@biomejs/biome@${version}/biome-darwin-arm64 -o biome
 chmod +x biome

--- a/src/content/docs/pl/guides/migrate-eslint-prettier.mdx
+++ b/src/content/docs/pl/guides/migrate-eslint-prettier.mdx
@@ -9,7 +9,7 @@ Biome udostępnia dedykowane polecenia ułatwiające migrację z ESLint i Pretti
 
 Jeśli nie chcesz znać szczegółów, wystarczy uruchomić następujące polecenia:
 
-```shell
+```shell showLineNumbers=false
 biome migrate eslint --write
 biome migrate prettier --write
 ```

--- a/src/content/docs/pt-BR/guides/configure-biome.mdx
+++ b/src/content/docs/pt-BR/guides/configure-biome.mdx
@@ -126,7 +126,7 @@ A primeira maneira de controlar quais arquivos e pastas são processados pelo Bi
 listá-los na CLI. No comando a seguir, formatamos apenas `file1.js` e
 todos os arquivos na pasta `src`, porque as pastas são percorridas recursivamente.
 
-```shell
+```shell showLineNumbers=false
 biome format file1.js src/
 ```
 
@@ -173,7 +173,7 @@ da pasta `src/`, da pasta `test/`, e ignorar arquivos que têm `.min.js` em seu 
 
 E execute o seguinte comando:
 
-```shell
+```shell showLineNumbers=false
 biome format test/
 ```
 
@@ -186,7 +186,7 @@ CLI.
 Se executarmos o seguinte comando, nenhum arquivo será analisado (linted) porque os arquivos dentro da
 pasta `test/` são explicitamente ignorados para o linter.
 
-```shell
+```shell showLineNumbers=false
 biome lint test/
 ```
 

--- a/src/content/docs/pt-BR/guides/getting-started.mdx
+++ b/src/content/docs/pt-BR/guides/getting-started.mdx
@@ -46,7 +46,7 @@ O Biome fornece uma [interface de linha de comando] para formatar, fazer lint e 
 
 <Tabs syncKey="command">
 	<TabItem label="npm" icon="seti:npm">
-		<Code frame="none" code={`
+		<Code frame="none" showLineNumbers={false} code={`
 # Formatar todos os arquivos
 npx @biomejs/biome format --write
 
@@ -67,7 +67,7 @@ npx @biomejs/biome check --write <files>
     `} lang="bash"  />
 	</TabItem>
 	<TabItem label="pnpm" icon="pnpm">
-		<Code frame="none" code={`
+		<Code frame="none" showLineNumbers={false} code={`
 # Formatar todos os arquivos
 pnpx @biomejs/biome format --write
 
@@ -88,7 +88,7 @@ pnpx @biomejs/biome check --write <files>
     `} lang="bash"  />
 	</TabItem>
 	<TabItem label="bun" icon="bun">
-		<Code frame="none" code={`
+		<Code frame="none" showLineNumbers={false} code={`
 # Formatar todos os arquivos
 bunx --bun @biomejs/biome format --write
 
@@ -109,7 +109,7 @@ bunx --bun @biomejs/biome check --write <files>
     `} lang="bash"  />
 	</TabItem>
 	<TabItem label="deno" icon="deno">
-		<Code frame="none" code={`
+		<Code frame="none" showLineNumbers={false} code={`
 # Formatar arquivos específicos
 deno run -A npm:@biomejs/biome format --write <files>
 
@@ -130,7 +130,7 @@ deno run -A npm:@biomejs/biome check --write <files>
     `} lang="bash"  />
 	</TabItem>
 	<TabItem label="yarn" icon="seti:yarn">
-		<Code frame="none" code={`
+		<Code frame="none" showLineNumbers={false} code={`
 # Formatar todos os arquivos
 yarn exec biome format --write
 

--- a/src/content/docs/pt-BR/guides/integrate-in-vcs.mdx
+++ b/src/content/docs/pt-BR/guides/integrate-in-vcs.mdx
@@ -52,7 +52,7 @@ Primeiro, você precisa atualizar seu arquivo de configuração e dizer ao Biome
 
 Em seguida, adicione a opção `--changed` ao seu comando, para processar apenas os arquivos que seu VCS reconheceu como "alterados". O Biome, com a ajuda do VCS, determinará os arquivos alterados a partir do branch `main` e da sua revisão atual:
 
-```shell
+```shell showLineNumbers=false
 biome check --changed
 ```
 
@@ -62,7 +62,7 @@ O Biome não verifica o que foi alterado, isso significa que até mesmo adiciona
 
 Alternativamente, você pode usar a opção `--since` para especificar um branch arbitrário. Esta opção **tem precedência** sobre a opção `vcs.defaultBranch`. Por exemplo, você pode querer verificar suas alterações em relação ao branch `next`:
 
-```shell
+```shell showLineNumbers=false
 biome check --changed --since=next
 ```
 
@@ -71,7 +71,7 @@ biome check --changed --since=next
 Antes de commitar suas alterações, você pode querer verificar a formatação e os lints dos arquivos que foram adicionados ao _index_, também conhecidos como _staged files_.
 Adicione a opção `--staged` ao seu comando, para processar apenas esses arquivos:
 
-```shell
+```shell showLineNumbers=false
 biome check --staged
 ```
 

--- a/src/content/docs/pt-BR/guides/manual-installation.mdx
+++ b/src/content/docs/pt-BR/guides/manual-installation.mdx
@@ -32,7 +32,7 @@ Utilize a versão Linux para o Windows Subsystem for Linux (WSL).
 
 O Biome está disponível no [Homebrew](https://formulae.brew.sh/formula/biome) para usuários macOS e Linux.
 
-```shell
+```shell showLineNumbers=false
 brew install biome
 ```
 
@@ -40,7 +40,7 @@ brew install biome
 
 Para instalar o Biome, baixe o [executável mais recente](https://github.com/biomejs/biome/releases) para a sua arquitetura no GitHub e conceda permissão de execução a ele.
 
-<Code lang="shell" code={`
+<Code lang="shell" showLineNumbers={false} code={`
 # macOS arm (M1 ou superior)
 curl -L https://github.com/biomejs/biome/releases/download/@biomejs/biome@${version}/biome-darwin-arm64 -o biome
 chmod +x biome

--- a/src/content/docs/pt-BR/guides/migrate-eslint-prettier.mdx
+++ b/src/content/docs/pt-BR/guides/migrate-eslint-prettier.mdx
@@ -9,7 +9,7 @@ O Biome fornece comandos dedicados para facilitar a migração do ESLint e do Pr
 
 Se você não quiser saber os detalhes, apenas execute os seguintes comandos:
 
-```shell
+```shell showLineNumbers=false
 biome migrate eslint --write
 biome migrate prettier --write
 ```

--- a/src/content/docs/ru/guides/getting-started.mdx
+++ b/src/content/docs/ru/guides/getting-started.mdx
@@ -51,7 +51,7 @@ Biome предоставляет [интерфейс командной стро
 
 <Tabs syncKey="command">
 	<TabItem label="npm" icon="seti:npm">
-		<Code frame="none" code={`
+		<Code frame="none" showLineNumbers={false} code={`
 # Отформатировать все файлы
 npx @biomejs/biome format --write
 
@@ -72,7 +72,7 @@ npx @biomejs/biome check --write <файлы>
     `} lang="bash"  />
 	</TabItem>
 	<TabItem label="pnpm" icon="pnpm">
-		<Code frame="none" code={`
+		<Code frame="none" showLineNumbers={false} code={`
 # Отформатировать все файлы
 pnpx @biomejs/biome format --write
 
@@ -93,7 +93,7 @@ pnpx @biomejs/biome check --write <файлы>
     `} lang="bash"  />
 	</TabItem>
 	<TabItem label="bun" icon="bun">
-		<Code frame="none" code={`
+		<Code frame="none" showLineNumbers={false} code={`
 # Отформатировать все файлы
 bunx --bun @biomejs/biome format --write
 
@@ -114,7 +114,7 @@ bunx --bun @biomejs/biome check --write <файлы>
     `} lang="bash"  />
 	</TabItem>
 	<TabItem label="deno" icon="deno">
-		<Code frame="none" code={`
+		<Code frame="none" showLineNumbers={false} code={`
 # Отформатировать выбранные файлы
 deno run -A npm:@biomejs/biome format --write <файлы>
 
@@ -135,7 +135,7 @@ deno run -A npm:@biomejs/biome check --write <файлы>
     `} lang="bash"  />
 	</TabItem>
 	<TabItem label="yarn" icon="seti:yarn">
-		<Code frame="none" code={`
+		<Code frame="none" showLineNumbers={false} code={`
 # Отформатировать все файлы
 yarn exec biome format --write
 

--- a/src/content/docs/ru/guides/manual-installation.mdx
+++ b/src/content/docs/ru/guides/manual-installation.mdx
@@ -34,7 +34,7 @@ export const version = await getLatestVersion("stable");
 
 Biome доступен в качестве [формулы Homebrew](https://formulae.brew.sh/formula/biome) для пользователей macOS и Linux.
 
-```shell
+```shell showLineNumbers=false
 brew install biome
 ```
 
@@ -43,7 +43,7 @@ brew install biome
 Biome предоставляет [официальные Docker-образы](https://github.com/biomejs/docker/pkgs/container/biome),
 которые поддерживают архитектуры **amd64** и **arm64** для всех версий Biome, начиная с `v1.7.0`.
 
-```
+```text showLineNumbers=false
 ghcr.io/biomejs/biome:{major}
 ghcr.io/biomejs/biome:{major}.{minor}
 ghcr.io/biomejs/biome:{major}.{minor}.{patch}
@@ -55,7 +55,7 @@ ghcr.io/biomejs/biome:{major}.{minor}.{patch}
 Рабочий каталог Docker-образа по умолчанию — `/code`.
 :::
 
-```shell
+```shell showLineNumbers=false
 # Выполнить линтинг файлов
 docker run -v $(pwd):/code ghcr.io/biomejs/biome lint
 docker run -v $(pwd):/code ghcr.io/biomejs/biome lint --write
@@ -72,7 +72,7 @@ docker run -v $(pwd):/code ghcr.io/biomejs/biome format --write
 Чтобы установить Biome, получите исполняемый файл для вашей платформы из
 [последнего выпуска CLI](https://github.com/biomejs/biome/releases) на GitHub и выдайте ему разрешение на выполнение.
 
-<Code lang="shell" code={`
+<Code lang="shell" showLineNumbers={false} code={`
 # macOS arm (M1 или новее)
 curl -L https://github.com/biomejs/biome/releases/download/@biomejs/biome@${version}/biome-darwin-arm64 -o biome
 chmod +x biome

--- a/src/content/docs/zh-CN/guides/configure-biome.mdx
+++ b/src/content/docs/zh-CN/guides/configure-biome.mdx
@@ -124,7 +124,7 @@ Biome（自 v2.0.0 起）支持嵌套的 `biome.json` 文件。
 控制 Biome 处理哪些文件和文件夹的第一种方法是在 CLI 中列出它们。
 在以下命令中，我们只格式化 `file1.js` 和 `src` 文件夹中的所有文件，因为文件夹是递归遍历的。
 
-```shell
+```shell showLineNumbers=false
 biome format file1.js src/
 ```
 
@@ -166,7 +166,7 @@ Biome 配置文件中的路径和 glob 相对于配置文件所在的文件夹�
 
 并运行以下命令：
 
-```shell
+```shell showLineNumbers=false
 biome format test/
 ```
 
@@ -176,7 +176,7 @@ biome format test/
 
 如果我们运行以下命令，则不会检查任何文件，因为 `test/` 文件夹中的文件在检查器中被显式忽略。
 
-```shell
+```shell showLineNumbers=false
 biome lint test/
 ```
 

--- a/src/content/docs/zh-CN/guides/getting-started.mdx
+++ b/src/content/docs/zh-CN/guides/getting-started.mdx
@@ -39,7 +39,7 @@ import PackageManagerCommand from "@/components/PackageManagerCommand.astro";
 
 运行`init`命令后，您的目录中将出现一个新的`biome.json`文件：
 
-```json title="biome.json"
+```json title="biome.json" showLineNumbers=false
 {
   "$schema": "https://biomejs.dev/schemas/2.4.13/schema.json",
   "organizeImports": {

--- a/src/content/docs/zh-CN/guides/integrate-in-vcs.mdx
+++ b/src/content/docs/zh-CN/guides/integrate-in-vcs.mdx
@@ -51,7 +51,7 @@ description: 了解 Biome 是如何工作的，如原理、配置等。
 
 然后，在命令行中增加 `--changed` 选项，来处理那些被版本控制系统标记为“变更”的文件。Biome 会在版本控制系统的帮助下，会判断出 `main` 分支的变更文件以及当前修订内容：
 
-```shell
+```shell showLineNumbers=false
 biome format --changed
 ```
 
@@ -61,6 +61,6 @@ Biome 不会检查变更内容，这意味着即使是在文件里增加了空�
 
 或者，可以通过 `--since` 选项来指定任意一个分支。这个选项**优先**于 `vcs.defaultBranch` 选项。例如，你可能想要针对 `next` 分支来检查变更：
 
-```shell
+```shell showLineNumbers=false
 biome format --changed --since=next
 ```

--- a/src/content/docs/zh-CN/guides/investigate-slowness.mdx
+++ b/src/content/docs/zh-CN/guides/investigate-slowness.mdx
@@ -21,19 +21,19 @@ Biome 的设计初衷就是追求高速，极致的高速。但有时它的实�
 - 搭配 `--log-kind=json`，可让 Biome 将日志以 JSON 格式输出。
 
 将三个参数组合使用，就能生成一份包含完整耗时信息的 JSON 日志文件，示例命令如下：
-```sh
+```sh showLineNumbers=false
 biome lint --log-level=tracing --log-kind=json --log-file=tracing.json
 ```
 执行后会生成 `tracing.json` 文件，但该文件数据量通常极大，我们可以借助工具 [`jq`](https://github.com/jqlang/jq) 筛选日志内容。
 
 举例：若你想查看构建模块图谱时耗时最长的文件路径，执行如下命令：
-```sh
+```sh showLineNumbers=false
 cat tracing.json | jq 'select(.span.name == "update_module_graph_internal") | { path: .span.path, time_busy: .["time.busy"], time_idle: .["time.idle"] }' > filtered.json
 ```
 执行完成后会生成 `filtered.json`，文件内包含所有执行路径及其对应的耗时数据。
 
 同理，若要定位代码分析耗时最久的文件，使用这条命令：
-```sh
+```sh showLineNumbers=false
 cat tracing.json | jq '. | select(.span.name == "pull_diagnostics") | { path: .span.path, time_busy: .["time.busy"], time_idle: .["time.idle"] }' > filtered.json
 ```
 

--- a/src/content/docs/zh-CN/guides/manual-installation.mdx
+++ b/src/content/docs/zh-CN/guides/manual-installation.mdx
@@ -30,7 +30,7 @@ export const version = await getLatestVersion("stable");
 
 Biome可以作为[Homebrew formula](https://formulae.brew.sh/formula/biome)提供给macOS和Linux用户。
 
-```shell
+```shell showLineNumbers=false
 brew install biome
 ```
 
@@ -38,7 +38,7 @@ brew install biome
 
 要安装Biome，请从GitHub的[最新CLI版本](https://github.com/biomejs/biome/releases)中获取适用于您平台的可执行文件，并给它执行权限。
 
-<Code lang="shell" code={`
+<Code lang="shell" showLineNumbers={false} code={`
 # macOS arm (M1或更新版本)
 curl -L https://github.com/biomejs/biome/releases/download/@biomejs/biome@${version}/biome-darwin-arm64 -o biome
 chmod +x biome

--- a/src/content/docs/zh-CN/guides/migrate-eslint-prettier.mdx
+++ b/src/content/docs/zh-CN/guides/migrate-eslint-prettier.mdx
@@ -9,7 +9,7 @@ Biome 提供了专门的命令来简化从 ESLint 和 Prettier 的迁移过程�
 
 如果你不想了解细节，只需运行以下命令：
 
-```shell
+```shell showLineNumbers=false
 biome migrate eslint --write
 biome migrate prettier --write
 ```


### PR DESCRIPTION
## Summary

This PR hides line number from code blocks in which they bring no significant value.

- One-liner commands
- Short code fences

This makes the interface feel less busy.

### Before

<img width="656" height="150" alt="Screenshot 2026-08-20 at 21 21 31" src="https://github.com/user-attachments/assets/b226c781-2751-499e-8e95-94ffad311dff" />

### After

<img width="656" height="150" alt="Screenshot 2026-08-20 at 21 21 41" src="https://github.com/user-attachments/assets/b33c4490-507c-4543-9103-e93da338f8ff" />
