### PR TITLE
fix(docs): transpose manual installation table

### DIFF
--- a/src/content/docs/guides/manual-installation.mdx
+++ b/src/content/docs/guides/manual-installation.mdx
@@ -19,10 +19,12 @@ You're already familiar with the tooling, and installing and updating are simple
 
 You have to pick the correct binary for your platform for Biome work. The following table should help you do so.
 
-| CPU Architecture | Windows       | macOS                        | Linux         | Linux (musl)       |
-| ---------------- | ------------- | ---------------------------- | ------------- | ------------------ |
-| `arm64`          | `win32-arm64` | `darwin-arm64` (M1 or newer) | `linux-arm64` | `linux-arm64-musl` |
-| `x64`            | `win32-x64`   | `darwin-x64`                 | `linux-x64`   | `linux-x64-musl`   |
+| Platform     | `arm64`                      | `x64`              |
+| ------------ | ---------------------------- | ------------------ |
+| Windows      | `win32-arm64`                | `win32-x64`        |
+| macOS        | `darwin-arm64` (M1 or newer) | `darwin-x64`       |
+| Linux        | `linux-arm64`                | `linux-x64`        |
+| Linux (musl) | `linux-arm64-musl`           | `linux-x64-musl`   |
 
 :::note
 Use the Linux variant for Windows Subsystem for Linux (WSL).


### PR DESCRIPTION
## Summary

This PR flips the **Supported platforms** table to make it easier to read.

### Before

<img width="570" height="383" alt="Screenshot 2026-08-21 at 16 22 42" src="https://github.com/user-attachments/assets/5d695636-3636-4ad5-be63-4abed43022ab" />


### After

<img width="570" height="383" alt="Screenshot 2026-08-21 at 16 22 29" src="https://github.com/user-attachments/assets/fc2fdf81-4652-4aaf-9a42-3cb8ef6f5c2b" />