### PR TITLE
feat(playground): add redesign foundations

### DIFF
--- a/src/playground/PlaygroundLoader.tsx
+++ b/src/playground/PlaygroundLoader.tsx
@@ -226,11 +226,11 @@ function PlaygroundLoader() {
 				type: "updateFiles",
 				files: Object.entries(state.files).map(([filename, file]) => ({
 					filename,
-					code: file?.content,
+					code: file?.content ?? "",
 				})),
 			});
 		});
-	}, [loadingState, Object.keys(state.files).length]);
+	}, [loadingState, Object.keys(state.files).join("\0")]);
 
 	// Dispatch updated code to Prettier
 	// biome-ignore lint/correctness/useExhaustiveDependencies: dependencies mismatch
@@ -288,9 +288,11 @@ function buildLocation(state: PlaygroundState): string {
 	const rawQueryParams: Record<string, unknown> = {
 		...state.settings,
 	};
+	delete rawQueryParams.ruleDomains;
 
 	// Eliminate default values
 	const queryStringObj: Record<string, string> = {};
+	const hashStringObj: Record<string, string> = {};
 	for (const key in rawQueryParams) {
 		const defaultValue = String(
 			defaultPlaygroundState.settings[key as keyof PlaygroundSettings],
@@ -302,6 +304,7 @@ function buildLocation(state: PlaygroundState): string {
 			queryStringObj[key] = value;
 		}
 	}
+	const lastSearchStringObj = { ...queryStringObj };
 
 	if (state.tab) {
 		queryStringObj.tab = state.tab;
@@ -314,25 +317,28 @@ function buildLocation(state: PlaygroundState): string {
 	if (state.singleFileMode && Object.keys(state.files).length === 1) {
 		// Single file mode
 		const code = getCurrentCode(state);
-		if (code) {
-			queryStringObj.code = encodeCode(code);
-		}
-
 		const language = guessLanguage(state.currentFile);
+		const isScript = state.currentFile.endsWith(".cjs");
+		if (code || language !== LANGUAGE.TSX || isScript) {
+			hashStringObj.code = encodeCode(code);
+		}
 		if (language !== LANGUAGE.TSX) {
 			queryStringObj.language = language;
 		}
-
-		const gritQuery = getFileState(state, state.currentFile)?.gritQuery;
-		if (gritQuery) {
-			queryStringObj.gritQuery = gritQuery;
+		if (isScript) {
+			queryStringObj.script = "true";
 		}
 	} else {
 		// Populate files
 		for (const filename in state.files) {
 			const content = state.files[filename]?.content ?? "";
-			queryStringObj[`files.${filename}`] = encodeCode(content);
+			hashStringObj[`files.${filename}`] = encodeCode(content);
 		}
+	}
+
+	const gritQuery = getFileState(state, state.currentFile)?.gritQuery;
+	if (gritQuery) {
+		hashStringObj.gritQuery = gritQuery;
 	}
 
 	// handle rule domains
@@ -340,60 +346,80 @@ function buildLocation(state: PlaygroundState): string {
 		const value = state.settings.ruleDomains[key as RuleDomain];
 		if (value !== undefined && value !== "none") {
 			queryStringObj[`ruleDomains.${key}`] = value;
+			lastSearchStringObj[`ruleDomains.${key}`] = value;
 		}
 	}
 
 	const queryString = new URLSearchParams(queryStringObj).toString();
-	lastSearchStore.set(queryString);
+	const hashString = new URLSearchParams(hashStringObj).toString();
+	lastSearchStore.set(new URLSearchParams(lastSearchStringObj).toString());
 
 	let url = `${window.location.protocol}//${window.location.host}${window.location.pathname}`;
 	if (queryString !== "") {
 		url += `?${queryString}`;
+	}
+	if (hashString !== "") {
+		url += `#${hashString}`;
 	}
 	return url;
 }
 
 function initState(
 	searchParams: URLSearchParams,
-	includeFiles: boolean,
+	hashParams: URLSearchParams,
+	legacyContentParams: URLSearchParams,
 ): PlaygroundState {
 	let singleFileMode = defaultPlaygroundState.singleFileMode;
 	let hasFiles = false;
 	let files: PlaygroundState["files"] = {};
 
-	if (includeFiles) {
-		// Populate files
-		for (const [key, value] of searchParams) {
-			const match = key.match(FILE_QUERY_KEY_REGEX);
-			if (match != null) {
-				const filename = normalizeFilename(match[1]!);
-				files[filename] = {
-					content: decodeCode(value),
-					biome: emptyBiomeOutput,
-					prettier: emptyPrettierOutput,
-				};
-				singleFileMode = false;
-				hasFiles = true;
-			}
-		}
+	const hashHasFiles = [...hashParams.keys()].some((key) =>
+		FILE_QUERY_KEY_REGEX.test(key),
+	);
+	const fileParams = hashHasFiles ? hashParams : legacyContentParams;
 
-		// Single file mode
-		if (searchParams.get("code")) {
+	// Populate files. Hash content wins over legacy query-string content.
+	for (const [key, value] of fileParams) {
+		const match = key.match(FILE_QUERY_KEY_REGEX);
+		if (match != null) {
+			const filename = normalizeFilename(match[1]!);
+			files[filename] = {
+				content: decodeCode(value),
+				biome: emptyBiomeOutput,
+				prettier: emptyPrettierOutput,
+			};
+			singleFileMode = false;
+			hasFiles = true;
+		}
+	}
+
+	if (!hasFiles) {
+		// Single file mode. Read content from the hash first, then legacy query params.
+		const encodedCode =
+			hashParams.get("code") ?? legacyContentParams.get("code");
+		if (encodedCode !== null) {
 			const ext = getExtension({
 				language: (searchParams.get("language") as Language) ?? LANGUAGE.TSX,
 				script: searchParams.get("script") === "true",
 			});
-			const gritQuery = searchParams.get("gritQuery");
-			const baseFile = {
-				content: decodeCode(searchParams.get("code") ?? ""),
+			files[`main.${ext}`] = {
+				content: decodeCode(encodedCode),
 				biome: emptyBiomeOutput,
 				prettier: emptyPrettierOutput,
 			};
-			files[`main.${ext}`] =
-				gritQuery !== null && gritQuery !== ""
-					? { ...baseFile, gritQuery }
-					: baseFile;
 			hasFiles = true;
+		}
+	}
+
+	const gritQuery =
+		hashParams.get("gritQuery") ?? legacyContentParams.get("gritQuery");
+	if (gritQuery) {
+		const filename = Object.keys(files)[0];
+		if (filename !== undefined) {
+			files[filename] = {
+				...files[filename]!,
+				gritQuery,
+			};
 		}
 	}
 
@@ -402,7 +428,7 @@ function initState(
 	}
 
 	// handle rule domains
-	const ruleDomains = defaultPlaygroundState.settings.ruleDomains;
+	const ruleDomains = { ...defaultPlaygroundState.settings.ruleDomains };
 	const prefixLength = "ruleDomains.".length;
 	for (const key of searchParams.keys()) {
 		if (key.startsWith("ruleDomains.")) {
@@ -467,52 +493,74 @@ function initState(
 			attributePosition:
 				(searchParams.get("attributePosition") as AttributePosition) ??
 				defaultPlaygroundState.settings.attributePosition,
-			bracketSpacing:
-				searchParams.get("bracketSpacing") === "true" ||
+			bracketSpacing: getBooleanParam(
+				searchParams,
+				"bracketSpacing",
 				defaultPlaygroundState.settings.bracketSpacing,
-			bracketSameLine:
-				searchParams.get("bracketSameLine") === "true" ||
+			),
+			bracketSameLine: getBooleanParam(
+				searchParams,
+				"bracketSameLine",
 				defaultPlaygroundState.settings.bracketSameLine,
+			),
 			expand:
 				(searchParams.get("expand") as Expand) ??
 				defaultPlaygroundState.settings.expand,
 			whitespaceSensitivity:
 				(searchParams.get("whitespaceSensitivity") as WhitespaceSensitivity) ??
 				defaultPlaygroundState.settings.whitespaceSensitivity,
-			indentScriptAndStyle:
-				searchParams.get("indentScriptAndStyle") === "true" ||
+			indentScriptAndStyle: getBooleanParam(
+				searchParams,
+				"indentScriptAndStyle",
 				defaultPlaygroundState.settings.indentScriptAndStyle,
+			),
 			lintRules:
 				(searchParams.get("lintRules") as LintRule) ??
 				defaultPlaygroundState.settings.lintRules,
-			enabledLinting:
-				searchParams.get("enabledLinting") === "true" ||
+			enabledLinting: getBooleanParam(
+				searchParams,
+				"enabledLinting",
 				defaultPlaygroundState.settings.enabledLinting,
+			),
 			analyzerFixMode:
 				(searchParams.get("analyzerFixMode") as FixFileMode) ??
 				defaultPlaygroundState.settings.analyzerFixMode,
-			enabledAssist:
-				searchParams.get("enabledAssist") === "true" ||
+			enabledAssist: getBooleanParam(
+				searchParams,
+				"enabledAssist",
 				defaultPlaygroundState.settings.enabledAssist,
-			unsafeParameterDecoratorsEnabled:
-				searchParams.get("unsafeParameterDecoratorsEnabled") === "true" ||
+			),
+			unsafeParameterDecoratorsEnabled: getBooleanParam(
+				searchParams,
+				"unsafeParameterDecoratorsEnabled",
 				defaultPlaygroundState.settings.unsafeParameterDecoratorsEnabled,
-			allowComments:
-				searchParams.get("allowComments") === "true" ||
+			),
+			allowComments: getBooleanParam(
+				searchParams,
+				"allowComments",
 				defaultPlaygroundState.settings.allowComments,
+			),
 			ruleDomains,
-			cssModules:
-				searchParams.get("cssModules") === "true" ||
+			cssModules: getBooleanParam(
+				searchParams,
+				"cssModules",
 				defaultPlaygroundState.settings.cssModules,
-			experimentalEmbeddedSnippetsEnabled:
-				searchParams.get("experimentalEmbeddedSnippetsEnabled") === "true" ||
+			),
+			experimentalEmbeddedSnippetsEnabled: getBooleanParam(
+				searchParams,
+				"experimentalEmbeddedSnippetsEnabled",
 				defaultPlaygroundState.settings.experimentalEmbeddedSnippetsEnabled,
-			experimentalFullSupportEnabled:
-				searchParams.get("experimentalFullSupportEnabled") === "true" ||
+			),
+			experimentalFullSupportEnabled: getBooleanParam(
+				searchParams,
+				"experimentalFullSupportEnabled",
 				defaultPlaygroundState.settings.experimentalFullSupportEnabled,
-			tailwindDirectives:
-				searchParams.get("tailwindDirectives") === "true" ||
+			),
+			tailwindDirectives: getBooleanParam(
+				searchParams,
+				"tailwindDirectives",
 				defaultPlaygroundState.settings.tailwindDirectives,
+			),
 			searchLanguage:
 				(searchParams.get("searchLanguage") as
 					| "js"
@@ -521,6 +569,15 @@ function initState(
 					| undefined) ?? defaultPlaygroundState.settings.searchLanguage,
 		},
 	};
+}
+
+function getBooleanParam(
+	searchParams: URLSearchParams,
+	key: string,
+	defaultValue: boolean,
+): boolean {
+	const value = searchParams.get(key);
+	return value === null ? defaultValue : value === "true";
 }
 
 const lastSearchStore = createLocalStorage("last-search");
@@ -539,20 +596,29 @@ export function usePlaygroundState(): [
 	const [url, setUrl] = useState(window.location.toString());
 
 	const [playgroundState, setPlaygroundState] = useState(() => {
-		let searchQuery = window.location.search;
-		let includeSearchQueryFiles = true;
+		const locationSearchParams = new URLSearchParams(window.location.search);
+		let settingsSearchParams = locationSearchParams;
 
 		// Default to query of last session to load settings
-		if (searchQuery === "") {
-			searchQuery = lastSearchStore.get() ?? "";
-			includeSearchQueryFiles = false;
+		if (window.location.search === "") {
+			settingsSearchParams = new URLSearchParams(lastSearchStore.get() ?? "");
 		}
 
-		return initState(new URLSearchParams(searchQuery), includeSearchQueryFiles);
+		return initState(
+			settingsSearchParams,
+			new URLSearchParams(window.location.hash.slice(1)),
+			locationSearchParams,
+		);
 	});
 
 	function resetPlaygroundState() {
-		setPlaygroundState(initState(new URLSearchParams(""), false));
+		setPlaygroundState(
+			initState(
+				new URLSearchParams(),
+				new URLSearchParams(),
+				new URLSearchParams(),
+			),
+		);
 	}
 
 	useEffect(() => {

--- a/src/playground/configuration.ts
+++ b/src/playground/configuration.ts
@@ -1,0 +1,167 @@
+import type { Configuration, Rules } from "@biomejs/wasm-web";
+import { LINT_RULES } from "@/playground/generated/lintRules.ts";
+import {
+	ArrowParentheses,
+	AttributePosition,
+	Expand,
+	IndentStyle,
+	type LintRule,
+	OperatorLinebreak,
+	type PlaygroundSettings,
+	QuoteProperties,
+	QuoteStyle,
+	Semicolons,
+} from "@/playground/types.ts";
+
+export function createBiomeConfiguration(
+	settings: PlaygroundSettings,
+): Configuration {
+	const configuration = {
+		formatter: {
+			enabled: true,
+			formatWithErrors: true,
+			lineWidth: settings.lineWidth,
+			indentStyle: settings.indentStyle === IndentStyle.Tab ? "tab" : "space",
+			indentWidth: settings.indentWidth,
+			attributePosition:
+				settings.attributePosition === AttributePosition.Auto
+					? "auto"
+					: "multiline",
+			expand:
+				settings.expand === Expand.Auto
+					? "auto"
+					: settings.expand === Expand.Always
+						? "always"
+						: "never",
+		},
+		linter: {
+			enabled: settings.enabledLinting,
+			domains: settings.ruleDomains,
+			rules: createLintRulesConfiguration(settings.lintRules),
+		},
+		assist: {
+			enabled: settings.enabledAssist,
+		},
+		javascript: {
+			formatter: {
+				quoteStyle:
+					settings.quoteStyle === QuoteStyle.Double ? "double" : "single",
+				jsxQuoteStyle:
+					settings.jsxQuoteStyle === QuoteStyle.Double ? "double" : "single",
+				quoteProperties:
+					settings.quoteProperties === QuoteProperties.Preserve
+						? "preserve"
+						: "asNeeded",
+				trailingCommas: settings.trailingCommas,
+				semicolons:
+					settings.semicolons === Semicolons.Always ? "always" : "asNeeded",
+				arrowParentheses:
+					settings.arrowParentheses === ArrowParentheses.Always
+						? "always"
+						: "asNeeded",
+				operatorLinebreak:
+					settings.operatorLinebreak === OperatorLinebreak.Before
+						? "before"
+						: "after",
+				bracketSpacing: settings.bracketSpacing,
+				bracketSameLine: settings.bracketSameLine,
+				attributePosition:
+					settings.attributePosition === AttributePosition.Auto
+						? "auto"
+						: "multiline",
+			},
+			parser: {
+				unsafeParameterDecoratorsEnabled:
+					settings.unsafeParameterDecoratorsEnabled,
+			},
+			experimentalEmbeddedSnippetsEnabled:
+				settings.experimentalEmbeddedSnippetsEnabled,
+		},
+		css: {
+			formatter: {
+				quoteStyle:
+					settings.quoteStyle === QuoteStyle.Double ? "double" : "single",
+			},
+			parser: {
+				allowWrongLineComments: true,
+				cssModules: settings.cssModules,
+				tailwindDirectives: settings.tailwindDirectives,
+			},
+		},
+		json: {
+			formatter: {},
+			parser: {
+				allowComments: settings.allowComments,
+			},
+		},
+		html: {
+			formatter: {
+				enabled: true,
+				indentScriptAndStyle: settings.indentScriptAndStyle,
+				whitespaceSensitivity: settings.whitespaceSensitivity,
+			},
+			experimentalFullSupportEnabled: settings.experimentalFullSupportEnabled,
+		},
+		markdown: {
+			formatter: {
+				enabled: true,
+			},
+		},
+		yaml: {
+			formatter: {
+				enabled: true,
+			},
+		},
+	};
+
+	// These runtime options are not present in the generated Configuration type yet.
+	return configuration as Configuration;
+}
+
+export function stringifyBiomeConfiguration(
+	settings: PlaygroundSettings,
+): string {
+	return `${JSON.stringify(createBiomeConfiguration(settings), null, 2)}\n`;
+}
+
+export function getOnlyLintRules(lintRule: LintRule): string[] {
+	return isLintPreset(lintRule) ? [] : [lintRule];
+}
+
+function createLintRulesConfiguration(lintRule: LintRule): Rules {
+	switch (lintRule) {
+		case LINT_RULES.preset.recommended:
+			return {
+				nursery: {
+					preset: "none",
+				},
+			};
+		case LINT_RULES.preset.all:
+			return { preset: "all" };
+		case LINT_RULES.preset.none:
+			return { preset: "none" };
+		default:
+			return createSingleLintRuleConfiguration(lintRule);
+	}
+}
+
+function createSingleLintRuleConfiguration(lintRule: LintRule): Rules {
+	for (const [group, rules] of Object.entries(LINT_RULES)) {
+		if (group === "preset" || !(lintRule in rules)) {
+			continue;
+		}
+
+		return {
+			preset: "none",
+			[group]: {
+				[lintRule]: "error",
+			},
+		} as Rules;
+	}
+
+	return { preset: "recommended" };
+}
+
+function isLintPreset(lintRule: LintRule): boolean {
+	return Object.values(LINT_RULES.preset).some((preset) => preset === lintRule);
+}

--- a/src/playground/state.ts
+++ b/src/playground/state.ts
@@ -1,0 +1,130 @@
+import {
+	emptyBiomeOutput,
+	emptyPrettierOutput,
+	type PlaygroundFileState,
+	type PlaygroundState,
+} from "@/playground/types.ts";
+import { normalizeFilename } from "@/playground/utils.ts";
+import { stringifyBiomeConfiguration } from "./configuration.ts";
+
+export const BIOME_CONFIG_FILENAME = "biome.json";
+
+export function createPlaygroundFile(
+	state: PlaygroundState,
+	filename: string,
+	content = "",
+): PlaygroundState {
+	const normalizedFilename = normalizeFilename(filename);
+	const existingFile = state.files[normalizedFilename];
+
+	return {
+		...state,
+		currentFile: normalizedFilename,
+		singleFileMode: false,
+		files: {
+			...state.files,
+			[normalizedFilename]: existingFile ?? createFileState(content),
+		},
+	};
+}
+
+export function deletePlaygroundFile(
+	state: PlaygroundState,
+	filename: string,
+): PlaygroundState {
+	if (!canDeletePlaygroundFile(state, filename)) {
+		return state;
+	}
+
+	const filenames = Object.keys(state.files);
+	const deletedIndex = filenames.indexOf(filename);
+	const { [filename]: _, ...files } = state.files;
+	const remainingFilenames = Object.keys(files);
+	const currentFile =
+		state.currentFile === filename
+			? (remainingFilenames[deletedIndex] ??
+				remainingFilenames[deletedIndex - 1] ??
+				state.currentFile)
+			: state.currentFile;
+
+	return {
+		...state,
+		currentFile,
+		files,
+	};
+}
+
+export function canDeletePlaygroundFile(
+	state: Pick<PlaygroundState, "files">,
+	filename: string,
+): boolean {
+	if (filename === BIOME_CONFIG_FILENAME) {
+		return state.files[filename] !== undefined;
+	}
+
+	return (
+		Object.keys(state.files).filter((file) => file !== BIOME_CONFIG_FILENAME)
+			.length > 1
+	);
+}
+
+export function renamePlaygroundFile(
+	state: PlaygroundState,
+	oldFilename: string,
+	newFilename: string,
+): PlaygroundState {
+	const normalizedNewFilename = normalizeFilename(newFilename);
+	if (
+		oldFilename === normalizedNewFilename ||
+		state.files[oldFilename] === undefined ||
+		state.files[normalizedNewFilename] !== undefined
+	) {
+		return state;
+	}
+
+	const { [oldFilename]: oldFile, ...files } = state.files;
+	return {
+		...state,
+		currentFile:
+			state.currentFile === oldFilename
+				? normalizedNewFilename
+				: state.currentFile,
+		files: {
+			...files,
+			[normalizedNewFilename]: oldFile,
+		},
+	};
+}
+
+export function openPlaygroundFile(
+	state: PlaygroundState,
+	filename: string,
+): PlaygroundState {
+	return state.files[filename] === undefined
+		? state
+		: { ...state, currentFile: filename };
+}
+
+export function createBiomeConfigFile(state: PlaygroundState): PlaygroundState {
+	return createPlaygroundFile(
+		state,
+		BIOME_CONFIG_FILENAME,
+		stringifyBiomeConfiguration(state.settings),
+	);
+}
+
+export function openBiomeConfigFile(state: PlaygroundState): PlaygroundState {
+	return openPlaygroundFile(state, BIOME_CONFIG_FILENAME);
+}
+
+export function deleteBiomeConfigFile(state: PlaygroundState): PlaygroundState {
+	return deletePlaygroundFile(state, BIOME_CONFIG_FILENAME);
+}
+
+function createFileState(content: string): PlaygroundFileState {
+	return {
+		content,
+		biome: emptyBiomeOutput,
+		prettier: emptyPrettierOutput,
+	};
+}

--- a/src/playground/tabs/SettingsTab.tsx
+++ b/src/playground/tabs/SettingsTab.tsx
@@ -9,6 +9,13 @@ import { type Dispatch, type SetStateAction, useId, useState } from "react";
 import EnumSelect from "@/playground/components/EnumSelect";
 import { LINT_RULES } from "@/playground/generated/lintRules.ts";
 import {
+	canDeletePlaygroundFile,
+	createPlaygroundFile,
+	deletePlaygroundFile,
+	openPlaygroundFile,
+	renamePlaygroundFile,
+} from "@/playground/state.ts";
+import {
 	ArrowParentheses,
 	AttributePosition,
 	Expand,
@@ -28,11 +35,9 @@ import {
 import {
 	classnames,
 	createPlaygroundSettingsSetter,
-	getFileState,
 	guessLanguage,
 	isScriptFilename,
 	modifyFilename,
-	normalizeFilename,
 } from "@/playground/utils";
 
 export interface SettingsTabProps {
@@ -198,92 +203,27 @@ export default function SettingsTab({
 	);
 
 	function setCurrentFilename(newFilename: string) {
-		setPlaygroundState((state) => {
-			if (state.currentFile === newFilename) {
-				return state;
-			}
-
-			const { [state.currentFile]: _, ...otherFiles } = state.files;
-
-			const files: PlaygroundState["files"] = {
-				...otherFiles,
-				[newFilename]: state.files[state.currentFile]!,
-			};
-
-			return {
-				...state,
-				currentFile: newFilename,
-				files,
-			};
-		});
+		setPlaygroundState((state) =>
+			renamePlaygroundFile(state, state.currentFile, newFilename),
+		);
 	}
 
 	function deleteFile(filename: string) {
-		setPlaygroundState((state) => {
-			const { [filename]: _, ...files } = state.files;
-			let currentFile = state.currentFile;
-
-			if (currentFile === filename) {
-				const files = Object.keys(state.files);
-				const index = files.indexOf(filename);
-				currentFile = files[index + 1] ?? files[index - 1] ?? currentFile;
-			}
-
-			return {
-				...state,
-				currentFile,
-				files: {
-					...files,
-					// Make sure currentFile is still accessible
-					[currentFile]: getFileState(state, currentFile),
-				},
-			};
-		});
+		setPlaygroundState((state) => deletePlaygroundFile(state, filename));
 	}
 
 	function createFile(filename: string) {
-		const normalizedFilename = normalizeFilename(filename);
-
-		setPlaygroundState((state) => ({
-			...state,
-			currentFile: normalizedFilename,
-			files: {
-				...state.files,
-				[normalizedFilename]: getFileState(
-					{
-						files: {},
-					},
-					normalizedFilename,
-				),
-			},
-		}));
+		setPlaygroundState((state) => createPlaygroundFile(state, filename));
 	}
 
 	function renameFile(oldFilename: string, newFilename: string) {
-		const normalizedNewFilename = normalizeFilename(newFilename);
-
-		setPlaygroundState((state) => {
-			const { [oldFilename]: oldFile, ...files } = state.files;
-
-			return {
-				...state,
-				currentFile:
-					state.currentFile === oldFilename
-						? normalizedNewFilename
-						: state.currentFile,
-				files: {
-					...files,
-					[normalizedNewFilename]: oldFile,
-				},
-			};
-		});
+		setPlaygroundState((state) =>
+			renamePlaygroundFile(state, oldFilename, newFilename),
+		);
 	}
 
 	function setCurrentFile(currentFile: string) {
-		setPlaygroundState((state) => ({
-			...state,
-			currentFile,
-		}));
+		setPlaygroundState((state) => openPlaygroundFile(state, currentFile));
 	}
 
 	function toggleSingleFileMode() {
@@ -331,6 +271,9 @@ export default function SettingsTab({
 					deleteFile={deleteFile}
 					setCurrentFile={setCurrentFile}
 					renameFile={renameFile}
+					canDeleteFile={(filename) =>
+						canDeletePlaygroundFile({ files }, filename)
+					}
 				/>
 			)}
 			<FormatterSettings
@@ -452,6 +395,7 @@ function FileView({
 	createFile,
 	deleteFile,
 	renameFile,
+	canDeleteFile,
 	setCurrentFile,
 	files,
 }: {
@@ -459,6 +403,7 @@ function FileView({
 	deleteFile: (filename: string) => void;
 	setCurrentFile: (filename: string) => void;
 	renameFile: (oldFilename: string, newFilename: string) => void;
+	canDeleteFile: (filename: string) => boolean;
 	currentFile: string;
 	files: string[];
 }) {
@@ -481,7 +426,7 @@ function FileView({
 							key={filename}
 							isActive={filename === currentFile}
 							filename={filename}
-							canDelete={files.length > 1}
+							canDelete={canDeleteFile(filename)}
 							onClick={() => {
 								setCurrentFile(filename);
 							}}

--- a/src/playground/workers/biomeWorker.ts
+++ b/src/playground/workers/biomeWorker.ts
@@ -7,19 +7,14 @@ import init, {
 	type RuleCategories,
 	Workspace,
 } from "@biomejs/wasm-web";
-import { LINT_RULES } from "@/playground/generated/lintRules.ts";
 import {
-	ArrowParentheses,
-	AttributePosition,
+	createBiomeConfiguration,
+	getOnlyLintRules,
+} from "@/playground/configuration.ts";
+import {
 	type BiomeOutput,
-	Expand,
-	IndentStyle,
 	LoadingState,
-	OperatorLinebreak,
 	type PlaygroundSettings,
-	QuoteProperties,
-	QuoteStyle,
-	Semicolons,
 } from "@/playground/types.ts";
 
 const encoder = new TextEncoder();
@@ -34,6 +29,7 @@ let fullSettings: undefined | PlaygroundSettings;
 let only: AnalyzerSelector[] = [];
 // Configuration that comes from a virtual file. It takes precedence over the settings
 let fileConfiguration: undefined | Configuration;
+let virtualPlugins: string[] = [];
 
 const originalConsole = {
 	log: console.log,
@@ -112,176 +108,12 @@ self.addEventListener("message", async (e) => {
 				break;
 			}
 
-			fullSettings = e.data.settings;
+			const settings = e.data.settings as PlaygroundSettings;
+			fullSettings = settings;
 
-			const {
-				lineWidth,
-				indentStyle,
-				indentWidth,
-				quoteStyle,
-				jsxQuoteStyle,
-				quoteProperties,
-				lintRules,
-				enabledLinting,
-				trailingCommas,
-				semicolons,
-				arrowParentheses,
-				operatorLinebreak,
-				bracketSpacing,
-				bracketSameLine,
-				expand,
-				indentScriptAndStyle,
-				whitespaceSensitivity,
-				enabledAssist,
-				unsafeParameterDecoratorsEnabled,
-				allowComments,
-				attributePosition,
-				ruleDomains,
-				experimentalEmbeddedSnippetsEnabled,
-				experimentalFullSupportEnabled,
-				cssModules,
-				tailwindDirectives,
-			} = e.data.settings as PlaygroundSettings;
-
-			configuration = {
-				...configuration,
-
-				formatter: {
-					enabled: true,
-					formatWithErrors: true,
-					lineWidth: lineWidth,
-					indentStyle: indentStyle === IndentStyle.Tab ? "tab" : "space",
-					indentWidth,
-					attributePosition:
-						attributePosition === AttributePosition.Auto ? "auto" : "multiline",
-					expand:
-						expand === Expand.Auto
-							? "auto"
-							: expand === Expand.Always
-								? "always"
-								: "never",
-				},
-
-				linter: {
-					enabled: enabledLinting,
-					domains: ruleDomains,
-				},
-
-				assist: {
-					enabled: enabledAssist,
-				},
-
-				javascript: {
-					formatter: {
-						quoteStyle: quoteStyle === QuoteStyle.Double ? "double" : "single",
-						jsxQuoteStyle:
-							jsxQuoteStyle === QuoteStyle.Double ? "double" : "single",
-						quoteProperties:
-							quoteProperties === QuoteProperties.Preserve
-								? "preserve"
-								: "asNeeded",
-						trailingCommas,
-						semicolons:
-							semicolons === Semicolons.Always ? "always" : "asNeeded",
-						arrowParentheses:
-							arrowParentheses === ArrowParentheses.Always
-								? "always"
-								: "asNeeded",
-						operatorLinebreak:
-							operatorLinebreak === OperatorLinebreak.Before
-								? "before"
-								: "after",
-						bracketSpacing,
-						bracketSameLine,
-						attributePosition:
-							attributePosition === AttributePosition.Auto
-								? "auto"
-								: "multiline",
-					},
-					parser: {
-						unsafeParameterDecoratorsEnabled,
-					},
-					experimentalEmbeddedSnippetsEnabled,
-				},
-				css: {
-					formatter: {
-						quoteStyle: quoteStyle === QuoteStyle.Double ? "double" : "single",
-					},
-					parser: {
-						allowWrongLineComments: true,
-						cssModules,
-						tailwindDirectives,
-					},
-				},
-				json: {
-					formatter: {},
-					parser: {
-						allowComments,
-					},
-				},
-				html: {
-					formatter: {
-						enabled: true,
-						indentScriptAndStyle,
-						whitespaceSensitivity,
-					},
-					experimentalFullSupportEnabled,
-				},
-				markdown: {
-					formatter: {
-						enabled: true,
-					},
-				},
-				yaml: {
-					formatter: {
-						enabled: true,
-					},
-				},
-			};
-
-			switch (lintRules) {
-				case LINT_RULES.preset.recommended: {
-					configuration!.linter!.rules = {
-						nursery: {
-							preset: "none",
-						},
-					};
-					break;
-				}
-				case LINT_RULES.preset.all: {
-					configuration!.linter!.rules = {
-						preset: "all",
-					};
-					break;
-				}
-				case LINT_RULES.preset.none: {
-					configuration!.linter!.rules = {
-						preset: "none",
-					};
-					break;
-				}
-
-				default: {
-					configuration!.linter!.rules = {
-						preset: "recommended",
-					};
-					only = [lintRules];
-				}
-			}
-
-			if (fileConfiguration) {
-				workspace.updateSettings({
-					configuration: fileConfiguration,
-					projectKey,
-					moduleGraphResolutionKind: "modulesAndTypes",
-				});
-			} else {
-				workspace.updateSettings({
-					configuration,
-					projectKey,
-					moduleGraphResolutionKind: "modulesAndTypes",
-				});
-			}
+			configuration = createBiomeConfiguration(settings);
+			only = getOnlyLintRules(settings.lintRules) as AnalyzerSelector[];
+			updateWorkspaceSettings();
 			break;
 		}
 
@@ -295,33 +127,32 @@ self.addEventListener("message", async (e) => {
 				files: { filename: string; code: string }[];
 			};
 
-			// Remove files that no longer exists
-			const filenames = new Set<string>(...files.map((file) => file.filename));
+			// Remove files that no longer exist.
+			const filenames = new Set(files.map((file) => file.filename));
 			for (const filename of knownFiles) {
 				if (!filenames.has(filename)) {
-					filesystem.remove(filename);
+					filesystem.remove(`/${filename}`);
+					knownFiles.delete(filename);
 				}
 			}
 
 			// Insert new or existing files
 			for (const { filename, code } of files) {
 				filesystem.insert(`/${filename}`, encoder.encode(code));
+				knownFiles.add(filename);
 			}
 
+			const configFile = files.find((file) => file.filename === "biome.json");
+			fileConfiguration = configFile
+				? parseFileConfiguration(configFile.code)
+				: undefined;
+
 			// Update plugins
-			const plugins = files
+			virtualPlugins = files
 				.map((file) => file.filename)
 				.filter((filename) => isPluginFile(filename))
 				.map((filename) => `/${filename}`);
-
-			workspace.updateSettings({
-				projectKey,
-				configuration: {
-					...configuration,
-					plugins,
-				},
-				moduleGraphResolutionKind: "modulesAndTypes",
-			});
+			updateWorkspaceSettings();
 
 			// TODO: Handle diagnostics
 			workspace.scanProject({
@@ -349,11 +180,7 @@ self.addEventListener("message", async (e) => {
 
 			// Reload plugins if changed
 			if (isPluginFile(filename)) {
-				workspace.updateSettings({
-					projectKey,
-					configuration: { ...configuration },
-					moduleGraphResolutionKind: "modulesAndTypes",
-				});
+				updateWorkspaceSettings();
 			}
 
 			workspace.openFile({
@@ -366,21 +193,11 @@ self.addEventListener("message", async (e) => {
 			});
 
 			if (filename === "biome.json") {
-				try {
-					fileConfiguration = JSON.parse(code) as Configuration;
-					workspace.updateSettings({
-						projectKey,
-						configuration: fileConfiguration,
-						moduleGraphResolutionKind: "modulesAndTypes",
-					});
+				const parsedConfiguration = parseFileConfiguration(code);
+				if (parsedConfiguration !== undefined) {
+					fileConfiguration = parsedConfiguration;
+					updateWorkspaceSettings();
 					console.info("Correct set custom configuration");
-					// biome-ignore lint/suspicious/noExplicitAny: It's an error message
-				} catch (e: any) {
-					// Let's use debug, because it could be noisy while typing
-					console.debug(
-						"The Biome configuration isn't a valid JSON.\n",
-						e.message,
-					);
 				}
 			}
 
@@ -511,7 +328,7 @@ self.addEventListener("message", async (e) => {
 				projectKey,
 				path,
 				categories,
-				only,
+				only: fileConfiguration ? [] : only,
 				skip: [],
 				includeCodeFix: true,
 			});
@@ -618,4 +435,38 @@ function isPluginFile(filename: string): boolean {
 		filename === "plugin.js" ||
 		filename === "plugin.ts"
 	);
+}
+
+function updateWorkspaceSettings(): void {
+	if (!workspace || projectKey == null) {
+		return;
+	}
+
+	const currentConfiguration = getCurrentConfiguration();
+	workspace.updateSettings({
+		projectKey,
+		configuration: {
+			...currentConfiguration,
+			plugins: [
+				...(currentConfiguration?.plugins ?? []),
+				...virtualPlugins.filter(
+					(plugin) => !currentConfiguration?.plugins?.includes(plugin),
+				),
+			],
+		},
+		moduleGraphResolutionKind: "modulesAndTypes",
+	});
+}
+
+function parseFileConfiguration(code: string): Configuration | undefined {
+	try {
+		return JSON.parse(code) as Configuration;
+	} catch (error) {
+		// This can be noisy while the user is editing the configuration.
+		console.debug(
+			"The Biome configuration isn't valid JSON.\n",
+			error instanceof Error ? error.message : error,
+		);
+		return undefined;
+	}
 }

--- a/tests/playground/smoke.spec.ts
+++ b/tests/playground/smoke.spec.ts
@@ -2,6 +2,10 @@
 
 import { expect, test } from "@playwright/test";
 
+function encodeCode(code: string): string {
+	return Buffer.from(code, "utf16le").toString("base64");
+}
+
 test.describe("playground should format code", () => {
 	test.describe("on navigation", () => {
 		test("javascript", async ({ page }) => {
@@ -91,5 +95,84 @@ test.describe("playground should show formatter IR", () => {
 		await expect(
 			page.getByTestId("prettier-ir-output").getByRole("textbox"),
 		).toContainText("div");
+	});
+});
+
+test.describe("playground links", () => {
+	test("loads code from the hash", async ({ page }) => {
+		const code = "let hashValue = 1;";
+		await page.goto(`/playground#code=${encodeURIComponent(encodeCode(code))}`);
+
+		await expect(page.getByTestId("editor").getByRole("textbox")).toContainText(
+			code,
+		);
+		await expect(
+			page.getByTestId("biome-output").getByRole("textbox"),
+		).toContainText(code);
+	});
+
+	test("upgrades legacy content parameters to the hash", async ({ page }) => {
+		const code = "let legacyValue = 1;";
+		await page.goto(
+			`/playground?code=${encodeURIComponent(encodeCode(code))}&lineWidth=100`,
+		);
+
+		await expect(page.getByTestId("editor").getByRole("textbox")).toContainText(
+			code,
+		);
+		await expect
+			.poll(() => {
+				const url = new URL(page.url());
+				return {
+					codeInQuery: url.searchParams.has("code"),
+					codeInHash: new URLSearchParams(url.hash.slice(1)).get("code"),
+					lineWidth: url.searchParams.get("lineWidth"),
+				};
+			})
+			.toEqual({
+				codeInQuery: false,
+				codeInHash: encodeCode(code),
+				lineWidth: "100",
+			});
+		await expect
+			.poll(() =>
+				page.evaluate(() => localStorage.getItem("playground:last-search")),
+			)
+			.toBe("lineWidth=100");
+	});
+
+	test("loads and analyzes files in folders", async ({ page }) => {
+		const code = "export const nested = true;";
+		const hash = new URLSearchParams({
+			"files.src/component.ts": encodeCode(code),
+			"files.main.ts": encodeCode('import { nested } from "./src/component";'),
+		});
+		await page.goto(`/playground#${hash}`);
+
+		await expect(
+			page.locator(".files-list li").filter({ hasText: "src/component.ts" }),
+		).toBeVisible();
+		await expect(page.getByTestId("editor").getByRole("textbox")).toContainText(
+			code,
+		);
+		await expect(
+			page.getByTestId("biome-output").getByRole("textbox"),
+		).toContainText(code);
+	});
+
+	test("applies a virtual biome.json to source files", async ({ page }) => {
+		const hash = new URLSearchParams({
+			"files.main.js": encodeCode('const value = "test";'),
+			"files.biome.json": encodeCode(
+				JSON.stringify({
+					javascript: { formatter: { quoteStyle: "single" } },
+				}),
+			),
+		});
+		await page.goto(`/playground#${hash}`);
+
+		await expect(
+			page.getByTestId("biome-output").getByRole("textbox"),
+		).toContainText("const value = 'test';");
 	});
 });


### PR DESCRIPTION
## Summary

<!-- 
Explain the **motivation** for making this change.
What existing problem does the pull request solve?
-->

This contains most of the mechanical changes for the playground refresh/redesign.

- Moves files from URL query parameters to URL hash fragments (backwards compat preserved)
    - This saves us inbound bandwidth, the hash is not sent to the server
- fixed boolean URL parameters so explicit false values work
- Centralizes how configuration is handled and managed
- Supports folders internally (no ui)

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>