### PR TITLE
fix: configure Expressive Code language aliases

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -171,8 +171,14 @@ export default defineConfig({
 			expressiveCode: {
 				shiki: {
 					langAlias: {
+						block: "txt",
 						cjs: "javascript",
+						editorconfig: "ini",
 						grit: "txt",
+						"js,expect_diagnostic": "javascript",
+						svg: "html",
+						"ts,expect_diagnostic": "typescript",
+						"vue,expect_diagnostic": "vue",
 					},
 				},
 			},
@@ -1098,7 +1104,6 @@ export default defineConfig({
 				cjs: "javascript",
 				grit: "txt",
 				cts: "javascript",
-				block: "txt",
 			},
 		},
 	},

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -1104,6 +1104,7 @@ export default defineConfig({
 				cjs: "javascript",
 				grit: "txt",
 				cts: "javascript",
+				block: "txt",
 			},
 		},
 	},


### PR DESCRIPTION
## Summary

This PR configures Expressive Code language aliases to prevent warnings when highlighting documentation code blocks.

## Aliases

`block` → `txt`
- `editorconfig` → `ini`
- `js,expect_diagnostic` → `javascript`
- `svg` → `html`
- `ts,expect_diagnostic` → `typescript`
- `vue,expect_diagnostic` → `vue`

## Test

No warning when running `pnpm dev`