### PR TITLE
feat: install instructions, changelog og images

### DIFF
--- a/src/components/PackageManagerCommand.astro
+++ b/src/components/PackageManagerCommand.astro
@@ -1,46 +1,47 @@
 ---
 import { Code, TabItem, Tabs } from "@astrojs/starlight/components";
+
+interface Props {
+	npm: string[];
+	pnpm: string[];
+	yarn: string[];
+	bun: string[];
+	deno: string[];
+}
+
+const { npm, pnpm, yarn, bun, deno } = Astro.props;
+
+let npmCommand = npm.reduce((acc, command) => {
+	return `${acc}npm ${command}\n`;
+}, "");
+let pnpmCommand = pnpm.reduce((acc, command) => {
+	return `${acc}pnpm ${command}\n`;
+}, "");
+let yarnCommand = yarn.reduce((acc, command) => {
+	return `${acc}yarn ${command}\n`;
+}, "");
+let bunCommand = bun.reduce((acc, command) => {
+	return `${acc}bun ${command}\n`;
+}, "");
+let denoCommand = deno.reduce((acc, command) => {
+	return `${acc}deno ${command}\n`;
+}, "");
 ---
 
 <Tabs syncKey="command">
 	<TabItem label="npm" icon="seti:npm">
-		<Code
-			frame="none"
-			showLineNumbers={false}
-			code={`${Astro.props.npx ? "npx" : "npm"} ${Astro.props.npx ?? Astro.props.npm ?? Astro.props.command}`}
-			lang="bash"
-		/>
+		<Code frame="none" showLineNumbers={false} code={npmCommand} lang="bash" />
 	</TabItem>
 	<TabItem label="pnpm" icon="pnpm">
-		<Code
-			frame="none"
-			showLineNumbers={false}
-			code={`pnpm ${Astro.props.pnpm ?? Astro.props.command}`}
-			lang="bash"
-		/>
+		<Code frame="none" showLineNumbers={false} code={pnpmCommand} lang="bash" />
 	</TabItem>
 	<TabItem label="bun" icon="bun">
-		<Code
-			frame="none"
-			showLineNumbers={false}
-			code={`bun${Astro.props.bun ? "" : "x"} ${Astro.props.bunx ?? Astro.props.bun ?? Astro.props.command}`}
-			lang="bash"
-		/>
+		<Code frame="none" showLineNumbers={false} code={bunCommand} lang="bash" />
 	</TabItem>
 	<TabItem label="deno" icon="deno">
-		<Code
-			frame="none"
-			showLineNumbers={false}
-			code={`deno ${Astro.props.deno ?? Astro.props.command}`}
-			lang="bash"
-		/>
+		<Code frame="none" showLineNumbers={false} code={denoCommand} lang="bash" />
 	</TabItem>
 	<TabItem label="yarn" icon="seti:yarn">
-		<Code
-			frame="none"
-			showLineNumbers={false}
-			code={`yarn ${Astro.props.yarn ?? Astro.props.command}`}
-			lang="bash"
-		/>
+		<Code frame="none" showLineNumbers={false} code={yarnCommand} lang="bash" />
 	</TabItem>
 </Tabs>

--- a/src/content/docs/es/guides/getting-started.mdx
+++ b/src/content/docs/es/guides/getting-started.mdx
@@ -16,11 +16,11 @@ El CLI también está disponible como [ejecutable independiente](/es/guides/manu
 Para instalar Biome, ejecute los siguientes comandos en un directorio que contenga un archivo `package.json`.
 
 <PackageManagerCommand
-  npm="install --save-dev --save-exact @biomejs/biome"
-  pnpm="add --save-dev --save-exact @biomejs/biome"
-  yarn="add --dev --exact @biomejs/biome"
-  bun="add --dev --exact @biomejs/biome"
-  deno="add --dev npm:@biomejs/biome"
+  npm={["install --save-dev --save-exact @biomejs/biome"]}
+  pnpm={["add --save-dev --save-exact @biomejs/biome"]}
+  yarn={["add --dev --exact @biomejs/biome"]}
+  bun={["add --dev --exact @biomejs/biome"]}
+  deno={["add --dev npm:@biomejs/biome"]}
 />
 
 :::note

--- a/src/content/docs/fr/guides/getting-started.mdx
+++ b/src/content/docs/fr/guides/getting-started.mdx
@@ -16,11 +16,11 @@ L’interface en ligne de commande est également disponible comme [exécutable 
 Pour installer Biome, exécutez les commandes suivantes dans un répertoire contenant un fichier `package.json`.
 
 <PackageManagerCommand
-  npm="install --save-dev --save-exact @biomejs/biome"
-  pnpm="add --save-dev --save-exact @biomejs/biome"
-  yarn="add --dev --exact @biomejs/biome"
-  bun="add --dev --exact @biomejs/biome"
-  deno="add --dev npm:@biomejs/biome"
+  npm={["install --save-dev --save-exact @biomejs/biome"]}
+  pnpm={["add --save-dev --save-exact @biomejs/biome"]}
+  yarn={["add --dev --exact @biomejs/biome"]}
+  bun={["add --dev --exact @biomejs/biome"]}
+  deno={["add --dev npm:@biomejs/biome"]}
 />
 
 :::note

--- a/src/content/docs/guides/getting-started.mdx
+++ b/src/content/docs/guides/getting-started.mdx
@@ -15,11 +15,11 @@ also available as a [standalone executable] that doesn't require Node.js.
 [standalone executable]: /guides/manual-installation
 
 <PackageManagerCommand
-  npm="i -D -E @biomejs/biome"
-  pnpm="add -D -E @biomejs/biome"
-  yarn="add -D -E @biomejs/biome"
-  bun="add -D -E @biomejs/biome"
-  deno="add -D npm:@biomejs/biome"
+  npm={["i -D -E @biomejs/biome"]}
+  pnpm={["add -D -E @biomejs/biome"]}
+  yarn={["add -D -E @biomejs/biome"]}
+  bun={["add -D -E @biomejs/biome"]}
+  deno={["add -D npm:@biomejs/biome"]}
 />
 
 :::note[Version pinning]

--- a/src/content/docs/guides/upgrade-to-biome-v2.mdx
+++ b/src/content/docs/guides/upgrade-to-biome-v2.mdx
@@ -19,11 +19,11 @@ you need.
 
             Use your package manager to install the version `2.0.6` of Biome:
             <PackageManagerCommand
-                npm="install --save-dev --save-exact @biomejs/biome@2.0.6"
-                pnpm="add --save-dev --save-exact @biomejs/biome@2.0.6"
-                yarn="add --dev --exact @biomejs/biome@2.0.6"
-                bun="add --dev --exact @biomejs/biome@2.0.6"
-                deno="add --dev npm:@biomejs/biome@2.0.6" />
+                npm={["install --save-dev --save-exact @biomejs/biome@2.0.6"]}
+                pnpm={["add --save-dev --save-exact @biomejs/biome@2.0.6"]}
+                yarn={["add --dev --exact @biomejs/biome@2.0.6"]}
+                bun={["add --dev --exact @biomejs/biome@2.0.6"]}
+                deno={["add --dev npm:@biomejs/biome@2.0.6"]} />
         </li>
         <li>
             Run the `migrate` command to update the configuration:

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -47,6 +47,7 @@ import LinterExample from "@/components/linter/example.md";
 import NumberOfRules from "@/components/generated/linter/NumberOfRules.astro";
 import AwardBanner from "@/components/AwardBanner.astro"
 import FeaturedUsers from "@/components/FeaturedUsers.astro"
+import PackageManagerCommand from "@/components/PackageManagerCommand.astro";
 
 <div class="gradient"></div>
 
@@ -95,10 +96,13 @@ import FeaturedUsers from "@/components/FeaturedUsers.astro"
 
     Try the Biome formatter on the [playground](/playground/) or directly on your project:
 
-    ```shell
-    npm i -D --save-exact @biomejs/biome
-    npx @biomejs/biome format --write ./src
-    ```
+  <PackageManagerCommand
+    npm={["i -D -E @biomejs/biome", "@biomejs/biome format"]}
+    pnpm={["add -D -E @biomejs/biome", "@biomejs/biome format"]}
+    yarn={["add -D -E @biomejs/biome", "@biomejs/biome format"]}
+    bun={["add -D -E @biomejs/biome", "@biomejs/biome format"]}
+    deno={["add -D npm:@biomejs/biome", "@biomejs/biome format"]}
+  />
 </div>
 
 
@@ -116,10 +120,13 @@ import FeaturedUsers from "@/components/FeaturedUsers.astro"
 
     Try the Biome linter on the [playground](/playground/) or directly on your project:
 
-    ```shell
-    npm i -D --save-exact @biomejs/biome
-    npx @biomejs/biome lint --write ./src
-    ```
+  <PackageManagerCommand
+    npm={["i -D -E @biomejs/biome", "@biomejs/biome lint --write"]}
+    pnpm={["add -D -E @biomejs/biome", "@biomejs/biome lint --write"]}
+    yarn={["add -D -E @biomejs/biome", "@biomejs/biome lint --write"]}
+    bun={["add -D -E @biomejs/biome", "@biomejs/biome lint --write"]}
+    deno={["add -D npm:@biomejs/biome", "@biomejs/biome lint --write"]}
+  />
 
 </div>
 
@@ -133,10 +140,13 @@ import FeaturedUsers from "@/components/FeaturedUsers.astro"
 
     Run all tools with the `check` command:
 
-    ```shell
-    npm i -D --save-exact @biomejs/biome
-    npx @biomejs/biome check --write ./src
-    ```
+    <PackageManagerCommand
+      npm={["i -D -E @biomejs/biome", "@biomejs/biome check --write"]}
+      pnpm={["add -D -E @biomejs/biome", "@biomejs/biome check --write"]}
+      yarn={["add -D -E @biomejs/biome", "@biomejs/biome check --write"]}
+      bun={["add -D -E @biomejs/biome", "@biomejs/biome check --write"]}
+      deno={["add -D npm:@biomejs/biome", "@biomejs/biome check --write"]}
+    />
 
 </div>
 

--- a/src/content/docs/ja/guides/getting-started.mdx
+++ b/src/content/docs/ja/guides/getting-started.mdx
@@ -12,11 +12,11 @@ Biomeはプロジェクトの開発依存としてインストールするのが
 [スタンドアロン実行形式]: /ja/guides/manual-installation
 
 <PackageManagerCommand
-  npm="i -D -E @biomejs/biome"
-  pnpm="add -D -E @biomejs/biome"
-  yarn="add -D -E @biomejs/biome"
-  bun="add -D -E @biomejs/biome"
-  deno="add -D npm:@biomejs/biome"
+  npm={["i -D -E @biomejs/biome"]}
+  pnpm={["add -D -E @biomejs/biome"]}
+  yarn={["add -D -E @biomejs/biome"]}
+  bun={["add -D -E @biomejs/biome"]}
+  deno={["add -D npm:@biomejs/biome"]}
 />
 
 :::note[バージョンの固定]

--- a/src/content/docs/pl/guides/getting-started.mdx
+++ b/src/content/docs/pl/guides/getting-started.mdx
@@ -15,11 +15,11 @@ również dostępny jako [samodzielny plik wykonywalny], który nie wymaga Node.
 [samodzielny plik wykonywalny]: /guides/manual-installation
 
 <PackageManagerCommand
-  npm="i -D -E @biomejs/biome"
-  pnpm="add -D -E @biomejs/biome"
-  yarn="add -D -E @biomejs/biome"
-  bun="add -D -E @biomejs/biome"
-  deno="add -D npm:@biomejs/biome"
+  npm={["i -D -E @biomejs/biome"]}
+  pnpm={["add -D -E @biomejs/biome"]}
+  yarn={["add -D -E @biomejs/biome"]}
+  bun={["add -D -E @biomejs/biome"]}
+  deno={["add -D npm:@biomejs/biome"]}
 />
 
 :::note[Przypinanie wersji]

--- a/src/content/docs/pl/guides/upgrade-to-biome-v2.mdx
+++ b/src/content/docs/pl/guides/upgrade-to-biome-v2.mdx
@@ -18,11 +18,11 @@ Jeśli masz projekt korzystający z Biome v1 i chcesz zaktualizować go do v2, t
 
             Użyj swojego menedżera pakietów, aby zainstalować wersję `2.0.6` Biome:
             <PackageManagerCommand
-                npm="install --save-dev --save-exact @biomejs/biome@2.0.6"
-                pnpm="add --save-dev --save-exact @biomejs/biome@2.0.6"
-                yarn="add --dev --exact @biomejs/biome@2.0.6"
-                bun="add --dev --exact @biomejs/biome@2.0.6"
-                deno="add --dev npm:@biomejs/biome@2.0.6" />
+                npm={["install --save-dev --save-exact @biomejs/biome@2.0.6"]}
+                pnpm={["add --save-dev --save-exact @biomejs/biome@2.0.6"]}
+                yarn={["add --dev --exact @biomejs/biome@2.0.6"]}
+                bun={["add --dev --exact @biomejs/biome@2.0.6"]}
+                deno={["add --dev npm:@biomejs/biome@2.0.6"]} />
         </li>
         <li>
             Uruchom polecenie `migrate`, aby zaktualizować konfigurację:

--- a/src/content/docs/pt-BR/guides/getting-started.mdx
+++ b/src/content/docs/pt-BR/guides/getting-started.mdx
@@ -13,11 +13,11 @@ O Biome é melhor instalado como uma dependência de desenvolvimento dos seus pr
 [executável standalone]: /guides/manual-installation
 
 <PackageManagerCommand
-  npm="i -D -E @biomejs/biome"
-  pnpm="add -D -E @biomejs/biome"
-  yarn="add -D -E @biomejs/biome"
-  bun="add -D -E @biomejs/biome"
-  deno="add -D npm:@biomejs/biome"
+  npm={["i -D -E @biomejs/biome"]}
+  pnpm={["add -D -E @biomejs/biome"]}
+  yarn={["add -D -E @biomejs/biome"]}
+  bun={["add -D -E @biomejs/biome"]}
+  deno={["add -D npm:@biomejs/biome"]}
 />
 
 :::note[Fixação de versão]

--- a/src/content/docs/ru/guides/getting-started.mdx
+++ b/src/content/docs/ru/guides/getting-started.mdx
@@ -15,11 +15,11 @@ Biome лучше всего устанавливать в качестве dev-�
 [автономного исполняемого файла]: /ru/guides/manual-installation
 
 <PackageManagerCommand
-  npm="i -D -E @biomejs/biome"
-  pnpm="add -D -E @biomejs/biome"
-  yarn="add -D -E @biomejs/biome"
-  bun="add -D -E @biomejs/biome"
-  deno="add -D npm:@biomejs/biome"
+  npm={["i -D -E @biomejs/biome"]}
+  pnpm={["add -D -E @biomejs/biome"]}
+  yarn={["add -D -E @biomejs/biome"]}
+  bun={["add -D -E @biomejs/biome"]}
+  deno={["add -D npm:@biomejs/biome"]}
 />
 
 :::note[Фиксация версии]

--- a/src/content/docs/zh-CN/guides/getting-started.mdx
+++ b/src/content/docs/zh-CN/guides/getting-started.mdx
@@ -16,11 +16,11 @@ import PackageManagerCommand from "@/components/PackageManagerCommand.astro";
 要安装Biome，请在包含`package.json`文件的目录中运行以下命令。
 
 <PackageManagerCommand
-  npm="install --save-dev --save-exact @biomejs/biome"
-  pnpm="add --save-dev --save-exact @biomejs/biome"
-  yarn="add --dev --exact @biomejs/biome"
-  bun="add --dev --exact @biomejs/biome"
-  deno="add --dev npm:@biomejs/biome"
+  npm={["install --save-dev --save-exact @biomejs/biome"]}
+  pnpm={["add --save-dev --save-exact @biomejs/biome"]}
+  yarn={["add --dev --exact @biomejs/biome"]}
+  bun={["add --dev --exact @biomejs/biome"]}
+  deno={["add --dev npm:@biomejs/biome"]}
 />
 
 :::note

--- a/src/content/docs/zh-CN/guides/upgrade-to-biome-v2.mdx
+++ b/src/content/docs/zh-CN/guides/upgrade-to-biome-v2.mdx
@@ -19,11 +19,11 @@ import {FileTree, Steps} from '@astrojs/starlight/components';
 
             使用包管理器安装 Biome `2.0.6`。
             <PackageManagerCommand
-                npm="install --save-dev --save-exact @biomejs/biome@2.0.6"
-                pnpm="add --save-dev --save-exact @biomejs/biome@2.0.6"
-                yarn="add --dev --exact @biomejs/biome@2.0.6"
-                bun="add --dev --exact @biomejs/biome@2.0.6"
-                deno="add --dev npm:@biomejs/biome@2.0.6" />
+                npm={["install --save-dev --save-exact @biomejs/biome@2.0.6"]}
+                pnpm={["add --save-dev --save-exact @biomejs/biome@2.0.6"]}
+                yarn={["add --dev --exact @biomejs/biome@2.0.6"]}
+                bun={["add --dev --exact @biomejs/biome@2.0.6"]}
+                deno={["add --dev npm:@biomejs/biome@2.0.6"]} />
         </li>
         <li>
             运行命令 `migrate` 以更新配置文件。

--- a/src/pages/og/[...path].ts
+++ b/src/pages/og/[...path].ts
@@ -23,6 +23,7 @@ export const { getStaticPaths, GET } = await OGImageRoute({
 		console.log(page);
 		return {
 			title: page.title,
+			// @ts-expect-error
 			description: page.description ?? "",
 			logo: {
 				path: "./public/img/logo-avatar.png",

--- a/src/pages/og/[...path].ts
+++ b/src/pages/og/[...path].ts
@@ -4,8 +4,6 @@ import { OGImageRoute } from "astro-og-canvas";
 const collectionEntries = await getCollection("docs");
 const changelogEntries = await getCollection("changelogs");
 
-console.log(changelogEntries);
-
 /** Paths for all of our Markdown content we want to generate OG images for. */
 const pages = process.env.SKIP_OG
 	? {}
@@ -20,7 +18,6 @@ export const { getStaticPaths, GET } = await OGImageRoute({
 	pages,
 
 	getImageOptions: (_, page) => {
-		console.log(page);
 		return {
 			title: page.title,
 			// @ts-expect-error Expected error

--- a/src/pages/og/[...path].ts
+++ b/src/pages/og/[...path].ts
@@ -2,16 +2,25 @@ import { getCollection } from "astro:content";
 import { OGImageRoute } from "astro-og-canvas";
 
 const collectionEntries = await getCollection("docs");
+const changelogEntries = await getCollection("changelogs");
+
+console.log(changelogEntries);
 
 /** Paths for all of our Markdown content we want to generate OG images for. */
 const pages = process.env.SKIP_OG
 	? {}
-	: Object.fromEntries(collectionEntries.map(({ id, data }) => [id, data]));
+	: Object.fromEntries(
+			[...collectionEntries, ...changelogEntries].map(({ id, data }) => [
+				id,
+				data,
+			]),
+		);
 
 export const { getStaticPaths, GET } = await OGImageRoute({
 	pages,
 
 	getImageOptions: (_, page) => {
+		console.log(page);
 		return {
 			title: page.title,
 			description: page.description ?? "",

--- a/src/pages/og/[...path].ts
+++ b/src/pages/og/[...path].ts
@@ -23,7 +23,7 @@ export const { getStaticPaths, GET } = await OGImageRoute({
 		console.log(page);
 		return {
 			title: page.title,
-			// @ts-expect-error
+			// @ts-expect-error Expected error
 			description: page.description ?? "",
 			logo: {
 				path: "./public/img/logo-avatar.png",

--- a/src/routeData.ts
+++ b/src/routeData.ts
@@ -57,7 +57,9 @@ export const onRequest = defineRouteMiddleware(async (context) => {
 });
 
 const docs = await getCollection("docs");
+const changelogs = await getCollection("changelogs");
 const routes = new Set(docs.map(({ id }) => `${id}.png`));
+const changelogRoutes = new Set(changelogs.map(({ id }) => `${id}.png`));
 
 /**
  * Get the path to the OpenGraph image for a page
@@ -79,6 +81,12 @@ async function getOgImageUrl(
 	}
 
 	if (routes.has(imagePath)) return `/og/${imagePath}`;
+	if (changelogRoutes.has(imagePath)) return `/og/${imagePath}`;
+
+	const baseChangelogImagePath = imagePath.slice(imagePath.indexOf("/") + 1);
+	if (changelogRoutes.has(baseChangelogImagePath)) {
+		return `/og/${baseChangelogImagePath}`;
+	}
 
 	return undefined;
 }


### PR DESCRIPTION
## Summary

- Updates `src/components/PackageManagerCommand.astro` so that we can pass an array of commands
- Updates all the callers of this component
- Adds `PackageManagerCommand` to the homepage so we can show all package managers we instruct
- Adds OG images for changelogs, so we can share changelog URLs with tailored OG images

I helped myself with an AI to update the callers, and find a bug for OG images.